### PR TITLE
Change input/output grid name for compatibility with netCDF

### DIFF
--- a/src/io/input.hpp
+++ b/src/io/input.hpp
@@ -96,7 +96,7 @@ inline IdxRange<Grid1D> init_spline_dependent_idx_range(
                     "read_" + mesh_identifier,
                     breakpoints_name,
                     breakpoints,
-                    grid_name,
+                    mesh_identifier,
                     mesh);
             ddc::init_discrete_space<BSplines>(breakpoints);
         }

--- a/src/io/input.hpp
+++ b/src/io/input.hpp
@@ -86,9 +86,9 @@ inline IdxRange<Grid1D> init_spline_dependent_idx_range(
         // if you want to ensure that the interpolation points used match exactly the points
         // used to initialise values passed into the simulation.
         std::vector<Coord1D> mesh;
-        std::string grid_name = "grid_" + mesh_identifier;
 
         if constexpr (BSplines::is_uniform()) {
+            std::string grid_name = "grid_" + mesh_identifier;
             PDI_get_arrays("read_" + mesh_identifier, grid_name, mesh);
         } else {
             std::string breakpoints_name = "breakpoints_" + mesh_identifier;


### PR DESCRIPTION
Change the reading of the grid to read and write tor1 instead of grid_tor1.