### PR TITLE
Improve rounding errors in uniform interpolation point initialisation

### DIFF
--- a/src/utils/non_uniform_interpolation_points.hpp
+++ b/src/utils/non_uniform_interpolation_points.hpp
@@ -117,7 +117,9 @@ public:
             return SamplingImpl(interp_points);
         } else {
             using SamplingImpl = typename Sampling::template Impl<Sampling, Kokkos::HostSpace>;
-            SamplingImpl result(interp_points[0], interp_points[1] - interp_points[0]);
+            double domain_len = ddc::discrete_space<BSplines>().rmax()
+                                - ddc::discrete_space<BSplines>().rmin();
+            SamplingImpl result(interp_points.front(), domain_len / (interp_points.size() - 1));
             IdxRange<Sampling> idx_range(get_domain<Sampling>());
             bool same_points = ddc::transform_reduce(
                     idx_range,


### PR DESCRIPTION
Use a better conditioned equation to calculate the step between grid points when creating uniform interpolation points. The uniform grid is compared to an input and the step is calculated from the input.