### PR TITLE
Add missing MPI error

### DIFF
--- a/simulations/geometryXYVxVy/landau/params.yaml.hpp
+++ b/simulations/geometryXYVxVy/landau/params.yaml.hpp
@@ -11,10 +11,10 @@ constexpr char const* const params_yaml = R"PDI_CFG(SplineMesh:
   y_ncells : 32
   vx_min: -6.0
   vx_max: +6.0
-  vx_ncells: 34
+  vx_ncells: 33
   vy_min: -6.0
   vy_max: +6.0
-  vy_ncells: 34
+  vy_ncells: 33
 
 SpeciesInfo:
 - charge: -1.

--- a/src/mpi_parallelisation/mpilayout.hpp
+++ b/src/mpi_parallelisation/mpilayout.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <numeric>
+#include <sstream>
 
 #include <ddc/ddc.hpp>
 
@@ -60,6 +61,14 @@ public:
             int comm_size,
             int rank)
     {
+        distributed_sub_idx_range distrib_idx_range(global_idx_range);
+        if (distrib_idx_range.size() % comm_size != 0) {
+            std::ostringstream error_msg;
+            error_msg << "The provided index range cannot be split equally over the specified "
+                         "number of MPI ranks ("
+                      << distrib_idx_range.extents() << " is not divisible by " << comm_size << ")";
+            throw std::runtime_error(error_msg.str());
+        }
         return internal_distribute_idx_range(global_idx_range, comm_size, rank);
     }
 


### PR DESCRIPTION
Add a missing MPI error to ensure that a clean error message is raised if the number of grid points is not compatible with the number of MPI ranks.