### PR TITLE
Remove unnecessary NDTag and replace with VectorIndexSet

### DIFF
--- a/simulations/geometryXY/guiding_centre/guiding_centre.cpp
+++ b/simulations/geometryXY/guiding_centre/guiding_centre.cpp
@@ -13,7 +13,6 @@
 
 #include "bsl_advection_1d.hpp"
 #include "ddc_alias_inline_functions.hpp"
-#include "directional_tag.hpp"
 #include "euler.hpp"
 #include "fft_poisson_solver.hpp"
 #include "geometry.hpp"

--- a/src/advection/ipolar_foot_finder.hpp
+++ b/src/advection/ipolar_foot_finder.hpp
@@ -64,6 +64,6 @@ public:
      */
     virtual void operator()(
             Field<Coord<R, Theta>, IdxRangeRTheta, memory_space> feet,
-            DVectorConstField<IdxRangeRTheta, NDTag<X, Y>, memory_space> advection_field,
+            DVectorConstField<IdxRangeRTheta, VectorIndexSet<X, Y>, memory_space> advection_field,
             double dt) const = 0;
 };

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -6,10 +6,10 @@
 #include "combined_mapping.hpp"
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
-#include "directional_tag.hpp"
 #include "geometry_pseudo_cartesian.hpp"
 #include "ipolar_foot_finder.hpp"
 #include "mapping_tools.hpp"
+#include "vector_index_tools.hpp"
 #include "vector_mapper.hpp"
 
 /**
@@ -136,19 +136,20 @@ public:
 
     /// The type of a vector (x,y) field on the polar plane on a compatible memory space.
     template <class Dim1, class Dim2>
-    using DVectorFieldRTheta = VectorField<double, IdxRangeRTheta, NDTag<Dim1, Dim2>, memory_space>;
+    using DVectorFieldRTheta
+            = VectorField<double, IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>, memory_space>;
 
     /// The type of a constant vector (x,y) field on the polar plane on a compatible memory space.
     template <class Dim1, class Dim2>
     using DVectorConstFieldRTheta
-            = VectorConstField<double, IdxRangeRTheta, NDTag<Dim1, Dim2>, memory_space>;
+            = VectorConstField<double, IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>, memory_space>;
 
     /// The type of 2 splines representing the x and y components of a vector on the polar plane on a compatible memory space.
     template <class Dim1, class Dim2>
     using VectorSplineCoeffsMem2D = VectorFieldMem<
             double,
             IdxRange<BSplinesR, BSplinesTheta>,
-            NDTag<Dim1, Dim2>,
+            VectorIndexSet<Dim1, Dim2>,
             memory_space>;
 
 public:

--- a/src/data_types/vector_field.hpp
+++ b/src/data_types/vector_field.hpp
@@ -485,7 +485,7 @@ auto create_mirror_view_and_copy(
         VectorField<
                 ElementType,
                 IdxRangeType,
-                VectorIndexSetType<Dims...>,
+                VectorIndexSet<Dims...>,
                 MemorySpace,
                 LayoutStridedPolicy> field)
 {
@@ -495,7 +495,7 @@ auto create_mirror_view_and_copy(
         VectorFieldMem<
                 std::remove_const_t<ElementType>,
                 IdxRangeType,
-                VectorIndexSetType<Dims...>,
+                VectorIndexSet<Dims...>,
                 typename ExecSpace::memory_space>
                 field_alloc(get_idx_range(field));
         ((ddc::parallel_deepcopy(field_alloc.template get<Dims>(), field.template get<Dims>())),

--- a/src/data_types/vector_field.hpp
+++ b/src/data_types/vector_field.hpp
@@ -4,14 +4,14 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
         class LayoutStridedPolicy = Kokkos::layout_right>
 class VectorField;
@@ -19,29 +19,41 @@ class VectorField;
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace,
         class LayoutStridedPolicy>
-inline constexpr bool enable_vector_field<
-        VectorField<ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>> = true;
+inline constexpr bool enable_vector_field<VectorField<
+        ElementType,
+        IdxRangeType,
+        VectorIndexSetType,
+        MemorySpace,
+        LayoutStridedPolicy>> = true;
 
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace,
         class LayoutStridedPolicy>
-inline constexpr bool enable_data_access_methods<
-        VectorField<ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>> = true;
+inline constexpr bool enable_data_access_methods<VectorField<
+        ElementType,
+        IdxRangeType,
+        VectorIndexSetType,
+        MemorySpace,
+        LayoutStridedPolicy>> = true;
 
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace,
         class LayoutStridedPolicy>
-inline constexpr bool enable_borrowed_vector_field<
-        VectorField<ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>> = true;
+inline constexpr bool enable_borrowed_vector_field<VectorField<
+        ElementType,
+        IdxRangeType,
+        VectorIndexSetType,
+        MemorySpace,
+        LayoutStridedPolicy>> = true;
 
 
 /**
@@ -49,20 +61,20 @@ inline constexpr bool enable_borrowed_vector_field<
  *
  * @tparam ElementType The data type of a scalar element of the vector field.
  * @tparam IdxRangeType
- * @tparam NDTag A NDTag describing the dimensions described by the scalar elements of a vector field element.
+ * @tparam VectorIndexSetType A VectorIndexSet describing the dimensions described by the scalar elements of a vector field element.
  * @tparam MemorySpace The memory space (CPU/GPU).
  * @tparam LayoutStridedPolicy The memory layout. See DDC.
  */
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace,
         class LayoutStridedPolicy>
 class VectorField
     : public VectorFieldCommon<
               Field<ElementType, IdxRangeType, MemorySpace, LayoutStridedPolicy>,
-              NDTag>
+              VectorIndexSetType>
 {
 public:
     /**
@@ -71,7 +83,7 @@ public:
     using field_type = Field<ElementType, IdxRangeType, MemorySpace, LayoutStridedPolicy>;
 
 private:
-    using base_type = VectorFieldCommon<field_type, NDTag>;
+    using base_type = VectorFieldCommon<field_type, VectorIndexSetType>;
 
 public:
     /// The type of an element in one of the Fields comprising the VectorField
@@ -90,14 +102,22 @@ public:
      * so is the span type.
      * This is a DDC keyword used to make this class interchangeable with Field.
      */
-    using span_type
-            = VectorField<ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>;
+    using span_type = VectorField<
+            ElementType,
+            IdxRangeType,
+            VectorIndexSetType,
+            MemorySpace,
+            LayoutStridedPolicy>;
     /**
      * @brief A type which can hold a constant reference to a VectorFieldMem.
      * This is a DDC keyword used to make this class interchangeable with Field.
      */
-    using view_type
-            = VectorField<const ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>;
+    using view_type = VectorField<
+            const ElementType,
+            IdxRangeType,
+            VectorIndexSetType,
+            MemorySpace,
+            LayoutStridedPolicy>;
 
     /**
      * @brief Type describing the way in which the data is laid out in the Field memory.
@@ -127,9 +147,10 @@ private:
 
     template <class OElementType, class Allocator, std::size_t... Is>
     KOKKOS_FUNCTION constexpr VectorField(
-            VectorFieldMem<OElementType, IdxRangeType, NDTag, Allocator>& other,
+            VectorFieldMem<OElementType, IdxRangeType, VectorIndexSetType, Allocator>& other,
             std::index_sequence<Is...> const&) noexcept
-        : base_type((field_type(ddcHelper::get<ddc::type_seq_element_t<Is, NDTag>>(other)))...)
+        : base_type((field_type(
+                ddcHelper::get<ddc::type_seq_element_t<Is, VectorIndexSetType>>(other)))...)
     {
     }
 
@@ -144,9 +165,10 @@ private:
             class = std::enable_if_t<std::is_const_v<SFINAEElementType>>,
             class Allocator>
     KOKKOS_FUNCTION constexpr VectorField(
-            VectorFieldMem<OElementType, IdxRangeType, NDTag, Allocator> const& other,
+            VectorFieldMem<OElementType, IdxRangeType, VectorIndexSetType, Allocator> const& other,
             std::index_sequence<Is...> const&) noexcept
-        : base_type((field_type(ddcHelper::get<ddc::type_seq_element_t<Is, NDTag>>(other)))...)
+        : base_type((field_type(
+                ddcHelper::get<ddc::type_seq_element_t<Is, VectorIndexSetType>>(other)))...)
     {
     }
 
@@ -158,11 +180,12 @@ private:
             VectorField<
                     OElementType,
                     index_range_type,
-                    NDTag,
+                    VectorIndexSetType,
                     MemorySpace,
                     LayoutStridedPolicy> const& other,
             std::index_sequence<Is...> const&) noexcept
-        : base_type((field_type(ddcHelper::get<ddc::type_seq_element_t<Is, NDTag>>(other)))...)
+        : base_type((field_type(
+                ddcHelper::get<ddc::type_seq_element_t<Is, VectorIndexSetType>>(other)))...)
     {
     }
 
@@ -170,12 +193,13 @@ private:
     constexpr auto get_slice(SliceType const& slice_spec, std::index_sequence<Is...> const&)
     {
         auto chunk_slices = std::make_tuple(
-                this->template get<ddc::type_seq_element_t<Is, NDTag>>()[slice_spec]...);
+                this->template get<
+                        ddc::type_seq_element_t<Is, VectorIndexSetType>>()[slice_spec]...);
         using FieldType = std::tuple_element_t<0, decltype(chunk_slices)>;
         return VectorField<
                 ElementType,
                 typename FieldType::discrete_domain_type,
-                NDTag,
+                VectorIndexSetType,
                 typename FieldType::memory_space,
                 typename FieldType::layout_type>(std::move(std::get<Is>(chunk_slices))...);
     }
@@ -214,7 +238,8 @@ public:
      */
     template <class OElementType, class Allocator>
     KOKKOS_FUNCTION explicit constexpr VectorField(
-            VectorFieldMem<OElementType, IdxRangeType, NDTag, Allocator>& other) noexcept
+            VectorFieldMem<OElementType, IdxRangeType, VectorIndexSetType, Allocator>&
+                    other) noexcept
         : VectorField(other, std::make_index_sequence<base_type::NDims> {})
     {
     }
@@ -229,13 +254,15 @@ public:
             class = std::enable_if_t<std::is_const_v<SFINAEElementType>>,
             class Allocator>
     KOKKOS_FUNCTION explicit constexpr VectorField(
-            VectorFieldMem<OElementType, IdxRangeType, NDTag, Allocator> const& other) noexcept
+            VectorFieldMem<OElementType, IdxRangeType, VectorIndexSetType, Allocator> const&
+                    other) noexcept
         : VectorField(other, std::make_index_sequence<base_type::NDims> {})
     {
     }
 
     template <class OElementType, class Allocator>
-    VectorField(VectorFieldMem<OElementType, IdxRangeType, NDTag, Allocator>&& other) = delete;
+    VectorField(VectorFieldMem<OElementType, IdxRangeType, VectorIndexSetType, Allocator>&& other)
+            = delete;
 
     /** Constructs a new VectorField by copy of a chunk, yields a new view to the same data
      * @param other the VectorField to move
@@ -244,7 +271,7 @@ public:
     KOKKOS_FUNCTION constexpr VectorField(VectorField<
                                           OElementType,
                                           index_range_type,
-                                          NDTag,
+                                          VectorIndexSetType,
                                           MemorySpace,
                                           LayoutStridedPolicy> const& other) noexcept
         : VectorField(other, std::make_index_sequence<base_type::NDims> {})
@@ -384,26 +411,35 @@ public:
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
         class LayoutStridedPolicy = Kokkos::layout_right>
-using VectorConstField
-        = VectorField<const ElementType, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>;
+using VectorConstField = VectorField<
+        const ElementType,
+        IdxRangeType,
+        VectorIndexSetType,
+        MemorySpace,
+        LayoutStridedPolicy>;
 
 template <
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
         class LayoutStridedPolicy = Kokkos::layout_right>
-using DVectorField = VectorField<double, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>;
+using DVectorField
+        = VectorField<double, IdxRangeType, VectorIndexSetType, MemorySpace, LayoutStridedPolicy>;
 
 template <
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
         class LayoutStridedPolicy = Kokkos::layout_right>
-using DVectorConstField
-        = VectorConstField<double, IdxRangeType, NDTag, MemorySpace, LayoutStridedPolicy>;
+using DVectorConstField = VectorConstField<
+        double,
+        IdxRangeType,
+        VectorIndexSetType,
+        MemorySpace,
+        LayoutStridedPolicy>;
 
 namespace detail {
 
@@ -413,7 +449,7 @@ namespace detail {
  * @tparam NewMemorySpace The new memory space. 
  * @tparam ElementType Type of the elements in the ddc::Chunk of the VectorFieldMem.
  * @tparam SupportType Type of the domain of the ddc::Chunk in the VectorFieldMem.
- * @tparam NDTag NDTag object storing directions of the VectorFieldMem as dimensions. 
+ * @tparam VectorIndexSetType VectorIndexSet object storing directions of the VectorFieldMem as dimensions. 
  *               The dimensions refer to the dimensions of the arrival domain of the VectorFieldMem. 
  * @tparam Layout Layout tag (see Kokkos).
  * @tparam MemorySpace The original memory space of the chunk of the VectorFieldMem.
@@ -423,14 +459,14 @@ template <
         class NewMemorySpace,
         class ElementType,
         class SupportType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemorySpace,
         class Layout>
 struct OnMemorySpace<
         NewMemorySpace,
-        VectorField<ElementType, SupportType, NDTag, MemorySpace, Layout>>
+        VectorField<ElementType, SupportType, VectorIndexSetType, MemorySpace, Layout>>
 {
-    using type = VectorField<ElementType, SupportType, NDTag, NewMemorySpace, Layout>;
+    using type = VectorField<ElementType, SupportType, VectorIndexSetType, NewMemorySpace, Layout>;
 };
 
 } // namespace detail
@@ -446,8 +482,12 @@ template <
         class LayoutStridedPolicy>
 auto create_mirror_view_and_copy(
         ExecSpace exec_space,
-        VectorField<ElementType, IdxRangeType, NDTag<Dims...>, MemorySpace, LayoutStridedPolicy>
-                field)
+        VectorField<
+                ElementType,
+                IdxRangeType,
+                VectorIndexSetType<Dims...>,
+                MemorySpace,
+                LayoutStridedPolicy> field)
 {
     if constexpr (Kokkos::SpaceAccessibility<ExecSpace, MemorySpace>::accessible) {
         return field;
@@ -455,7 +495,7 @@ auto create_mirror_view_and_copy(
         VectorFieldMem<
                 std::remove_const_t<ElementType>,
                 IdxRangeType,
-                NDTag<Dims...>,
+                VectorIndexSetType<Dims...>,
                 typename ExecSpace::memory_space>
                 field_alloc(get_idx_range(field));
         ((ddc::parallel_deepcopy(field_alloc.template get<Dims>(), field.template get<Dims>())),

--- a/src/data_types/vector_field_mem.hpp
+++ b/src/data_types/vector_field_mem.hpp
@@ -7,6 +7,7 @@
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
 #include "vector_field_common.hpp"
+#include "vector_index_tools.hpp"
 
 /**
  * @brief Pre-declaration of VectorFieldMem.
@@ -14,7 +15,7 @@
 template <
         class ElementType,
         class IdxRangeType,
-        class NDTag,
+        class VectorIndexSetType,
         class MemSpace = Kokkos::DefaultExecutionSpace::memory_space>
 class VectorFieldMem;
 
@@ -46,12 +47,12 @@ class VectorField;
  *
  * @tparam ElementType The data type of a scalar element of the vector field.
  * @tparam IdxRangeType
- * @tparam NDTag A NDTag describing the dimensions described by the scalar elements of a vector field element.
+ * @tparam VectorIndexSetType A VectorIndexSet describing the dimensions described by the scalar elements of a vector field element.
  * @tparam MemSpace The type describing where the memory is allocated. See DDC.
  */
-template <class ElementType, class IdxRangeType, class NDTag, class MemSpace>
+template <class ElementType, class IdxRangeType, class VectorIndexSetType, class MemSpace>
 class VectorFieldMem
-    : public VectorFieldCommon<FieldMem<ElementType, IdxRangeType, MemSpace>, NDTag>
+    : public VectorFieldCommon<FieldMem<ElementType, IdxRangeType, MemSpace>, VectorIndexSetType>
 {
 public:
     /**
@@ -64,7 +65,7 @@ public:
     using chunk_type = FieldMem<ElementType, IdxRangeType, MemSpace>;
 
 private:
-    using base_type = VectorFieldCommon<chunk_type, NDTag>;
+    using base_type = VectorFieldCommon<chunk_type, VectorIndexSetType>;
 
 public:
     /// The type of an element in one of the FieldMems comprising the VectorFieldMem
@@ -84,15 +85,24 @@ public:
      *
      * This is a DDC keyword used to make this class interchangeable with Field.
      */
-    using span_type = VectorField<ElementType, IdxRangeType, NDTag, MemSpace, Kokkos::layout_right>;
+    using span_type = VectorField<
+            ElementType,
+            IdxRangeType,
+            VectorIndexSetType,
+            MemSpace,
+            Kokkos::layout_right>;
 
     /**
      * @brief A type which can hold a constant reference to this VectorFieldMem.
      *
      * This is a DDC keyword used to make this class interchangeable with Field.
      */
-    using view_type
-            = VectorField<const ElementType, IdxRangeType, NDTag, MemSpace, Kokkos::layout_right>;
+    using view_type = VectorField<
+            const ElementType,
+            IdxRangeType,
+            VectorIndexSetType,
+            MemSpace,
+            Kokkos::layout_right>;
 
     /**
      * @brief The type of the index range on which the field is defined.
@@ -321,14 +331,21 @@ namespace detail {
  * @tparam NewMemorySpace The new memory space. 
  * @tparam ElementType Type of the elements in the ddc::Chunk of the VectorFieldMem.
  * @tparam SupportType Type of the domain of the ddc::Chunk in the VectorFieldMem.
- * @tparam NDTag NDTag object storing the dimensions along which the VectorFieldMem is defined.
+ * @tparam VectorIndexSetType VectorIndexSet object storing the dimensions along which the VectorFieldMem is defined.
  *               The dimensions refer to the dimensions of the arrival domain of the VectorFieldMem. 
  * @tparam MemSpace The old memory space.
  * @see VectorFieldMem
  */
-template <class NewMemorySpace, class ElementType, class SupportType, class NDTag, class MemSpace>
-struct OnMemorySpace<NewMemorySpace, VectorFieldMem<ElementType, SupportType, NDTag, MemSpace>>
+template <
+        class NewMemorySpace,
+        class ElementType,
+        class SupportType,
+        class VectorIndexSetType,
+        class MemSpace>
+struct OnMemorySpace<
+        NewMemorySpace,
+        VectorFieldMem<ElementType, SupportType, VectorIndexSetType, MemSpace>>
 {
-    using type = VectorFieldMem<ElementType, SupportType, NDTag, NewMemorySpace>;
+    using type = VectorFieldMem<ElementType, SupportType, VectorIndexSetType, NewMemorySpace>;
 };
 } // namespace detail

--- a/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
@@ -3,7 +3,6 @@
 
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
-#include "directional_tag.hpp"
 #include "geometry.hpp"
 #include "i_interpolator_rtheta.hpp"
 #include "iadvection_rtheta.hpp"

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -4,7 +4,6 @@
 
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
-#include "directional_tag.hpp"
 #include "geometry.hpp"
 #include "iqnsolver.hpp"
 #include "metric_tensor_evaluator.hpp"
@@ -14,6 +13,7 @@
 #include "polarpoissonlikesolver.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 

--- a/src/geometryRTheta/geometry/README.md
+++ b/src/geometryRTheta/geometry/README.md
@@ -31,4 +31,4 @@ The shortcuts defined in the geometry file represent:
 14. The templated type of a constant field defined on each of the domains (e.g. `ConstFieldR<ElementType>`).
 15. The type of a constant field of doubles defined on each of the domains (e.g. `DConstFieldR`).
 16. The type of a field of doubles defined on the spline domains representing a spline on the Cartesian product base (e.g. `Spline2D`), and a spline on the polar spline base (e.g. `PolarSplineRTheta`).
-17. The type of VectorField defined on the index range `IdxRangeRTheta` on the template directions `NDTag<Dim1, Dim2>` (`VectorDFieldRTheta<Dim1, Dim2>`). The directions used in the code are either `<R, Theta>` or `<X, Y>`. 
+17. The type of VectorField defined on the index range `IdxRangeRTheta` on the template directions `VectorIndexSet<Dim1, Dim2>` (`VectorDFieldRTheta<Dim1, Dim2>`). The directions used in the code are either `<R, Theta>` or `<X, Y>`. 

--- a/src/geometryRTheta/geometry/geometry.hpp
+++ b/src/geometryRTheta/geometry/geometry.hpp
@@ -6,10 +6,10 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "polar_bsplines.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 /*

--- a/src/geometryRTheta/geometry/geometry.hpp
+++ b/src/geometryRTheta/geometry/geometry.hpp
@@ -348,24 +348,27 @@ using IdxPolarBspl = Idx<PolarBSplinesRTheta>;
 
 // --- VectorFieldMem definitions
 template <class Dim1, class Dim2>
-using DVectorFieldMemRTheta = VectorFieldMem<double, IdxRangeRTheta, NDTag<Dim1, Dim2>>;
+using DVectorFieldMemRTheta = VectorFieldMem<double, IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 template <class Dim1, class Dim2>
-using DVectorFieldRTheta = VectorField<double, IdxRangeRTheta, NDTag<Dim1, Dim2>>;
+using DVectorFieldRTheta = VectorField<double, IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 template <class Dim1, class Dim2>
-using DConstVectorFieldRTheta = VectorConstField<double, IdxRangeRTheta, NDTag<Dim1, Dim2>>;
+using DConstVectorFieldRTheta
+        = VectorConstField<double, IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 
 
 template <class Dim1, class Dim2>
-using VectorSplineCoeffsMem2D = VectorFieldMem<double, IdxRangeBSRTheta, NDTag<Dim1, Dim2>>;
+using VectorSplineCoeffsMem2D
+        = VectorFieldMem<double, IdxRangeBSRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 template <class Dim1, class Dim2>
-using VectorSplineCoeffs2D = VectorField<double, IdxRangeBSRTheta, NDTag<Dim1, Dim2>>;
+using VectorSplineCoeffs2D = VectorField<double, IdxRangeBSRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 template <class Dim1, class Dim2>
-using ConstVectorSplineCoeffs2D = VectorConstField<double, IdxRangeBSRTheta, NDTag<Dim1, Dim2>>;
+using ConstVectorSplineCoeffs2D
+        = VectorConstField<double, IdxRangeBSRTheta, VectorIndexSet<Dim1, Dim2>>;
 
 
 

--- a/src/geometryXY/geometry/README.md
+++ b/src/geometryXY/geometry/README.md
@@ -20,4 +20,4 @@ The shortcuts defined in the geometry file represent:
 13. The type of a field of doubles defined on each of the domains (e.g. `DFieldX`).
 14. The templated type of a constant field defined on each of the domains (e.g. `ConstFieldX<ElementType>`).
 15. The type of a constant field of doubles defined on each of the domains (e.g. `DConstFieldX`).
-16. The type of VectorField defined on the index range `IdxRangeXY` on the directions `NDTag<RDimX, RDimY>` (`VectorFieldXY_XY`). 
+16. The type of VectorField defined on the index range `IdxRangeXY` on the directions `VectorIndexSet<RDimX, RDimY>` (`VectorFieldXY_XY`). 

--- a/src/geometryXY/geometry/geometry.hpp
+++ b/src/geometryXY/geometry/geometry.hpp
@@ -7,9 +7,9 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 
@@ -208,7 +208,7 @@ using DConstFieldXY = ConstFieldXY<double>;
 using VectorFieldMemXY_XY = VectorFieldMem<
         double,
         IdxRangeXY,
-        NDTag<X, Y>,
+        VectorIndexSet<X, Y>,
         Kokkos::DefaultExecutionSpace::memory_space>;
 using VectorFieldXY_XY = typename VectorFieldMemXY_XY::span_type;
 using VectorConstFieldXY_XY = typename VectorFieldMemXY_XY::view_type;

--- a/src/geometryXY/time_integration/predcorr_RK2.hpp
+++ b/src/geometryXY/time_integration/predcorr_RK2.hpp
@@ -11,7 +11,6 @@
 #include "bsl_advection_1d.hpp"
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
-#include "directional_tag.hpp"
 #include "geometry.hpp"
 #include "l_norm_tools.hpp"
 #include "paraconfpp.hpp"

--- a/src/geometryXYVxVy/poisson/qnsolver.cpp
+++ b/src/geometryXYVxVy/poisson/qnsolver.cpp
@@ -8,9 +8,9 @@
 #include <ddc/ddc.hpp>
 
 #include "ddc_alias_inline_functions.hpp"
-#include "directional_tag.hpp"
 #include "geometry.hpp"
 #include "qnsolver.hpp"
+#include "vector_index_tools.hpp"
 
 QNSolver::QNSolver(PoissonSolver const& solve_poisson, IChargeDensityCalculator const& compute_rho)
     : m_solve_poisson(solve_poisson)
@@ -36,7 +36,7 @@ void QNSolver::operator()(
     VectorField<
             double,
             IdxRangeXY,
-            NDTag<X, Y>,
+            VectorIndexSet<X, Y>,
             Kokkos::DefaultExecutionSpace::memory_space,
             typename DFieldMemXY::layout_type>
             electric_field(electric_field_x, electric_field_y);

--- a/src/mapping/vector_mapper.hpp
+++ b/src/mapping/vector_mapper.hpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "directional_tag.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 #include "view.hpp"
 
 /** The general predeclaration of VectorMapper.
@@ -17,13 +17,13 @@ class VectorMapper;
  *
  * @anchor VectorMapperImplementation
  *
- * @tparam InVectorSpace A NDTag<XIn, YIn> describing the dimensions of the coordinate system taken as input.
- * @tparam OutVectorSpace A NDTag<XOut, YOut> describing the dimensions of the coordinate system returned as output.
+ * @tparam InVectorSpace A VectorIndexSet<XIn, YIn> describing the dimensions of the coordinate system taken as input.
+ * @tparam OutVectorSpace A VectorIndexSet<XOut, YOut> describing the dimensions of the coordinate system returned as output.
  * @tparam Mapping A class describing a mapping system.
  * @tparam ExecSpace The space (CPU/GPU) where the calculations are carried out.
  */
 template <class XIn, class YIn, class XOut, class YOut, class Mapping, class ExecSpace>
-class VectorMapper<NDTag<XIn, YIn>, NDTag<XOut, YOut>, Mapping, ExecSpace>
+class VectorMapper<VectorIndexSet<XIn, YIn>, VectorIndexSet<XOut, YOut>, Mapping, ExecSpace>
 {
     static_assert(is_accessible_v<ExecSpace, Mapping>);
     static_assert(
@@ -58,12 +58,16 @@ public:
     template <class IdxRangeType, class LayoutStridedPolicy1, class LayoutStridedPolicy2>
     void operator()(
             ExecSpace exec_space,
-            VectorField<double, IdxRangeType, NDTag<XOut, YOut>, memory_space, LayoutStridedPolicy1>
-                    vector_field_output,
+            VectorField<
+                    double,
+                    IdxRangeType,
+                    VectorIndexSet<XOut, YOut>,
+                    memory_space,
+                    LayoutStridedPolicy1> vector_field_output,
             VectorConstField<
                     double,
                     IdxRangeType,
-                    NDTag<XIn, YIn>,
+                    VectorIndexSet<XIn, YIn>,
                     memory_space,
                     LayoutStridedPolicy2> vector_field_input)
     {
@@ -135,7 +139,7 @@ auto create_geometry_mirror_view(
         VectorField<
                 ElementType,
                 IdxRangeType,
-                NDTag<X, Y>,
+                VectorIndexSet<X, Y>,
                 typename ExecSpace::memory_space,
                 LayoutStridedPolicy> vector_field,
         Mapping mapping)
@@ -152,10 +156,11 @@ auto create_geometry_mirror_view(
         VectorFieldMem<
                 std::remove_const_t<ElementType>,
                 IdxRangeType,
-                NDTag<X_out, Y_out>,
+                VectorIndexSet<X_out, Y_out>,
                 typename ExecSpace::memory_space>
                 vector_field_out(get_idx_range(vector_field));
-        VectorMapper<NDTag<X, Y>, NDTag<X_out, Y_out>, Mapping, ExecSpace> vector_mapping(mapping);
+        VectorMapper<VectorIndexSet<X, Y>, VectorIndexSet<X_out, Y_out>, Mapping, ExecSpace>
+                vector_mapping(mapping);
         vector_mapping(exec_space, get_field(vector_field_out), get_const_field(vector_field));
         return vector_field_out;
     }

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -10,6 +10,7 @@
 
 #include "quadrature.hpp"
 #include "vector_field.hpp"
+#include "vector_index_tools.hpp"
 
 /**
  * @brief Compute the infinity norm.
@@ -131,10 +132,14 @@ inline double norm_inf(
  * @param[in] function The function whose norm is calculated.
  * @return A double containing the value of the infinity norm.
  */
-template <class ExecSpace, class ElementType, class IdxRange, class NDTag>
+template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
 inline double norm_inf(
         ExecSpace exec_space,
-        VectorConstField<ElementType, IdxRange, NDTag, typename ExecSpace::memory_space> function)
+        VectorConstField<
+                ElementType,
+                IdxRange,
+                VectorIndexSetType,
+                typename ExecSpace::memory_space> function)
 {
     return detail::norm_inf(exec_space, function);
 }
@@ -162,12 +167,19 @@ inline double error_norm_inf(
  * @param[in] exact_function The exact function with which the calculated function is compared.
  * @return A double containing the value of the infinity norm.
  */
-template <class ExecSpace, class ElementType, class IdxRange, class NDTag>
+template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
 inline double error_norm_inf(
         ExecSpace exec_space,
-        VectorConstField<ElementType, IdxRange, NDTag, typename ExecSpace::memory_space> function,
-        VectorConstField<ElementType, IdxRange, NDTag, typename ExecSpace::memory_space>
-                exact_function)
+        VectorConstField<
+                ElementType,
+                IdxRange,
+                VectorIndexSetType,
+                typename ExecSpace::memory_space> function,
+        VectorConstField<
+                ElementType,
+                IdxRange,
+                VectorIndexSetType,
+                typename ExecSpace::memory_space> exact_function)
 {
     return detail::error_norm_inf(exec_space, function, exact_function);
 }

--- a/src/multipatch/data_types/types.hpp
+++ b/src/multipatch/data_types/types.hpp
@@ -5,9 +5,9 @@
 
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 // GRIDS -----------------------------------------------------------------------------------------
@@ -65,21 +65,21 @@ template <class Patch>
 using DVectorFieldMemOnPatch = VectorFieldMem<
         double,
         typename Patch::IdxRange12,
-        NDTag<typename Patch::Dim1, typename Patch::Dim2>>;
+        VectorIndexSet<typename Patch::Dim1, typename Patch::Dim2>>;
 
 /// @brief A VectorField defined on the Patch's 2D logical domain.
 template <class Patch>
 using DVectorFieldOnPatch = VectorField<
         double,
         typename Patch::IdxRange12,
-        NDTag<typename Patch::Dim1, typename Patch::Dim2>>;
+        VectorIndexSet<typename Patch::Dim1, typename Patch::Dim2>>;
 
 /// @brief A ConstVectorField defined on the Patch's 2D logical domain.
 template <class Patch>
 using DVectorConstFieldOnPatch = VectorConstField<
         double,
         typename Patch::IdxRange12,
-        NDTag<typename Patch::Dim1, typename Patch::Dim2>>;
+        VectorIndexSet<typename Patch::Dim1, typename Patch::Dim2>>;
 
 // IDX, IDXRANGE ---------------------------------------------------------------------------------
 

--- a/src/pde_solvers/fft_poisson_solver.hpp
+++ b/src/pde_solvers/fft_poisson_solver.hpp
@@ -6,8 +6,8 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "ipoisson_solver.hpp"
+#include "vector_index_tools.hpp"
 
 /**
  * See @ref FFTPoissonSolverImplementation.

--- a/src/pde_solvers/fft_poisson_solver.hpp
+++ b/src/pde_solvers/fft_poisson_solver.hpp
@@ -163,7 +163,7 @@ private:
             VectorField<
                     double,
                     laplacian_idx_range_type,
-                    NDTag<Dims...>,
+                    VectorIndexSet<Dims...>,
                     memory_space,
                     layout_space> gradient,
             fourier_field_type fourier_derivative,

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -4,4 +4,4 @@ This folder contains classes and functions which facilitate the writing of the r
 
 The class ddcHelper exists to provide functionalities which are currently missing from DDC.
 
-The class NDTag exists to provide a way to group directional tags together. This is notably useful in order to create a vector field.
+The class VectorIndexSet exists to provide a way to group directional tags together. This is notably useful in order to create a vector field.

--- a/src/utils/directional_tag.hpp
+++ b/src/utils/directional_tag.hpp
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: MIT
-
-#pragma once
-
-#include <ddc/ddc.hpp>
-
-template <class... DDims>
-using NDTag = ddc::detail::TypeSeq<DDims...>;

--- a/tests/data_types/deriv_field.cpp
+++ b/tests/data_types/deriv_field.cpp
@@ -9,7 +9,6 @@
 #include "ddc_helper.hpp"
 #include "derivative_field.hpp"
 #include "derivative_field_mem.hpp"
-#include "directional_tag.hpp"
 #include "grid_builder.hpp"
 #include "view.hpp"
 

--- a/tests/data_types/device_host_t.cpp
+++ b/tests/data_types/device_host_t.cpp
@@ -8,9 +8,9 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 namespace {
@@ -21,7 +21,7 @@ class Tag2
 {
 };
 
-using Direction = NDTag<Tag1, Tag2>;
+using Direction = VectorIndexSet<Tag1, Tag2>;
 
 
 struct GridX

--- a/tests/data_types/field.cpp
+++ b/tests/data_types/field.cpp
@@ -6,9 +6,9 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 namespace {
 
@@ -25,7 +25,7 @@ struct Tag2
     using Dual = Tag2;
 };
 
-using Direction = NDTag<Tag1, Tag2>;
+using Direction = VectorIndexSet<Tag1, Tag2>;
 
 using Coord2D = Coord<Tag1, Tag2>;
 

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -19,7 +19,6 @@
 #include "crank_nicolson.hpp"
 #include "czarny_to_cartesian.hpp"
 #include "ddc_aliases.hpp"
-#include "directional_tag.hpp"
 #include "discrete_mapping_builder.hpp"
 #include "discrete_to_cartesian.hpp"
 #include "euler.hpp"

--- a/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
@@ -10,7 +10,6 @@
 #include <ddc/ddc.hpp>
 
 #include "bsl_advection_rtheta.hpp"
-#include "directional_tag.hpp"
 #include "geometry.hpp"
 #include "l_norm_tools.hpp"
 #include "math_tools.hpp"

--- a/tests/math_tools/test_lnorm_tools.cpp
+++ b/tests/math_tools/test_lnorm_tools.cpp
@@ -6,10 +6,10 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "l_norm_tools.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 namespace {
 
@@ -52,10 +52,10 @@ using CoordY = Coord<Y>;
 using CoordXY = Coord<X, Y>;
 
 using DFieldMemXY = DFieldMem<IdxRangeXY>;
-using DVectorFieldMemXY = VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>;
+using DVectorFieldMemXY = VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>;
 
 using DFieldXY = DField<IdxRangeXY>;
-using DVectorFieldXY = VectorField<double, IdxRangeXY, NDTag<X, Y>>;
+using DVectorFieldXY = VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>;
 
 template <class Grid1D>
 KOKKOS_FUNCTION typename Grid1D::continuous_element_type get_coordinate(Idx<Grid1D> x)

--- a/tests/multipatch/spline/multipatch_spline_builder.cpp
+++ b/tests/multipatch/spline/multipatch_spline_builder.cpp
@@ -7,7 +7,6 @@
 #include "2patches_2d_non_periodic_non_uniform.hpp"
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "mesh_builder.hpp"
 #include "multipatch_field.hpp"
 #include "multipatch_spline_builder.hpp"

--- a/tests/multipatch/spline/multipatch_spline_builder_2d.cpp
+++ b/tests/multipatch/spline/multipatch_spline_builder_2d.cpp
@@ -7,7 +7,6 @@
 #include "2patches_2d_non_periodic_non_uniform.hpp"
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_helper.hpp"
-#include "directional_tag.hpp"
 #include "mesh_builder.hpp"
 #include "multipatch_field.hpp"
 #include "multipatch_spline_builder_2d.hpp"

--- a/tests/pde_solvers/fftpoissonsolver.cpp
+++ b/tests/pde_solvers/fftpoissonsolver.cpp
@@ -173,7 +173,7 @@ static void TestFftPoissonSolver2DCosineSource()
     FFTPoissonSolver<IdxRangeXY, IdxRangeXY, Kokkos::DefaultExecutionSpace> poisson(gridxy);
 
     DFieldMemXY electrostatic_potential_alloc(gridxy);
-    VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>> electric_field_alloc(gridxy);
+    VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>> electric_field_alloc(gridxy);
     DFieldMemXY rhs_alloc(gridxy);
 
     DFieldXY electrostatic_potential = get_field(electrostatic_potential_alloc);

--- a/tests/timestepper/crank_nicolson_2d_mixed.cpp
+++ b/tests/timestepper/crank_nicolson_2d_mixed.cpp
@@ -9,10 +9,10 @@
 #include <gtest/gtest.h>
 
 #include "crank_nicolson.hpp"
-#include "directional_tag.hpp"
 #include "l_norm_tools.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 using namespace ddc;
 
@@ -55,11 +55,11 @@ TEST(CrankNicolson2DFixtureMixedTypes, CrankNicolson2DOrderMixedTypes)
     using IdxRangeY = IdxRange<GridY>;
     using IdxXY = Idx<GridX, GridY>;
     using IdxRangeXY = IdxRange<GridX, GridY>;
-    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
     using CFieldMemXY = host_t<FieldMem<CoordXY, IdxRangeXY>>;
     using Method = CrankNicolson<CFieldMemXY, AdvectionFieldMem, Kokkos::DefaultHostExecutionSpace>;
-    using AdvectionField = host_t<VectorField<double, IdxRangeXY, NDTag<X, Y>>>;
-    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionField = host_t<VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
+    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
 
     CoordX x_min(-1.0);
     CoordX x_max(1.0);
@@ -162,12 +162,12 @@ void CrankNicolson2DOrderMixedTypesTest()
     using IdxRangeY = IdxRange<GridY>;
     using IdxXY = Idx<GridX, GridY>;
     using IdxRangeXY = IdxRange<GridX, GridY>;
-    using AdvectionFieldMem = VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>;
+    using AdvectionFieldMem = VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>;
     using CFieldMemXY = FieldMem<CoordXY, IdxRangeXY>;
     using CFieldXY = Field<CoordXY, IdxRangeXY>;
     using Method = CrankNicolson<CFieldMemXY, AdvectionFieldMem>;
-    using AdvectionField = VectorField<double, IdxRangeXY, NDTag<X, Y>>;
-    using ConstAdvectionField = VectorConstField<double, IdxRangeXY, NDTag<X, Y>>;
+    using AdvectionField = VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>;
+    using ConstAdvectionField = VectorConstField<double, IdxRangeXY, VectorIndexSet<X, Y>>;
 
     CoordX x_min(-1.0);
     CoordX x_max(1.0);

--- a/tests/timestepper/euler_2d_mixed.cpp
+++ b/tests/timestepper/euler_2d_mixed.cpp
@@ -9,11 +9,11 @@
 #include <gtest/gtest.h>
 
 #include "crank_nicolson.hpp"
-#include "directional_tag.hpp"
 #include "euler.hpp"
 #include "l_norm_tools.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 struct X
@@ -53,11 +53,11 @@ TEST(Euler2DFixtureMixedTypes, Euler2DOrderMixedTypes)
     using IdxRangeY = IdxRange<GridY>;
     using IdxXY = Idx<GridX, GridY>;
     using IdxRangeXY = IdxRange<GridX, GridY>;
-    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
     using CFieldXY = host_t<FieldMem<CoordXY, IdxRangeXY>>;
     using Methods = Euler<CFieldXY, AdvectionFieldMem, Kokkos::DefaultHostExecutionSpace>;
-    using AdvectionField = host_t<VectorField<double, IdxRangeXY, NDTag<X, Y>>>;
-    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionField = host_t<VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
+    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
 
     CoordX x_min(-1.0);
     CoordX x_max(1.0);

--- a/tests/timestepper/runge_kutta_2d.cpp
+++ b/tests/timestepper/runge_kutta_2d.cpp
@@ -8,12 +8,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "directional_tag.hpp"
 #include "rk2.hpp"
 #include "rk3.hpp"
 #include "rk4.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 using namespace ddc;
 
@@ -59,7 +59,7 @@ public:
     using IdxRangeY = IdxRange<GridY>;
     using IdxXY = Idx<GridX, GridY>;
     using IdxRangeXY = IdxRange<GridX, GridY>;
-    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
     using RungeKutta = std::conditional_t<
             ORDER == 2,
             RK2<AdvectionFieldMem, AdvectionFieldMem, Kokkos::DefaultHostExecutionSpace>,
@@ -96,8 +96,8 @@ TYPED_TEST(RungeKutta2DFixture, RungeKutta2DOrder)
     using IdxRangeXY = typename TestFixture::IdxRangeXY;
     using RungeKutta = typename TestFixture::RungeKutta;
     using AdvectionFieldMem = typename TestFixture::AdvectionFieldMem;
-    using AdvectionField = host_t<VectorField<double, IdxRangeXY, NDTag<X, Y>>>;
-    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionField = host_t<VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
+    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
 
     CoordX x_min(-1.0);
     CoordX x_max(1.0);

--- a/tests/timestepper/runge_kutta_2d_mixed.cpp
+++ b/tests/timestepper/runge_kutta_2d_mixed.cpp
@@ -8,12 +8,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "directional_tag.hpp"
 #include "rk2.hpp"
 #include "rk3.hpp"
 #include "rk4.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 using namespace ddc;
 
@@ -60,7 +60,7 @@ public:
     using IdxRangeY = IdxRange<GridY>;
     using IdxXY = Idx<GridX, GridY>;
     using IdxRangeXY = IdxRange<GridX, GridY>;
-    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionFieldMem = host_t<VectorFieldMem<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
     using CFieldXY = host_t<FieldMem<CoordXY, IdxRangeXY>>;
     using RungeKutta = std::conditional_t<
             ORDER == 2,
@@ -99,8 +99,8 @@ TYPED_TEST(RungeKutta2DFixtureMixedTypes, RungeKutta2DOrderMixedTypes)
     using IdxRangeXY = typename TestFixture::IdxRangeXY;
     using CFieldXY = typename TestFixture::CFieldXY;
     using RungeKutta = typename TestFixture::RungeKutta;
-    using AdvectionField = host_t<VectorField<double, IdxRangeXY, NDTag<X, Y>>>;
-    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, NDTag<X, Y>>>;
+    using AdvectionField = host_t<VectorField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
+    using ConstAdvectionField = host_t<VectorConstField<double, IdxRangeXY, VectorIndexSet<X, Y>>>;
 
     CoordX x_min(-1.0);
     CoordX x_max(1.0);


### PR DESCRIPTION
Both `NDTag` and `VectorIndexSet` represent the same concept and are implemented in the same way. There is no need to have both. `NDTag` is therefore removed in favour of the more explicit `VectorIndexSet`.