### PR TITLE
Fix CMAKE_TOOLCHAIN_FILE cmake variable

### DIFF
--- a/.github/actions/build_code/action.yml
+++ b/.github/actions/build_code/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Compile code
       run: |
-        cmake -DCMAKE_TOOLCHAIN=${{ inputs.toolchain }} -B build -S .
+        cmake -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }} -B build -S .
         cmake --build build --parallel 4
       shell: bash
 

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -11,6 +11,9 @@ runs:
       env:
         OMPI_ALLOW_RUN_AS_ROOT: 1
         OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+        OMP_NUM_THREADS: 4
+        OMP_PLACES: threads
+        OMP_PROC_BIND: spread
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
       if: success() || failure() # always run even if the previous step fails

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
           skip_after_successful_duplicate: 'true'
-          paths: '["src/**/*.hpp", "src/**/*.cpp", "tests/**/*.hpp", "tests/**/*.cpp", "simulations/**/*.hpp", "simulations/**/*.cpp", "**/CMakeLists.txt", "vendor/**"]'
+          paths: '["src/**/*.hpp", "src/**/*.cpp", "tests/**/*.hpp", "tests/**/*.cpp", "simulations/**/*.hpp", "simulations/**/*.cpp", "**/CMakeLists.txt", "vendor/**", ".github/**"]'
           cancel_others: 'false'
 
   cpu_tests:


### PR DESCRIPTION
The toolchain is likely not used, there is a warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_TOOLCHAIN
```