### PR TITLE
Update Persee environment with Kokkos 4.5.1, Kokkos Kernels 4.5.1 and Kokkos-fft 0.2.1

### DIFF
--- a/tests/mapping/mapping_jacobian_matrix_coef.cpp
+++ b/tests/mapping/mapping_jacobian_matrix_coef.cpp
@@ -122,7 +122,7 @@ using Matrix_2x2 = std::array<std::array<double, 2>, 2>;
  */
 void check_matrix(Matrix_2x2 matrix, Matrix_2x2 matrix_coeff)
 {
-    const double TOL = 1e-14;
+    const double TOL = 1e-13;
     constexpr std::size_t N = 2;
 
     for (std::size_t i(0); i < N; ++i) {

--- a/toolchains/a100.leonardo.spack/toolchain.cmake
+++ b/toolchains/a100.leonardo.spack/toolchain.cmake
@@ -6,6 +6,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
 set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_LIST_DIR}/../../vendor/kokkos/bin/nvcc_wrapper)
+set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 set(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
 
 # Gyselalibxx options

--- a/toolchains/cicd_default_toolchain.cmake
+++ b/toolchains/cicd_default_toolchain.cmake
@@ -1,6 +1,6 @@
 
 # Kokkos flags
-set(Kokkos_ENABLE_DEPRECATED_CODE_3 OFF)
+set(Kokkos_ENABLE_DEPRECATED_CODE_4 OFF)
 set(Kokkos_ENABLE_DEPRECATION_WARNINGS OFF)
 
 # Deactivate slow tests if requested

--- a/toolchains/v100.persee/debug_toolchain.cmake
+++ b/toolchains/v100.persee/debug_toolchain.cmake
@@ -6,6 +6,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
 set(CMAKE_CXX_COMPILER nvcc_wrapper)
+set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 set(CMAKE_CXX_FLAGS "-g -Wall -Werror -Wno-sign-compare -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -Wno-unused-but-set-variable")
 
 # Activate/deactivate parts of the code

--- a/toolchains/v100.persee/debug_toolchain.cmake
+++ b/toolchains/v100.persee/debug_toolchain.cmake
@@ -5,13 +5,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cicd_default_toolchain.cmake)
 set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
-set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_LIST_DIR}/../../vendor/kokkos/bin/nvcc_wrapper)
+set(CMAKE_CXX_COMPILER nvcc_wrapper)
 set(CMAKE_CXX_FLAGS "-g -Wall -Werror -Wno-sign-compare -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -Wno-unused-but-set-variable")
-
-# Kokkos options
-set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "Allow serial code to run" FORCE)
-set(Kokkos_ENABLE_CUDA ON CACHE BOOL "Activate GPU usage via cuda" FORCE)
-set(Kokkos_ARCH_VOLTA70 ON CACHE BOOL "Indicate that the GPU architecture is V100" FORCE)
 
 # Activate/deactivate parts of the code
 if (DEFINED ENV{DDC_BUILD_TESTING})

--- a/toolchains/v100.persee/environment.sh
+++ b/toolchains/v100.persee/environment.sh
@@ -8,7 +8,7 @@ fi
 . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
 
 spack load gcc@12
-spack env activate gyselalibxx-env-omp-cuda-candidate
+spack env activate gyselalibxx-env-omp-cuda
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
 export OMP_NUM_THREADS=8

--- a/toolchains/v100.persee/environment.sh
+++ b/toolchains/v100.persee/environment.sh
@@ -8,7 +8,7 @@ fi
 . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
 
 spack load gcc@12
-spack env activate gyselalibxx-env-omp-cuda
+spack env activate gyselalibxx-env-omp-cuda-candidate
 export OMP_PROC_BIND=spread
 export OMP_PLACES=threads
 export OMP_NUM_THREADS=8

--- a/toolchains/v100.persee/toolchain.cmake
+++ b/toolchains/v100.persee/toolchain.cmake
@@ -5,16 +5,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/../cicd_default_toolchain.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_LIST_DIR}/../../vendor/kokkos/bin/nvcc_wrapper)
+set(CMAKE_CXX_COMPILER nvcc_wrapper)
 set(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
 
 # Gyselalibxx options
 set(GYSELALIBXX_DEFAULT_CXX_FLAGS "" CACHE STRING "Default flags for C++ specific to Voice++" FORCE)
-
-# Kokkos options
-set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "Allow serial code to run" FORCE)
-set(Kokkos_ENABLE_CUDA ON CACHE BOOL "Activate GPU usage via cuda" FORCE)
-set(Kokkos_ARCH_VOLTA70 ON CACHE BOOL "Indicate that the GPU architecture is V100" FORCE)
 
 # Activate/deactivate parts of the code
 if (DEFINED ENV{DDC_BUILD_TESTING})

--- a/toolchains/v100.persee/toolchain.cmake
+++ b/toolchains/v100.persee/toolchain.cmake
@@ -6,6 +6,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
 set(CMAKE_CXX_COMPILER nvcc_wrapper)
+set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 set(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
 
 # Gyselalibxx options

--- a/toolchains/v100.ruche/toolchain.cmake
+++ b/toolchains/v100.ruche/toolchain.cmake
@@ -5,6 +5,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
 set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_LIST_DIR}/../../vendor/kokkos/bin/nvcc_wrapper)
+set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 set(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
 
 # Gyselalibxx options


### PR DESCRIPTION
- [x] Rely on packages installed by spack on Persee
- [x] Update in consequence toolchains
- [x] Before merging, rename the environment `gyselalibxx-env-omp-cuda-candidate` to `gyselalibxx-env-omp-cuda`