### PR TITLE
Update typos config file

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,9 +1,10 @@
 [default]
 locale = 'en-gb'
 extend-ignore-re = ["capitalize()",
-                    "MPI_\\S*",
-                    "PDI_\\S*",
-                    "ddc::\\S*",
+                    "MPI_[^(\\s]*",
+                    "PDI_[^(\\s]*",
+                    "CMAKE_\\S*",
+                    "ddc::[^(\\s]*",
                     "gko_exec->\\S*",
                     "on_finalize:",
                     "colors.Normalize",


### PR DESCRIPTION
Updates the regexp in the `.typos.toml` files. 

With this update, the `inititialization' identifier in `ddc::some_function(initialization)` gets counted as an error by the spell checker. 