### PR TITLE
Improve `tensor_mul` static assertions

### DIFF
--- a/src/data_types/indexed_tensor.hpp
+++ b/src/data_types/indexed_tensor.hpp
@@ -204,6 +204,11 @@ KOKKOS_FUNCTION auto tensor_mul(IndexedTensorType... tensor_to_mul)
             "You should not have more than two of any one index in an index expression. "
             "Additionally repeated indices should not be associated with two covariant or two "
             "contravariant indices.");
+    using SumVectorIndexIdMap = repeated_indices_t<AllIndexIdMaps>;
+    using SumUniqueIds = type_seq_unique_t<index_identifiers_t<SumVectorIndexIdMap>>;
+    static_assert(
+            ddc::type_seq_size_v<SumVectorIndexIdMap> == ddc::type_seq_size_v<SumUniqueIds>,
+            "Cannot sum over incompatible VectorIndexSets.");
     // Use the first tensor argument to extract the element type of the result.
     using ElementType = std::tuple_element_t<
             0,
@@ -212,7 +217,7 @@ KOKKOS_FUNCTION auto tensor_mul(IndexedTensorType... tensor_to_mul)
             (std::is_same_v<
                      typename IndexedTensorType::tensor_type::element_type,
                      ElementType> && ...),
-            "All tensors must have the same element type");
+            "All tensors in a tensor_mul must have the same element type.");
     using ResultIndexTypeSeq = non_repeated_indices_t<AllIndexIdMaps>;
     if constexpr (ddc::type_seq_size_v<ResultIndexTypeSeq> == 0) {
         ElementType result = 0.0;

--- a/src/data_types/indexed_tensor.hpp
+++ b/src/data_types/indexed_tensor.hpp
@@ -155,9 +155,9 @@ KOKKOS_FUNCTION void internal_tensor_mul(
 template <char ID, class AllIndexIdMaps>
 KOKKOS_INLINE_FUNCTION void check_id_validity()
 {
-    constexpr std::size_t n_occurences
+    constexpr std::size_t n_occurrences
             = char_occurrences_v<ID, index_identifiers_t<AllIndexIdMaps>>;
-    if constexpr (n_occurences == 2) {
+    if constexpr (n_occurrences == 2) {
         using RelevantVectorIndexSets = relevant_vector_index_sets_t<ID, AllIndexIdMaps>;
         using Set1 = ddc::type_seq_element_t<0, RelevantVectorIndexSets>;
         using Set2 = ddc::type_seq_element_t<1, RelevantVectorIndexSets>;
@@ -174,7 +174,7 @@ KOKKOS_INLINE_FUNCTION void check_id_validity()
                 "Cannot sum over incompatible VectorIndexSets.");
     } else {
         static_assert(
-                n_occurences == 1,
+                n_occurrences == 1,
                 "You should not have more than two of any one index in an index expression.");
     }
 }

--- a/src/data_types/indexed_tensor.hpp
+++ b/src/data_types/indexed_tensor.hpp
@@ -162,11 +162,11 @@ KOKKOS_INLINE_FUNCTION void check_id_validity()
         using Set1 = ddc::type_seq_element_t<0, RelevantVectorIndexSets>;
         using Set2 = ddc::type_seq_element_t<1, RelevantVectorIndexSets>;
         constexpr bool has_covariant_idx = (is_covariant_vector_index_set_v<Set1>)
-                                           or (is_covariant_vector_index_set_v<Set2>);
+                                           || (is_covariant_vector_index_set_v<Set2>);
         constexpr bool has_contravariant_idx = (is_contravariant_vector_index_set_v<Set1>)
-                                               or (is_contravariant_vector_index_set_v<Set2>);
+                                               || (is_contravariant_vector_index_set_v<Set2>);
         static_assert(
-                has_covariant_idx and has_contravariant_idx,
+                has_covariant_idx && has_contravariant_idx,
                 "Repeated indices should not be associated with two covariant or two contravariant "
                 "indices.");
         static_assert(

--- a/src/data_types/tensor_index_tools.hpp
+++ b/src/data_types/tensor_index_tools.hpp
@@ -277,8 +277,10 @@ struct GetRepeatedIndices
             ddc::type_seq_size_v<TypeSeqVectorIndexIdMap> - 1 - Elem,
             TypeSeqVectorIndexIdMap>;
     static constexpr char current_char = CurrentIndex::id;
-    using ContraIdxValues = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
-    using InsertTypeSeq = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContraIdxValues>>;
+    using ContravariantVectorIndexSet
+            = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
+    using InsertTypeSeq
+            = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContravariantVectorIndexSet>>;
 
     using type = typename GetRepeatedIndices<
             TypeSeqVectorIndexIdMap,
@@ -297,8 +299,10 @@ struct GetRepeatedIndices<TypeSeqVectorIndexIdMap, 0, IdsFound, ResultTypeSeq>
             ddc::type_seq_size_v<TypeSeqVectorIndexIdMap> - 1,
             TypeSeqVectorIndexIdMap>;
     static constexpr char current_char = CurrentIndex::id;
-    using ContraIdxValues = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
-    using InsertTypeSeq = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContraIdxValues>>;
+    using ContravariantVectorIndexSet
+            = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
+    using InsertTypeSeq
+            = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContravariantVectorIndexSet>>;
 
     using type = std::conditional_t<
             CountChar<current_char, IdsFound>::value == 1,

--- a/src/data_types/tensor_index_tools.hpp
+++ b/src/data_types/tensor_index_tools.hpp
@@ -263,51 +263,34 @@ struct GetNonRepeatedIndices<
             ddc::detail::TypeSeq<OutIndices...>>;
 };
 
+template <char ID, class TypeSeqVectorIndexIdMap, class ResultTypeSeq = ddc::detail::TypeSeq<>>
+struct GetRelevantVectorIndexSets;
+
 template <
-        class TypeSeqVectorIndexIdMap,
-        std::size_t Elem,
-        class IdsFound,
-        class ResultTuple = ddc::detail::TypeSeq<>>
-struct GetRepeatedIndices;
-
-template <class TypeSeqVectorIndexIdMap, std::size_t Elem, class IdsFound, class ResultTypeSeq>
-struct GetRepeatedIndices
+        char ID,
+        class HeadVectorIndexIdMap,
+        class... TailVectorIndexIdMap,
+        class... OutVectorIndexSets>
+struct GetRelevantVectorIndexSets<
+        ID,
+        ddc::detail::TypeSeq<HeadVectorIndexIdMap, TailVectorIndexIdMap...>,
+        ddc::detail::TypeSeq<OutVectorIndexSets...>>
 {
-    using CurrentIndex = ddc::type_seq_element_t<
-            ddc::type_seq_size_v<TypeSeqVectorIndexIdMap> - 1 - Elem,
-            TypeSeqVectorIndexIdMap>;
-    static constexpr char current_char = CurrentIndex::id;
-    using ContravariantVectorIndexSet
-            = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
-    using InsertTypeSeq
-            = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContravariantVectorIndexSet>>;
-
-    using type = typename GetRepeatedIndices<
-            TypeSeqVectorIndexIdMap,
-            Elem - 1,
-            IdsFound,
+    using type = typename GetRelevantVectorIndexSets<
+            ID,
+            ddc::detail::TypeSeq<TailVectorIndexIdMap...>,
             std::conditional_t<
-                    CountChar<current_char, IdsFound>::value == 1,
-                    ResultTypeSeq,
-                    ddc::type_seq_merge_t<ResultTypeSeq, InsertTypeSeq>>>::type;
+                    HeadVectorIndexIdMap::id == ID,
+                    ddc::detail::TypeSeq<
+                            typename HeadVectorIndexIdMap::possible_idx_values,
+                            OutVectorIndexSets...>,
+                    ddc::detail::TypeSeq<OutVectorIndexSets...>>>::type;
 };
 
-template <class TypeSeqVectorIndexIdMap, class IdsFound, class ResultTypeSeq>
-struct GetRepeatedIndices<TypeSeqVectorIndexIdMap, 0, IdsFound, ResultTypeSeq>
+template <char ID, class ResultTypeSeq>
+struct GetRelevantVectorIndexSets<ID, ddc::detail::TypeSeq<>, ResultTypeSeq>
 {
-    using CurrentIndex = ddc::type_seq_element_t<
-            ddc::type_seq_size_v<TypeSeqVectorIndexIdMap> - 1,
-            TypeSeqVectorIndexIdMap>;
-    static constexpr char current_char = CurrentIndex::id;
-    using ContravariantVectorIndexSet
-            = get_contravariant_dims_t<typename CurrentIndex::possible_idx_values>;
-    using InsertTypeSeq
-            = ddc::detail::TypeSeq<VectorIndexIdMap<current_char, ContravariantVectorIndexSet>>;
-
-    using type = std::conditional_t<
-            CountChar<current_char, IdsFound>::value == 1,
-            ResultTypeSeq,
-            ddc::type_seq_merge_t<ResultTypeSeq, InsertTypeSeq>>;
+    using type = ResultTypeSeq;
 };
 
 } // namespace details
@@ -344,16 +327,14 @@ using non_repeated_indices_t = typename details::GetNonRepeatedIndices<
         index_identifiers_t<TypeSeqVectorIndexIdMap>>::type;
 
 /**
- * @brief Extract the VectorIndexIdMaps whose character id appears more than once in a TypeSeq of
- * VectorIndexIdMaps. The output only contains contravariant VectorIndexSets.
+ * @brief Extract all VectorIndexSets which are described by the same character identifier.
+ * @tparam ID The character identifying the VectorIndexSets we are searching for.
  * @tparam TypeSeqVectorIndexIdMap A TypeSeq containing a VectorIndexIdMap for each dimension
  *              of the tensor.
  */
-template <class TypeSeqVectorIndexIdMap>
-using repeated_indices_t = typename details::GetRepeatedIndices<
-        TypeSeqVectorIndexIdMap,
-        ddc::type_seq_size_v<TypeSeqVectorIndexIdMap> - 1,
-        index_identifiers_t<TypeSeqVectorIndexIdMap>>::type;
+template <char ID, class TypeSeqVectorIndexIdMap>
+using relevant_vector_index_sets_t =
+        typename details::GetRelevantVectorIndexSets<ID, TypeSeqVectorIndexIdMap>::type;
 
 //-------------------------------------------------------------------------------------------
 

--- a/tests/data_types/CMakeLists.txt
+++ b/tests/data_types/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(unit_tests_data_types
 )
 
 gtest_discover_tests(unit_tests_data_types DISCOVERY_MODE PRE_TEST)
+
+add_subdirectory(static_assert_tests)

--- a/tests/data_types/geometry_tensor.hpp
+++ b/tests/data_types/geometry_tensor.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+namespace {
+
+struct R_cov;
+struct Theta_cov;
+
+struct R
+{
+    static bool constexpr IS_COVARIANT = false;
+    static bool constexpr IS_CONTRAVARIANT = true;
+    using Dual = R_cov;
+};
+struct Theta
+{
+    static bool constexpr IS_COVARIANT = false;
+    static bool constexpr IS_CONTRAVARIANT = true;
+    using Dual = Theta_cov;
+};
+
+struct R_cov
+{
+    static bool constexpr IS_COVARIANT = true;
+    static bool constexpr IS_CONTRAVARIANT = false;
+    using Dual = R;
+};
+struct Theta_cov
+{
+    static bool constexpr IS_COVARIANT = true;
+    static bool constexpr IS_CONTRAVARIANT = false;
+    using Dual = Theta;
+};
+
+struct X
+{
+    static bool constexpr IS_COVARIANT = true;
+    static bool constexpr IS_CONTRAVARIANT = true;
+    using Dual = X;
+};
+struct Y
+{
+    static bool constexpr IS_COVARIANT = true;
+    static bool constexpr IS_CONTRAVARIANT = true;
+    using Dual = Y;
+};
+
+} // namespace
+

--- a/tests/data_types/geometry_tensor.hpp
+++ b/tests/data_types/geometry_tensor.hpp
@@ -46,4 +46,3 @@ struct Y
 };
 
 } // namespace
-

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -28,6 +28,8 @@ set_tests_properties(${file} PROPERTIES
     PASS_REGULAR_EXPRESSION ${error_msg}
 )
 
+set_property(TEST ${file} PROPERTY TIMEOUT 20)
+
 endfunction()
 
 add_static_assert_test(tensor_mul_cov_cov "Repeated indices should not be associated with two covariant or two contravariant indices.")

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -3,12 +3,9 @@ function(add_static_assert_test file error_msg)
 
 add_executable(${file}-build-fail-test
     ${file}.cpp
-    ../../main.cpp
 )
 target_link_libraries(${file}-build-fail-test
         PUBLIC
-        GTest::gmock
-
         gslx::data_types
         gslx::utils
 )

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -31,8 +31,8 @@ set_tests_properties(${file} PROPERTIES
 
 endfunction()
 
-add_static_assert_test(tensor_mul_cov_cov "Additionally repeated indices should not be associated with two covariant or two contravariant indices.")
-add_static_assert_test(tensor_mul_contra_contra "Additionally repeated indices should not be associated with two covariant or two contravariant indices.")
+add_static_assert_test(tensor_mul_cov_cov "Repeated indices should not be associated with two covariant or two contravariant indices.")
+add_static_assert_test(tensor_mul_contra_contra "Repeated indices should not be associated with two covariant or two contravariant indices.")
 add_static_assert_test(tensor_mul_incompatible_index_set "Cannot sum over incompatible VectorIndexSets.")
 add_static_assert_test(tensor_mul_3_indices "You should not have more than two of any one index in an index expression.")
 add_static_assert_test(tensor_mul_multiple_types "All tensors in a tensor_mul must have the same element type.")

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+
+function(add_static_assert_test file error_msg)
+
+add_executable(${file}-build-fail-test
+    ${file}.cpp
+    ../../main.cpp
+)
+target_link_libraries(${file}-build-fail-test
+        PUBLIC
+        GTest::gtest
+        GTest::gmock
+
+        gslx::data_types
+        gslx::utils
+)
+
+set_target_properties(${file}-build-fail-test PROPERTIES
+    EXCLUDE_FROM_ALL TRUE
+    EXCLUDE_FROM_DEFAULT_BUILD TRUE
+)
+
+add_test(
+    NAME ${file}
+    COMMAND ${CMAKE_COMMAND} --build . --target ${file}-build-fail-test --config $<CONFIG>
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR} # the place where we would run ctest
+)
+
+set_tests_properties(${file} PROPERTIES
+    PASS_REGULAR_EXPRESSION ${error_msg}
+)
+
+endfunction()
+
+add_static_assert_test(tensor_mul_cov_cov "Additionally repeated indices should not be associated with two covariant or two contravariant indices.")
+add_static_assert_test(tensor_mul_contra_contra "Additionally repeated indices should not be associated with two covariant or two contravariant indices.")
+add_static_assert_test(tensor_mul_incompatible_index_set "Cannot sum over incompatible VectorIndexSets.")
+add_static_assert_test(tensor_mul_3_indices "You should not have more than two of any one index in an index expression.")
+add_static_assert_test(tensor_mul_multiple_types "All tensors in a tensor_mul must have the same element type.")
+
+

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(${file}-build-fail-test
 )
 target_link_libraries(${file}-build-fail-test
         PUBLIC
-        GTest::gtest
         GTest::gmock
 
         gslx::data_types

--- a/tests/data_types/static_assert_tests/CMakeLists.txt
+++ b/tests/data_types/static_assert_tests/CMakeLists.txt
@@ -36,5 +36,6 @@ add_static_assert_test(tensor_mul_contra_contra "Additionally repeated indices s
 add_static_assert_test(tensor_mul_incompatible_index_set "Cannot sum over incompatible VectorIndexSets.")
 add_static_assert_test(tensor_mul_3_indices "You should not have more than two of any one index in an index expression.")
 add_static_assert_test(tensor_mul_multiple_types "All tensors in a tensor_mul must have the same element type.")
+add_static_assert_test(tensor_mul_wrong_index "Index is not compatible with tensor type")
 
 

--- a/tests/data_types/static_assert_tests/tensor_mul_3_indices.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_3_indices.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,21 +8,11 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Mul)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+using Tensor2D_B = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+Tensor2D_C compile_tensor_test_mul(Tensor2D_A const& A, Tensor2D_B const& B)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
-    using Tensor2D_B
-            = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
-    Tensor2D_B B;
-    ddcHelper::get<R, R>(A) = 1;
-    ddcHelper::get<R, Theta>(A) = 0;
-    ddcHelper::get<Theta, R>(A) = 2;
-    ddcHelper::get<Theta, Theta>(A) = 4;
-    ddcHelper::get<R, R_cov>(B) = 6;
-    ddcHelper::get<R, Theta_cov>(B) = 8;
-    ddcHelper::get<Theta, R_cov>(B) = 4;
-    ddcHelper::get<Theta, Theta_cov>(B) = 5;
-    Tensor2D_C C = tensor_mul(index<'j', 'j'>(A), index<'j', 'k'>(B));
+    return tensor_mul(index<'j', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_3_indices.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_3_indices.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "../geometry_tensor.hpp"
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+
+TEST(TensorTest, Mul)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+    using Tensor2D_B
+            = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<R, R>(A) = 1;
+    ddcHelper::get<R, Theta>(A) = 0;
+    ddcHelper::get<Theta, R>(A) = 2;
+    ddcHelper::get<Theta, Theta>(A) = 4;
+    ddcHelper::get<R, R_cov>(B) = 6;
+    ddcHelper::get<R, Theta_cov>(B) = 8;
+    ddcHelper::get<Theta, R_cov>(B) = 4;
+    ddcHelper::get<Theta, Theta_cov>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'j', 'j'>(A), index<'j', 'k'>(B));
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
@@ -3,17 +3,17 @@
 
 #include <gtest/gtest.h>
 
+#include "../geometry_tensor.hpp"
+
 #include "indexed_tensor.hpp"
 #include "tensor.hpp"
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
-#include "../geometry_tensor.hpp"
 
 TEST(TensorTest, Mul)
 {
     using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
-    using Tensor2D_B
-            = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_B = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
     using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
     Tensor2D_A A;
     Tensor2D_B B;

--- a/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+#include "../geometry_tensor.hpp"
+
+TEST(TensorTest, Mul)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+    using Tensor2D_B
+            = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<R, R>(A) = 1;
+    ddcHelper::get<R, Theta>(A) = 0;
+    ddcHelper::get<Theta, R>(A) = 2;
+    ddcHelper::get<Theta, Theta>(A) = 4;
+    ddcHelper::get<R, R_cov>(B) = 6;
+    ddcHelper::get<R, Theta_cov>(B) = 8;
+    ddcHelper::get<Theta, R_cov>(B) = 4;
+    ddcHelper::get<Theta, Theta_cov>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_contra_contra.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,20 +8,11 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Mul)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+using Tensor2D_B = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+Tensor2D_C compile_tensor_test_mul(Tensor2D_A const& A, Tensor2D_B const& B)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
-    using Tensor2D_B = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
-    Tensor2D_B B;
-    ddcHelper::get<R, R>(A) = 1;
-    ddcHelper::get<R, Theta>(A) = 0;
-    ddcHelper::get<Theta, R>(A) = 2;
-    ddcHelper::get<Theta, Theta>(A) = 4;
-    ddcHelper::get<R, R_cov>(B) = 6;
-    ddcHelper::get<R, Theta_cov>(B) = 8;
-    ddcHelper::get<Theta, R_cov>(B) = 4;
-    ddcHelper::get<Theta, Theta_cov>(B) = 5;
-    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+    return tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+#include "../geometry_tensor.hpp"
+
+TEST(TensorTest, Mul)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_B
+            = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<R, R>(A) = 1;
+    ddcHelper::get<R, Theta>(A) = 0;
+    ddcHelper::get<Theta, R>(A) = 2;
+    ddcHelper::get<Theta, Theta>(A) = 4;
+    ddcHelper::get<R, R_cov>(B) = 6;
+    ddcHelper::get<R, Theta_cov>(B) = 8;
+    ddcHelper::get<Theta, R_cov>(B) = 4;
+    ddcHelper::get<Theta, Theta_cov>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
@@ -3,11 +3,12 @@
 
 #include <gtest/gtest.h>
 
+#include "../geometry_tensor.hpp"
+
 #include "indexed_tensor.hpp"
 #include "tensor.hpp"
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
-#include "../geometry_tensor.hpp"
 
 TEST(TensorTest, Mul)
 {

--- a/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
@@ -18,13 +18,13 @@ TEST(TensorTest, Mul)
     using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
     Tensor2D_A A;
     Tensor2D_B B;
-    ddcHelper::get<R, R>(A) = 1;
-    ddcHelper::get<R, Theta>(A) = 0;
-    ddcHelper::get<Theta, R>(A) = 2;
-    ddcHelper::get<Theta, Theta>(A) = 4;
-    ddcHelper::get<R, R_cov>(B) = 6;
-    ddcHelper::get<R, Theta_cov>(B) = 8;
-    ddcHelper::get<Theta, R_cov>(B) = 4;
-    ddcHelper::get<Theta, Theta_cov>(B) = 5;
+    ddcHelper::get<R, R_cov>(A) = 1;
+    ddcHelper::get<R, Theta_cov>(A) = 0;
+    ddcHelper::get<Theta, R_cov>(A) = 2;
+    ddcHelper::get<Theta, Theta_cov>(A) = 4;
+    ddcHelper::get<R_cov, R_cov>(B) = 6;
+    ddcHelper::get<R_cov, Theta_cov>(B) = 8;
+    ddcHelper::get<Theta_cov, R_cov>(B) = 4;
+    ddcHelper::get<Theta_cov, Theta_cov>(B) = 5;
     Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_cov_cov.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,21 +8,11 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Mul)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_B = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+Tensor2D_C compile_tensor_test_mul(Tensor2D_A const& A, Tensor2D_B const& B)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_B
-            = Tensor<int, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
-    Tensor2D_B B;
-    ddcHelper::get<R, R_cov>(A) = 1;
-    ddcHelper::get<R, Theta_cov>(A) = 0;
-    ddcHelper::get<Theta, R_cov>(A) = 2;
-    ddcHelper::get<Theta, Theta_cov>(A) = 4;
-    ddcHelper::get<R_cov, R_cov>(B) = 6;
-    ddcHelper::get<R_cov, Theta_cov>(B) = 8;
-    ddcHelper::get<Theta_cov, R_cov>(B) = 4;
-    ddcHelper::get<Theta_cov, Theta_cov>(B) = 5;
-    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+    return tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_incompatible_index_set.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_incompatible_index_set.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,20 +8,11 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Mul)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_B = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+Tensor2D_C compile_tensor_test_mul(Tensor2D_A const& A, Tensor2D_B const& B)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_B = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
-    Tensor2D_B B;
-    ddcHelper::get<R, R>(A) = 1;
-    ddcHelper::get<R, Theta>(A) = 0;
-    ddcHelper::get<Theta, R>(A) = 2;
-    ddcHelper::get<Theta, Theta>(A) = 4;
-    ddcHelper::get<X, R_cov>(B) = 6;
-    ddcHelper::get<X, Theta_cov>(B) = 8;
-    ddcHelper::get<Y, R_cov>(B) = 4;
-    ddcHelper::get<Y, Theta_cov>(B) = 5;
-    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+    return tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_incompatible_index_set.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_incompatible_index_set.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "../geometry_tensor.hpp"
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+
+TEST(TensorTest, Mul)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_B = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<R, R>(A) = 1;
+    ddcHelper::get<R, Theta>(A) = 0;
+    ddcHelper::get<Theta, R>(A) = 2;
+    ddcHelper::get<Theta, Theta>(A) = 4;
+    ddcHelper::get<X, R_cov>(B) = 6;
+    ddcHelper::get<X, Theta_cov>(B) = 8;
+    ddcHelper::get<Y, R_cov>(B) = 4;
+    ddcHelper::get<Y, Theta_cov>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_multiple_types.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_multiple_types.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "../geometry_tensor.hpp"
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+
+TEST(TensorTest, Mul)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+    using Tensor2D_B
+            = Tensor<float, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<R, R>(A) = 1;
+    ddcHelper::get<R, Theta>(A) = 0;
+    ddcHelper::get<Theta, R>(A) = 2;
+    ddcHelper::get<Theta, Theta>(A) = 4;
+    ddcHelper::get<R, R_cov>(B) = 6;
+    ddcHelper::get<R, Theta_cov>(B) = 8;
+    ddcHelper::get<Theta, R_cov>(B) = 4;
+    ddcHelper::get<Theta, Theta_cov>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_multiple_types.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_multiple_types.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,21 +8,12 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Mul)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
+using Tensor2D_B
+        = Tensor<float, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
+using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+Tensor2D_C compile_tensor_test_mul(Tensor2D_A const& A, Tensor2D_B const& B)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>>;
-    using Tensor2D_B
-            = Tensor<float, VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>>;
-    using Tensor2D_C = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
-    Tensor2D_B B;
-    ddcHelper::get<R, R>(A) = 1;
-    ddcHelper::get<R, Theta>(A) = 0;
-    ddcHelper::get<Theta, R>(A) = 2;
-    ddcHelper::get<Theta, Theta>(A) = 4;
-    ddcHelper::get<R, R_cov>(B) = 6;
-    ddcHelper::get<R, Theta_cov>(B) = 8;
-    ddcHelper::get<Theta, R_cov>(B) = 4;
-    ddcHelper::get<Theta, Theta_cov>(B) = 5;
-    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+    return tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
 }

--- a/tests/data_types/static_assert_tests/tensor_mul_wrong_index.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_wrong_index.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "../geometry_tensor.hpp"
+
+#include "indexed_tensor.hpp"
+#include "tensor.hpp"
+#include "tensor_index_tools.hpp"
+#include "vector_index_tools.hpp"
+
+TEST(TensorTest, Index)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+    Tensor2D_A A;
+    ddcHelper::get<R, X>(A) = 1;
+    ddcHelper::get<R, Y>(A) = 0;
+    ddcHelper::get<Theta, X>(A) = 2;
+    ddcHelper::get<Theta, Y>(A) = 4;
+}

--- a/tests/data_types/static_assert_tests/tensor_mul_wrong_index.cpp
+++ b/tests/data_types/static_assert_tests/tensor_mul_wrong_index.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
-#include <gtest/gtest.h>
-
 #include "../geometry_tensor.hpp"
 
 #include "indexed_tensor.hpp"
@@ -10,10 +8,10 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-TEST(TensorTest, Index)
+using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
+
+void compile_tensor_test_fill(Tensor2D_A& A)
 {
-    using Tensor2D_A = Tensor<int, VectorIndexSet<R, Theta>, VectorIndexSet<R_cov, Theta_cov>>;
-    Tensor2D_A A;
     ddcHelper::get<R, X>(A) = 1;
     ddcHelper::get<R, Y>(A) = 0;
     ddcHelper::get<Theta, X>(A) = 2;

--- a/tests/data_types/tensor.cpp
+++ b/tests/data_types/tensor.cpp
@@ -357,3 +357,40 @@ TEST(TensorTest, MulConst)
     val = ddcHelper::get<Theta, Theta_cov>(C);
     EXPECT_EQ(val, 36);
 }
+
+TEST(TensorTest, MulOrthonormal)
+{
+    using Tensor2D_A = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<X, Y>>;
+    using Tensor2D_B = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<X, Y>>;
+    using Tensor2D_C = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<X, Y>>;
+    Tensor2D_A A;
+    Tensor2D_B B;
+    ddcHelper::get<X, X>(A) = 1;
+    ddcHelper::get<X, Y>(A) = 0;
+    ddcHelper::get<Y, X>(A) = 2;
+    ddcHelper::get<Y, Y>(A) = 4;
+    ddcHelper::get<X, X>(B) = 6;
+    ddcHelper::get<X, Y>(B) = 8;
+    ddcHelper::get<Y, X>(B) = 4;
+    ddcHelper::get<Y, Y>(B) = 5;
+    Tensor2D_C C = tensor_mul(index<'i', 'j'>(A), index<'j', 'k'>(B));
+    int val = ddcHelper::get<X, X>(C);
+    EXPECT_EQ(val, 6);
+    val = ddcHelper::get<X, Y>(C);
+    EXPECT_EQ(val, 8);
+    val = ddcHelper::get<Y, X>(C);
+    EXPECT_EQ(val, 28);
+    val = ddcHelper::get<Y, Y>(C);
+    EXPECT_EQ(val, 36);
+    Tensor2D_C D = tensor_mul(index<'i', 'j'>(A), index<'k', 'j'>(B));
+    val = ddcHelper::get<X, X>(D);
+    EXPECT_EQ(val, 6);
+    val = ddcHelper::get<X, Y>(D);
+    EXPECT_EQ(val, 4);
+    val = ddcHelper::get<Y, X>(D);
+    EXPECT_EQ(val, 44);
+    val = ddcHelper::get<Y, Y>(D);
+    EXPECT_EQ(val, 28);
+    int E = tensor_mul(index<'i', 'j'>(A), index<'j', 'i'>(B));
+    EXPECT_EQ(E, 42);
+}

--- a/tests/data_types/tensor.cpp
+++ b/tests/data_types/tensor.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include "geometry_tensor.hpp"
 #include "indexed_tensor.hpp"
 #include "tensor.hpp"
 #include "tensor_index_tools.hpp"
@@ -10,43 +11,12 @@
 
 using namespace tensor_tools;
 
-namespace {
-struct R_cov;
-struct Theta_cov;
-
-struct R
-{
-    static bool constexpr IS_COVARIANT = false;
-    static bool constexpr IS_CONTRAVARIANT = true;
-    using Dual = R_cov;
-};
-struct Theta
-{
-    static bool constexpr IS_COVARIANT = false;
-    static bool constexpr IS_CONTRAVARIANT = true;
-    using Dual = Theta_cov;
-};
-
-struct R_cov
-{
-    static bool constexpr IS_COVARIANT = true;
-    static bool constexpr IS_CONTRAVARIANT = false;
-    using Dual = R;
-};
-struct Theta_cov
-{
-    static bool constexpr IS_COVARIANT = true;
-    static bool constexpr IS_CONTRAVARIANT = false;
-    using Dual = Theta;
-};
 
 int dot_product(Vector<int, R_cov, Theta_cov> a, Vector<int, R, Theta> b)
 {
     return ddcHelper::get<R_cov>(a) * ddcHelper::get<R>(b)
            + ddcHelper::get<Theta_cov>(a) * ddcHelper::get<Theta>(b);
 }
-
-} // namespace
 
 TEST(TensorTest, ExplicitDotProduct)
 {


### PR DESCRIPTION
Improve `tensor_mul` static assertions. Add the missing static assert to verify if the `VectorIndexSet`s that are indicated with the same character id are compatible. Fixes #172.
Add tests to ensure static assertions are correctly raised