### PR TITLE
Update minimal version support of DDC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if (NOT EIGEN3_FOUND)
   add_subdirectory("vendor/eigen/" "eigen") # SYSTEM)
 endif (NOT EIGEN3_FOUND)
 
-find_package(DDC 0.4 QUIET COMPONENTS fft pdi splines)
+find_package(DDC 0.5 QUIET COMPONENTS fft pdi splines)
 if(NOT "${DDC_FOUND}")
   ## Use the discrete domain computation library (ddc) from `vendor/`
   add_subdirectory("vendor/ddc/" "ddc") # SYSTEM)

--- a/tests/geometryXVx/CMakeLists.txt
+++ b/tests/geometryXVx/CMakeLists.txt
@@ -15,7 +15,6 @@ add_executable(unit_tests_${GEOMETRY_VARIANT}
     krooksource.cpp
     masks.cpp
     splitvlasovsolver.cpp
-    maxwellian.cpp
     ../main.cpp
 )
 
@@ -36,6 +35,29 @@ target_link_libraries(unit_tests_${GEOMETRY_VARIANT}
 )
 
 gtest_discover_tests(unit_tests_${GEOMETRY_VARIANT}
+    TEST_SUFFIX "_${GEOMETRY_VARIANT}"
+    PROPERTIES TIMEOUT 10
+    DISCOVERY_MODE PRE_TEST
+)
+
+add_executable(unit_tests_maxwellian_${GEOMETRY_VARIANT}
+    maxwellian.cpp
+    ../main.cpp
+)
+
+target_link_libraries(unit_tests_maxwellian_${GEOMETRY_VARIANT}
+    PUBLIC
+        GTest::gtest
+        GTest::gmock
+        gslx::geometry_${GEOMETRY_VARIANT}
+        gslx::initialisation_${GEOMETRY_VARIANT}
+        gslx::quadrature
+        gslx::speciesinfo
+        gslx::time_integration_${GEOMETRY_VARIANT}
+        gslx::utils
+)
+
+gtest_discover_tests(unit_tests_maxwellian_${GEOMETRY_VARIANT}
     TEST_SUFFIX "_${GEOMETRY_VARIANT}"
     PROPERTIES TIMEOUT 10
     DISCOVERY_MODE PRE_TEST


### PR DESCRIPTION
- set minimum supported to version 0.5.1, this brings the new DDC domains
- isolate the maxwellian tests to avoid failures, not clear yet why this makes it work. The issue is being tracked by https://github.com/CExA-project/ddc/issues/790