### PR TITLE
Port (r,theta) BSL advection to GPU

### DIFF
--- a/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
@@ -194,6 +194,7 @@ public:
 
         // (Ax, Ay) = J (Ar, Atheta)
         ddc::parallel_for_each(
+                Kokkos::DefaultExecutionSpace(),
                 grid_without_Opoint,
                 KOKKOS_LAMBDA(IdxRTheta const irtheta) {
                     CoordRTheta const coord_rtheta(ddc::coordinate(irtheta));
@@ -209,10 +210,15 @@ public:
                             = ddcHelper::get<Y>(advec_field_xy);
                 });
 
-        ddc::parallel_for_each(Opoint_grid, [&](IdxRTheta const irtheta) {
-            ddcHelper::get<X>(advection_field_xy)(irtheta) = CoordX(advection_field_xy_centre);
-            ddcHelper::get<Y>(advection_field_xy)(irtheta) = CoordY(advection_field_xy_centre);
-        });
+        ddc::parallel_for_each(
+                Kokkos::DefaultExecutionSpace(),
+                Opoint_grid,
+                KOKKOS_LAMBDA(IdxRTheta const irtheta) {
+                    ddcHelper::get<X>(advection_field_xy)(irtheta)
+                            = CoordX(advection_field_xy_centre);
+                    ddcHelper::get<Y>(advection_field_xy)(irtheta)
+                            = CoordY(advection_field_xy_centre);
+                });
 
         auto allfdistribu = ddc::
                 create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), allfdistribu_host);

--- a/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
@@ -190,13 +190,15 @@ public:
         DConstVectorFieldRTheta<R, Theta> advection_field_rtheta
                 = get_const_field(advection_field_rtheta_alloc);
 
+        Mapping const& mapping_proxy = m_mapping;
+
         // (Ax, Ay) = J (Ar, Atheta)
         ddc::parallel_for_each(
                 grid_without_Opoint,
                 KOKKOS_LAMBDA(IdxRTheta const irtheta) {
                     CoordRTheta const coord_rtheta(ddc::coordinate(irtheta));
 
-                    Tensor J = m_mapping.jacobian_matrix(coord_rtheta);
+                    Tensor J = mapping_proxy.jacobian_matrix(coord_rtheta);
 
                     DVector<X, Y> advec_field_xy = tensor_mul(
                             index<'i', 'j'>(J),

--- a/src/geometryRTheta/advection/iadvection_rtheta.hpp
+++ b/src/geometryRTheta/advection/iadvection_rtheta.hpp
@@ -48,9 +48,9 @@ public:
      *
      * @return A Field of the advected function (allfdistribu).
      */
-    virtual host_t<DFieldRTheta> operator()(
-            host_t<DFieldRTheta> allfdistribu,
-            host_t<DConstVectorFieldRTheta<R, Theta>> advection_field,
+    virtual DFieldRTheta operator()(
+            DFieldRTheta allfdistribu,
+            DConstVectorFieldRTheta<R, Theta> advection_field,
             CoordXY const& advection_field_xy_centre,
             double const dt) const = 0;
 };

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -297,13 +297,18 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     auto advection_field_xy_device = ddcHelper::
             create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_xy);
 
+    auto allfdistribu_rtheta_device = ddc::
+            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), allfdistribu_rtheta);
+    auto advection_field_rtheta_device = ddcHelper::
+            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_rtheta);
+
     // ================================================================================================
     // SIMULATION                                                                                     |
     // ================================================================================================
     for (int iter(0); iter < iter_nb; ++iter) {
         advection_operator(
-                allfdistribu_rtheta,
-                advection_field_rtheta,
+                get_field(allfdistribu_rtheta_device),
+                get_const_field(advection_field_rtheta_device),
                 advection_field_xy_centre,
                 dt);
         advection_operator(

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -317,6 +317,7 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
                 dt);
 
         ddc::parallel_deepcopy(allfdistribu_xy, get_const_field(allfdistribu_xy_device));
+        ddc::parallel_deepcopy(allfdistribu_rtheta, get_const_field(allfdistribu_rtheta_device));
 
         // Check the advected functions ---
         ddc::for_each(grid, [&](IdxRTheta const irtheta) {


### PR DESCRIPTION
Complete the porting of `BslAdvectionRTheta` to GPU by porting the remaining `operator()` which acts on fields defined in r, theta coordinates.