### PR TITLE
Setup GitLab mirror

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           git remote add gitlab https://ci_bot:${GITLAB_PAT}@gitlab.maisondelasimulation.fr/gysela-developpers/gyselalibxx.git
           git fetch gitlab public
-          git push
+          git push gitlab main:public
         shell: bash
         env:
           GITLAB_PAT: ${{secrets.GITLAB_PAT}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,3 +76,18 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+
+  Mirror:
+    if: github.repository == 'gyselax/gyselalibxx'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Update GitLab
+        run: |
+          git remote add gitlab https://ci_bot:${GITLAB_PAT}@gitlab.maisondelasimulation.fr/gysela-developpers/gyselalibxx.git
+          git fetch gitlab public
+          git push
+        shell: bash
+        env:
+          GITLAB_PAT: ${{secrets.GITLAB_PAT}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       toolchain: ${{ matrix.toolchain }}
       merge_target: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       pr_number: ${{ github.event.pull_request.number }}
-      is_duplicate: ${{ needs.pre_job.outputs.should_skip != 'true' && github.event.pull_request.draft == false }}
+      is_duplicate: ${{ needs.pre_job.outputs.should_skip == 'true' && github.event.pull_request.draft == false }}
 
   gpu_tests:
     name: GPU Test
@@ -55,7 +55,7 @@ jobs:
       merge_target: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       SHA: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.pull_request.number }}
-      is_duplicate: ${{ needs.pre_job.outputs.should_skip != 'true' && github.event.pull_request.draft == false }}
+      is_duplicate: ${{ needs.pre_job.outputs.should_skip == 'true' && github.event.pull_request.draft == false }}
     secrets: inherit
 
   set_draft_failing:

--- a/src/multipatch/README.md
+++ b/src/multipatch/README.md
@@ -6,8 +6,6 @@ The `multipatch` folder contains all the code describing methods and classes whi
 
 - [data\_types](./data_types/README.md) - Defines classes to handle objects on a multipatch domain more conveniently.
 
-- [interface\_derivatives](./interface_derivatives/README.md) - Ongoing work only available on GitLab.
-
 - [spline](./spline/README.md) - Defines structures and methods to deal with different splines on every patches.
 
 - [utils](./utils/README.md) - Defines utility functions to operate over multiple patches.


### PR DESCRIPTION
Setup a push to the `public` branch on GitLab when the `main` branch is updated on GitHub.