### PR TITLE
Express metric tensor on correct basis

### DIFF
--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -469,14 +469,14 @@ private:
         });
 
         // > computation of the phi derivatives
-        host_t<DVectorFieldMemRTheta<R, Theta>> deriv_phi(grid_without_Opoint);
+        host_t<DVectorFieldMemRTheta<R_cov, Theta_cov>> deriv_phi(grid_without_Opoint);
 
         evaluator.deriv_dim_1(
-                ddcHelper::get<R>(deriv_phi),
+                ddcHelper::get<R_cov>(deriv_phi),
                 get_const_field(coords),
                 get_const_field(electrostatic_potential_coef));
         evaluator.deriv_dim_2(
-                ddcHelper::get<Theta>(deriv_phi),
+                ddcHelper::get<Theta_cov>(deriv_phi),
                 get_const_field(coords),
                 get_const_field(electrostatic_potential_coef));
 

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -483,16 +483,16 @@ private:
         ddc::for_each(grid_without_Opoint, [&](IdxRTheta const irtheta) {
             CoordRTheta const coord_rtheta(ddc::coordinate(irtheta));
 
-            DTensor<VectorIndexSet<R_cov, Theta_cov>, VectorIndexSet<R_cov, Theta_cov>> inv_G
+            DTensor<VectorIndexSet<R, Theta>, VectorIndexSet<R, Theta>> inv_G
                     = metric_tensor.inverse(coord_rtheta);
 
             // E = -grad phi
             double const electric_field_r
-                    = -deriv_r_phi(irtheta) * ddcHelper::get<R_cov, R_cov>(inv_G)
-                      - deriv_theta_phi(irtheta) * ddcHelper::get<R_cov, Theta_cov>(inv_G);
+                    = -deriv_r_phi(irtheta) * ddcHelper::get<R, R>(inv_G)
+                      - deriv_theta_phi(irtheta) * ddcHelper::get<R, Theta>(inv_G);
             double const electric_field_theta
-                    = -deriv_r_phi(irtheta) * ddcHelper::get<Theta_cov, R_cov>(inv_G)
-                      - deriv_theta_phi(irtheta) * ddcHelper::get<Theta_cov, Theta_cov>(inv_G);
+                    = -deriv_r_phi(irtheta) * ddcHelper::get<Theta, R>(inv_G)
+                      - deriv_theta_phi(irtheta) * ddcHelper::get<Theta, Theta>(inv_G);
 
             // A = E \wedge e_z
             ddcHelper::get<R_cov>(advection_field_rtheta)(irtheta) = -electric_field_theta;

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -57,17 +57,17 @@ public:
      * @return metric_tensor
      * 				A DTensor object containing the value of the metric tensor.
      */
-    KOKKOS_FUNCTION DTensor<Dims, Dims> operator()(PositionCoordinate const& coord) const
+    KOKKOS_FUNCTION DTensor<Dims_cov, Dims_cov> operator()(PositionCoordinate const& coord) const
     {
         const double J_11 = m_mapping.jacobian_11(coord);
         const double J_12 = m_mapping.jacobian_12(coord);
         const double J_21 = m_mapping.jacobian_21(coord);
         const double J_22 = m_mapping.jacobian_22(coord);
-        DTensor<Dims, Dims> metric_tensor;
-        ddcHelper::get<Dim0, Dim0>(metric_tensor) = (J_11 * J_11 + J_21 * J_21);
-        ddcHelper::get<Dim0, Dim1>(metric_tensor) = (J_11 * J_12 + J_21 * J_22);
-        ddcHelper::get<Dim1, Dim0>(metric_tensor) = (J_11 * J_12 + J_21 * J_22);
-        ddcHelper::get<Dim1, Dim1>(metric_tensor) = (J_12 * J_12 + J_22 * J_22);
+        DTensor<Dims_cov, Dims_cov> metric_tensor;
+        ddcHelper::get<Dim0_cov, Dim0_cov>(metric_tensor) = (J_11 * J_11 + J_21 * J_21);
+        ddcHelper::get<Dim0_cov, Dim1_cov>(metric_tensor) = (J_11 * J_12 + J_21 * J_22);
+        ddcHelper::get<Dim1_cov, Dim0_cov>(metric_tensor) = (J_11 * J_12 + J_21 * J_22);
+        ddcHelper::get<Dim1_cov, Dim1_cov>(metric_tensor) = (J_12 * J_12 + J_22 * J_22);
 
         return metric_tensor;
     }
@@ -80,7 +80,7 @@ public:
      * @return inverse_metric_tensor
      * 				A DTensor object containing the value of the inverse of the metric tensor.
      */
-    KOKKOS_FUNCTION DTensor<Dims_cov, Dims_cov> inverse(PositionCoordinate const& coord) const
+    KOKKOS_FUNCTION DTensor<Dims, Dims> inverse(PositionCoordinate const& coord) const
     {
         const double J_11 = m_mapping.jacobian_11(coord);
         const double J_12 = m_mapping.jacobian_12(coord);
@@ -88,14 +88,14 @@ public:
         const double J_22 = m_mapping.jacobian_22(coord);
         const double jacob_2 = m_mapping.jacobian(coord) * m_mapping.jacobian(coord);
 
-        DTensor<Dims_cov, Dims_cov> inverse_metric_tensor;
-        ddcHelper::get<Dim0_cov, Dim0_cov>(inverse_metric_tensor)
+        DTensor<Dims, Dims> inverse_metric_tensor;
+        ddcHelper::get<Dim0, Dim0>(inverse_metric_tensor)
                 = (J_12 * J_12 + J_22 * J_22) / jacob_2;
-        ddcHelper::get<Dim0_cov, Dim1_cov>(inverse_metric_tensor)
+        ddcHelper::get<Dim0, Dim1>(inverse_metric_tensor)
                 = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
-        ddcHelper::get<Dim1_cov, Dim0_cov>(inverse_metric_tensor)
+        ddcHelper::get<Dim1, Dim0>(inverse_metric_tensor)
                 = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
-        ddcHelper::get<Dim1_cov, Dim1_cov>(inverse_metric_tensor)
+        ddcHelper::get<Dim1, Dim1>(inverse_metric_tensor)
                 = (J_11 * J_11 + J_21 * J_21) / jacob_2;
 
         return inverse_metric_tensor;

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -89,14 +89,10 @@ public:
         const double jacob_2 = m_mapping.jacobian(coord) * m_mapping.jacobian(coord);
 
         DTensor<Dims, Dims> inverse_metric_tensor;
-        ddcHelper::get<Dim0, Dim0>(inverse_metric_tensor)
-                = (J_12 * J_12 + J_22 * J_22) / jacob_2;
-        ddcHelper::get<Dim0, Dim1>(inverse_metric_tensor)
-                = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
-        ddcHelper::get<Dim1, Dim0>(inverse_metric_tensor)
-                = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
-        ddcHelper::get<Dim1, Dim1>(inverse_metric_tensor)
-                = (J_11 * J_11 + J_21 * J_21) / jacob_2;
+        ddcHelper::get<Dim0, Dim0>(inverse_metric_tensor) = (J_12 * J_12 + J_22 * J_22) / jacob_2;
+        ddcHelper::get<Dim0, Dim1>(inverse_metric_tensor) = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
+        ddcHelper::get<Dim1, Dim0>(inverse_metric_tensor) = (-J_11 * J_12 - J_21 * J_22) / jacob_2;
+        ddcHelper::get<Dim1, Dim1>(inverse_metric_tensor) = (J_11 * J_11 + J_21 * J_21) / jacob_2;
 
         return inverse_metric_tensor;
     }

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -187,7 +187,7 @@ public:
     struct EvalDeriv2DType
     {
         double value;
-        DVector<R, Theta> derivative;
+        DVector<R_cov, Theta_cov> derivative;
     };
 
     /**
@@ -403,14 +403,14 @@ public:
             // Calculate the radial derivative
             ddc::discrete_space<PolarBSplinesRTheta>().eval_deriv_r(singular_vals, vals, coord);
             for (IdxBSPolar ib : idxrange_singular) {
-                ddcHelper::get<R>(m_singular_basis_vals_and_derivs(ib, idx_r, idx_theta).derivative)
+                ddcHelper::get<R_cov>(m_singular_basis_vals_and_derivs(ib, idx_r, idx_theta).derivative)
                         = singular_vals[ib - idxrange_singular.front()];
             }
 
             // Calculate the poloidal derivative
             ddc::discrete_space<PolarBSplinesRTheta>().eval_deriv_theta(singular_vals, vals, coord);
             for (IdxBSPolar ib : idxrange_singular) {
-                ddcHelper::get<Theta>(
+                ddcHelper::get<Theta_cov>(
                         m_singular_basis_vals_and_derivs(ib, idx_r, idx_theta).derivative)
                         = singular_vals[ib - idxrange_singular.front()];
             }
@@ -1199,13 +1199,13 @@ public:
      */
     static KOKKOS_INLINE_FUNCTION void get_value_and_gradient(
             double& value,
-            DVector<R, Theta>& derivs,
+            DVector<R_cov, Theta_cov>& derivs,
             EvalDeriv1DType const& r_basis,
             EvalDeriv1DType const& theta_basis)
     {
         value = r_basis.value * theta_basis.value;
-        ddcHelper::get<R>(derivs) = r_basis.derivative * theta_basis.value;
-        ddcHelper::get<Theta>(derivs) = r_basis.value * theta_basis.derivative;
+        ddcHelper::get<R_cov>(derivs) = r_basis.derivative * theta_basis.value;
+        ddcHelper::get<Theta_cov>(derivs) = r_basis.value * theta_basis.derivative;
     }
 
     /**
@@ -1220,7 +1220,7 @@ public:
      */
     static KOKKOS_INLINE_FUNCTION void get_value_and_gradient(
             double& value,
-            DVector<R, Theta>& derivs,
+            DVector<R_cov, Theta_cov>& derivs,
             EvalDeriv2DType const& basis,
             EvalDeriv2DType const&) // Last argument is duplicate
     {
@@ -1293,8 +1293,8 @@ public:
         // Define the value and gradient of the test and trial basis functions
         double basis_val_test_space;
         double basis_val_trial_space;
-        DVector<R, Theta> basis_derivs_test_space;
-        DVector<R, Theta> basis_derivs_trial_space;
+        DVector<R_cov, Theta_cov> basis_derivs_test_space;
+        DVector<R_cov, Theta_cov> basis_derivs_trial_space;
         get_value_and_gradient(
                 basis_val_test_space,
                 basis_derivs_test_space,

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -403,7 +403,8 @@ public:
             // Calculate the radial derivative
             ddc::discrete_space<PolarBSplinesRTheta>().eval_deriv_r(singular_vals, vals, coord);
             for (IdxBSPolar ib : idxrange_singular) {
-                ddcHelper::get<R_cov>(m_singular_basis_vals_and_derivs(ib, idx_r, idx_theta).derivative)
+                ddcHelper::get<R_cov>(
+                        m_singular_basis_vals_and_derivs(ib, idx_r, idx_theta).derivative)
                         = singular_vals[ib - idxrange_singular.front()];
             }
 

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -246,7 +246,6 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     // > Compare the advection field computed on RTheta to the advection field computed on XY
     host_t<DVectorFieldMemRTheta<X, Y>> difference_between_fields_xy_and_rtheta(grid);
 
-    MetricTensorEvaluator<LogicalToPhysicalMapping, CoordRTheta> metric_tensor(to_physical_mapping);
     ddc::for_each(grid_without_Opoint, [&](IdxRTheta const irtheta) {
         CoordRTheta const coord_rtheta(ddc::coordinate(irtheta));
 


### PR DESCRIPTION
The metric tensor should be expressed on the covariant basis by default, and its inverse on the contravariant basis