### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/clean_up.yml
+++ b/.github/workflows/clean_up.yml
@@ -1,0 +1,30 @@
+name: Clean up
+
+on:
+  check_run:
+    types: completed
+
+jobs:
+
+  set_labels:
+    runs-on: ubuntu-latest
+    name: Set PR labels
+    if: github.repository == 'gyselax/gyselalibxx' && github.event.check_run.pull_requests
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set PR labels for reviews
+        run: |
+          STATES=$(gh pr checks ${{ github.event.check_run.pull_requests.number }} --required --json state)
+          N_PASSES=$(echo $STATES | grep -o "\"state\":\"SUCCESS\"" | wc -l)
+          if [[ ${N_PASSES} == 10 ]]
+          then
+            # If all required tests are passing then mark as ready to review
+            gh pr edit ${{ github.event.check_run.pull_requests.number }} --add-label "Ready to review"
+          fi
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/draft_flags.yml
+++ b/.github/workflows/draft_flags.yml
@@ -15,3 +15,6 @@ jobs:
           ref: main
       - run: |
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "Ready to review"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/flag_checks.yml
+++ b/.github/workflows/flag_checks.yml
@@ -9,18 +9,12 @@ jobs:
   Check_flags:
     name: Check flags
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-      pull-requests: write
-      repository-projects: read
-      issues: write
+    if: github.action.label.name == 'Ready to review' && github.action.pull_request.draft
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
-      - if: github.action.label.name == 'Ready to review' && github.action.pull_request.draft
-        run: |
+      - run: |
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "Ready to review"
           gh pr comment ${{ github.event.pull_request.number }} -b "Please remove the draft status if the PR is ready to review"
         shell: bash

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -55,7 +55,7 @@ jobs:
           git config --global user.email "username@users.noreply.github.com"
           echo "${GITHUB_REPOSITORY}" > repo
           echo "${{ inputs.SHA || github.sha }}" > commit
-          git commit -m "Test commit ${GITHUB_SHA}" repo commit
+          git commit -m "Test commit ${{ inputs.SHA || github.sha }}" repo commit
           git push
         shell: bash
         env:

--- a/.github/workflows/static_analyses.yml
+++ b/.github/workflows/static_analyses.yml
@@ -10,11 +10,6 @@ on:
   merge_group:
     types: [checks_requested]
 
-# Cancel old static analyses if new pushes are added to the branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.action.number }}
-  cancel-in-progress: true
-
 jobs:
   Indentation:
     name: Clang Formatting Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-      - labeled
   merge_group:
     types:
       - checks_requested
@@ -16,10 +15,7 @@ jobs:
   pre_job:
     name: 'Check for unnecessary runs'
     runs-on: ubuntu-latest
-    if: |
-      (github.repository == 'gyselax/gyselalibxx' && github.event.action != 'labeled' && github.event.pull_request.draft == false) ||
-      (github.repository != 'gyselax/gyselalibxx' && github.event.action == 'labeled' && github.event.label.name == 'Ready to review') ||
-      (github.repository != 'gyselax/gyselalibxx' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Ready to review'))
+    if: github.repository == 'gyselax/gyselalibxx' && github.event.pull_request.draft == false
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -98,30 +94,6 @@ jobs:
             fi
             gh pr comment ${{ github.event.pull_request.number }} -b "It seems like you haven't finished working on this PR so it has been put back into draft. Please remove the draft status when the PR can run tests without being interrupted."
             gh pr edit ${{ github.event.pull_request.number }} --remove-label "Ready to review"
-          fi
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  set_labels:
-    runs-on: ubuntu-latest
-    needs: [cpu_tests, gpu_tests]
-    name: Set PR labels
-    if: github.event_name == 'pull_request' && success() && github.repository == 'gyselax/gyselalibxx'
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set PR labels for reviews
-        run: |
-          if [ "${{ github.event.pull_request.draft }}" != "true" ]
-          then
-            STATES=$(gh pr checks ${{ github.event.pull_request.number }} --required --json state)
-            N_PASSES=$(echo $STATES | grep -o "\"state\":\"SUCCESS\"" | wc -l)
-            if [[ ${N_PASSES} == 10 ]]
-            then
-              # If all required tests are passing then mark as ready to review
-              gh pr edit ${{ github.event.pull_request.number }} --add-label "Ready to review"
-            fi
           fi
         shell: bash
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set PR to draft to avoid unnecessary runs
         if: github.repository == 'gyselax/gyselalibxx'
         run: |
-          isDraft=${{ github.event.pull_request.draft || (github.repository != 'gyselax/gyselalibxx' && ! contains(github.event.pull_request.labels.*.name, 'Ready to review')) }}
+          isDraft=${{ github.event.pull_request.draft }}
           if [ "${isDraft}" != "true" ]
           then
             if [ "${{github.repository == 'gyselax/gyselalibxx'}}" == "true" ]
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set PR to draft to avoid unnecessary runs
         run: |
-          isDraft=${{ github.event.pull_request.draft || (github.repository != 'gyselax/gyselalibxx' && ! contains(github.event.pull_request.labels.*.name, 'Ready to review')) }}
+          isDraft=${{ github.event.pull_request.draft }}
           if [ "${isDraft}" != "true" ]
           then
             if [ "${{github.repository == 'gyselax/gyselalibxx'}}" == "true" ]


### PR DESCRIPTION
Minor improvements to the CI:
- Add a clean up workflow to take care of adding the `Ready to review` flag. This (should) ensure that this step is correctly triggered and takes into consideration both the CPU and GPU tests
- Remove unnecessary permissions (default are sufficient)
- Add missing `GH_TOKEN` to be able to correct flags
- Match SHA mentioned in commit to SHA used for GPU tests to make it easier to locate tests on GitLab
- Remove label workarounds in tests.yml that were designed for private forks but don't work (because private forks have to pay for CI)
- Remove concurrency limits