### PR TITLE
Allow tensors of references

### DIFF
--- a/ci_tools/gyselalib_static_analysis.py
+++ b/ci_tools/gyselalib_static_analysis.py
@@ -776,7 +776,7 @@ def check_exec_space_usage(file):
                               'integer_sequence', 'pair', 'declval', 'tuple_cat', 'integral_constant', 'size_t', 'move',
                               'make_integer_sequence', 'make_index_sequence', 'index_sequence',
                               'experimental::full_extent', 'experimental::submdspan', 'conjunction_v', 'disjunction_v',
-                              'conjunction', 'disjunction')
+                              'conjunction', 'disjunction', 'is_const_v', 'is_reference_v')
             if 'std' in code_keys:
                 idx = code_keys.index('std')
                 func = None

--- a/src/data_types/tensor.hpp
+++ b/src/data_types/tensor.hpp
@@ -97,6 +97,7 @@ public:
         return s_n_elements;
     }
 
+private:
     template <class OElementType, size_t... Is>
     KOKKOS_FUNCTION void mul(OElementType val, std::index_sequence<Is...>)
     {

--- a/src/data_types/tensor.hpp
+++ b/src/data_types/tensor.hpp
@@ -237,6 +237,11 @@ public:
      */
     KOKKOS_DEFAULTED_FUNCTION Tensor& operator=(Tensor const& other) = default;
 
+    /**
+     * @brief A copy operator.
+     * @param o_tensor The tensor to be copied.
+     * @return A reference to the current tensor.
+     */
     template <class OElementType>
     KOKKOS_FUNCTION Tensor& operator=(Tensor<OElementType, ValidIndexSet...> const& o_tensor)
     {

--- a/src/data_types/vector_field.hpp
+++ b/src/data_types/vector_field.hpp
@@ -73,8 +73,8 @@ private:
     using base_type = VectorFieldCommon<field_type, NDTag>;
 
 public:
-    using typename base_type::element_type;
     using typename base_type::element_ref_type;
+    using typename base_type::element_type;
 
     using typename base_type::NDTypeTag;
 

--- a/src/data_types/vector_field.hpp
+++ b/src/data_types/vector_field.hpp
@@ -73,8 +73,8 @@ private:
     using base_type = VectorFieldCommon<field_type, NDTag>;
 
 public:
-    /// The type of an element in one of the Fields comprising the VectorField
-    using element_type = typename base_type::element_type;
+    using typename base_type::element_type;
+    using typename base_type::element_ref_type;
 
     using typename base_type::NDTypeTag;
 
@@ -184,10 +184,14 @@ private:
      * @return copy of this element
      */
     template <class... ODDims, typename T, T... ints>
-    KOKKOS_FUNCTION element_type
-    operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>) const noexcept
+    KOKKOS_FUNCTION auto operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>)
+            const noexcept
     {
-        return element_type((base_type::m_values[ints](delems))...);
+        if constexpr (std::is_const_v<ElementType>) {
+            return element_type((base_type::m_values[ints](delems))...);
+        } else {
+            return element_ref_type((base_type::m_values[ints](delems))...);
+        }
     }
 
 public:
@@ -316,8 +320,7 @@ public:
      * @return copy of this element
      */
     template <class... ODDims>
-    KOKKOS_FUNCTION element_type
-    operator()(ddc::DiscreteElement<ODDims> const&... delems) const noexcept
+    KOKKOS_FUNCTION auto operator()(ddc::DiscreteElement<ODDims> const&... delems) const noexcept
     {
         Idx<ODDims...> delem_idx(delems...);
         return this->
@@ -329,7 +332,7 @@ public:
      * @return copy of this element
      */
     template <class... ODDims, class = std::enable_if_t<sizeof...(ODDims) != 1>>
-    KOKKOS_FUNCTION element_type operator()(Idx<ODDims...> const& delems) const noexcept
+    KOKKOS_FUNCTION auto operator()(Idx<ODDims...> const& delems) const noexcept
     {
         return this->operator()(delems, std::make_integer_sequence<int, element_type::size()> {});
     }

--- a/src/data_types/vector_field_mem.hpp
+++ b/src/data_types/vector_field_mem.hpp
@@ -124,8 +124,7 @@ private:
      * @return copy of this element
      */
     template <class... ODDims, typename T, T... ints>
-    auto operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>)
-            const noexcept
+    auto operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>) const noexcept
     {
         if constexpr (std::is_const_v<ElementType>) {
             return element_type((base_type::m_values[ints](delems))...);

--- a/src/data_types/vector_field_mem.hpp
+++ b/src/data_types/vector_field_mem.hpp
@@ -124,10 +124,14 @@ private:
      * @return copy of this element
      */
     template <class... ODDims, typename T, T... ints>
-    element_type operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>)
+    auto operator()(Idx<ODDims...> const& delems, std::integer_sequence<T, ints...>)
             const noexcept
     {
-        return element_type((base_type::m_values[ints](delems))...);
+        if constexpr (std::is_const_v<ElementType>) {
+            return element_type((base_type::m_values[ints](delems))...);
+        } else {
+            return element_ref_type((base_type::m_values[ints](delems))...);
+        }
     }
 
 public:
@@ -210,7 +214,7 @@ public:
      * @return copy of this element
      */
     template <class... ODDims>
-    element_type operator()(ddc::DiscreteElement<ODDims> const&... delems) const noexcept
+    auto operator()(ddc::DiscreteElement<ODDims> const&... delems) const noexcept
     {
         Idx<ODDims...> delem_idx(delems...);
         return this->
@@ -222,7 +226,7 @@ public:
      * @return copy of this element
      */
     template <class... ODDims, class = std::enable_if_t<sizeof...(ODDims) != 1>>
-    element_type operator()(Idx<ODDims...> const& delems) const noexcept
+    auto operator()(Idx<ODDims...> const& delems) const noexcept
     {
         return this->operator()(delems, std::make_integer_sequence<int, element_type::size()> {});
     }

--- a/src/geometryRTheta/advection/bsl_advection_rp.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rp.hpp
@@ -191,8 +191,7 @@ public:
         });
 
         ddc::for_each(Opoint_grid, [&](IdxRTheta const irp) {
-            ddcHelper::get<X>(advection_field_xy)(irp) = CoordX(advection_field_xy_center);
-            ddcHelper::get<Y>(advection_field_xy)(irp) = CoordY(advection_field_xy_center);
+            advection_field_xy(irp) = advection_field_xy_center;
         });
 
         // Pre-allocate some memory to prevent allocation later in loop

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -268,14 +268,8 @@ public:
 
             // STEP 6: From rho^n and (A^n(X^P) + A^P(X^n))/2, we compute rho^{n+1}: Vlasov equation
             ddc::for_each(grid, [&](IdxRTheta const irp) {
-                ddcHelper::get<X>(advection_field)(irp)
-                        = (ddcHelper::get<X>(advection_field_evaluated)(irp)
-                           + ddcHelper::get<X>(advection_field_predicted)(irp))
-                          / 2.;
-                ddcHelper::get<Y>(advection_field)(irp)
-                        = (ddcHelper::get<Y>(advection_field_evaluated)(irp)
-                           + ddcHelper::get<Y>(advection_field_predicted)(irp))
-                          / 2.;
+                advection_field(irp)
+                        = (advection_field_evaluated(irp) + advection_field_predicted(irp)) / 2.;
             });
 
 

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
@@ -253,16 +253,8 @@ public:
 
             // Compute the new advection field (E^n(X^n) + E^n(X^P)) /2:
             ddc::for_each(grid, [&](IdxRTheta const irp) {
-                ddcHelper::get<X>(advection_field_k_tot)(irp)
-                        = (ddcHelper::get<X>(advection_field)(irp)
-                           + ddcHelper::get<X>(advection_field_k)(irp))
-                          / 2.;
-                ddcHelper::get<Y>(advection_field_k_tot)(irp)
-                        = (ddcHelper::get<Y>(advection_field)(irp)
-                           + ddcHelper::get<Y>(advection_field_k)(irp))
-                          / 2.;
+                advection_field_k_tot(irp) = advection_field(irp) + advection_field_k(irp) / 2.;
             });
-
 
             // X^P = X^n - dt/2 * ( E^n(X^n) + E^n(X^P) )/2:
             // --- Copy phi^n because it will be modified:
@@ -323,14 +315,7 @@ public:
 
             // Computed advection field (A^P(X^n) + A^P(X^P)) /2:
             ddc::for_each(grid, [&](IdxRTheta const irp) {
-                ddcHelper::get<X>(advection_field_k_tot)(irp)
-                        = (ddcHelper::get<X>(advection_field)(irp)
-                           + ddcHelper::get<X>(advection_field_k)(irp))
-                          / 2.;
-                ddcHelper::get<Y>(advection_field_k_tot)(irp)
-                        = (ddcHelper::get<Y>(advection_field)(irp)
-                           + ddcHelper::get<Y>(advection_field_k)(irp))
-                          / 2.;
+                advection_field_k_tot(irp) = advection_field(irp) + advection_field_k(irp) / 2.;
             });
             // X^k = X^n - dt * ( A^P(X^n) + A^P(X^P) )/2
             m_advection_solver(allfdistribu, get_const_field(advection_field_k_tot), dt);
@@ -405,12 +390,7 @@ private:
 
             // Compute the new advection field A(X^n) + A(X^{k-1}):
             ddc::for_each(grid, [&](IdxRTheta const irp) {
-                ddcHelper::get<X>(advection_field_k_tot)(irp)
-                        = ddcHelper::get<X>(advection_field)(irp)
-                          + ddcHelper::get<X>(advection_field_k)(irp);
-                ddcHelper::get<Y>(advection_field_k_tot)(irp)
-                        = ddcHelper::get<Y>(advection_field)(irp)
-                          + ddcHelper::get<Y>(advection_field_k)(irp);
+                advection_field_k_tot(irp) = advection_field(irp) + advection_field_k(irp);
             });
 
             // X^{k-1} = X^k:

--- a/src/mapping/vector_mapper.hpp
+++ b/src/mapping/vector_mapper.hpp
@@ -86,8 +86,7 @@ public:
 
                         Coord<XOut, YOut> vector_out;
                         vector_out.array() = mat_vec_mul(map_J, vector_field_input(idx).array());
-                        ddcHelper::get<XOut>(vector_field_output)(idx) = ddc::get<XOut>(vector_out);
-                        ddcHelper::get<YOut>(vector_field_output)(idx) = ddc::get<YOut>(vector_out);
+                        vector_field_output(idx) = vector_out;
                     });
         } else {
             InverseJacobianMatrix<Mapping, ddc::coordinate_of_t<IdxType>> inv_mapping(m_mapping);
@@ -103,8 +102,7 @@ public:
                         vector_out.array() = mat_vec_mul(
                                 map_J,
                                 ddcHelper::to_coord(vector_field_input(idx)).array());
-                        ddcHelper::get<XOut>(vector_field_output)(idx) = ddc::get<XOut>(vector_out);
-                        ddcHelper::get<YOut>(vector_field_output)(idx) = ddc::get<YOut>(vector_out);
+                        vector_field_output(idx) = vector_out;
                     });
         }
     }

--- a/tests/data_types/field.cpp
+++ b/tests/data_types/field.cpp
@@ -268,6 +268,19 @@ TEST(VectorField1DTest, Access)
     }
 }
 
+TEST(VectorField1DTest, VectorAccess)
+{
+    Coord2D constexpr factor(1.391, 2.444);
+    DVectorFieldMemX field(idx_range_x);
+    for (IdxX ix : get_idx_range(field)) {
+        Coord2D val = double((ix - idx_range_x.front()).value()) * factor;
+        field(ix) = val;
+        // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
+        EXPECT_EQ(ddc::get<Tag1>(val), ddcHelper::get<Tag1>(field(ix)));
+        EXPECT_EQ(ddc::get<Tag2>(val), ddcHelper::get<Tag2>(field(ix)));
+    }
+}
+
 TEST(VectorField1DTest, GetConstField)
 {
     Coord2D constexpr factor(1.391, 2.444);


### PR DESCRIPTION
Represent tensor elements using `std::tuple` instead of `std::array` to allow `ElementType` to be a reference. Use vectors with references as elements to improve the use of `VectorField`