### PR TITLE
Store advection field in Vector not Coordinate

### DIFF
--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     name: CPU PR result
     needs: [cpu_tests]
-    if: always() && ${{ inputs.pr_number }} != ""
+    if: always() && (${{ inputs.pr_number }} != "")
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/set_pr_status

--- a/.github/workflows/draft_flags.yml
+++ b/.github/workflows/draft_flags.yml
@@ -15,7 +15,7 @@ jobs:
           ref: main
       - run: |
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "Ready to review"
-          RUNNING_WORKFLOW_LINKS=$(gh pr checks ${{ github.event.pull_request.number }} --json state,link --jq '.[] | select(.state == "QUEUED" or .state == "IN_PROGRESS" or .state == "WATING") | .link')
+          RUNNING_WORKFLOW_LINKS=$(gh pr checks ${{ github.event.pull_request.number }} --json state,link --jq '.[] | select(.state == "QUEUED" or .state == "IN_PROGRESS" or .state == "WATING") | .link' | grep github)
           RUNNING_WORKFLOWS=$(echo "$RUNNING_WORKFLOW_LINKS" | awk -F'[/"]' '{print $(NF-2); }' | sort -u)
           for workflow_id in ${RUNNING_WORKFLOWS}
           do

--- a/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
@@ -159,8 +159,8 @@ public:
      *      on the logical index range axis.
      *      It is expressed on the contravariant basis.
      * @param [in] advection_field_xy_centre
-     *      A CoordXY containing the value of the advection field on the 
-     *      physical index range axis at the O-point. 
+     *      A vector in the Cartesian basis, containing the value of the advection
+     *      field at the O-point.
      * @param [in] dt
      *      A time step used.
      *

--- a/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
+++ b/src/geometryRTheta/advection/bsl_advection_rtheta.hpp
@@ -169,7 +169,7 @@ public:
     DFieldRTheta operator()(
             DFieldRTheta allfdistribu,
             DConstVectorFieldRTheta<R, Theta> advection_field_rtheta,
-            CoordXY const& advection_field_xy_centre,
+            DVector<X, Y> const& advection_field_xy_centre,
             double dt) const override
     {
         Kokkos::Profiling::pushRegion("PolarAdvection");
@@ -195,23 +195,22 @@ public:
 
                     Tensor J = mapping_proxy.jacobian_matrix(coord_rtheta);
 
-                    DVector<X, Y> advec_field_xy = tensor_mul(
-                            index<'i', 'j'>(J),
-                            index<'j'>(advection_field_rtheta(irtheta)));
-                    ddcHelper::get<X>(advection_field_xy)(irtheta)
-                            = ddcHelper::get<X>(advec_field_xy);
-                    ddcHelper::get<Y>(advection_field_xy)(irtheta)
-                            = ddcHelper::get<Y>(advec_field_xy);
+                    ddcHelper::assign_vector_field_element(
+                            advection_field_xy,
+                            irtheta,
+                            tensor_mul(
+                                    index<'i', 'j'>(J),
+                                    index<'j'>(advection_field_rtheta(irtheta))));
                 });
 
         ddc::parallel_for_each(
                 Kokkos::DefaultExecutionSpace(),
                 Opoint_grid,
                 KOKKOS_LAMBDA(IdxRTheta const irtheta) {
-                    ddcHelper::get<X>(advection_field_xy)(irtheta)
-                            = CoordX(advection_field_xy_centre);
-                    ddcHelper::get<Y>(advection_field_xy)(irtheta)
-                            = CoordY(advection_field_xy_centre);
+                    ddcHelper::assign_vector_field_element(
+                            advection_field_xy,
+                            irtheta,
+                            advection_field_xy_centre);
                 });
 
         (*this)(get_field(allfdistribu), get_const_field(advection_field_xy), dt);

--- a/src/geometryRTheta/advection/iadvection_rtheta.hpp
+++ b/src/geometryRTheta/advection/iadvection_rtheta.hpp
@@ -40,9 +40,9 @@ public:
      *      The function to be advected.
      * @param[in] advection_field
      *      The advection field on the contravariant basis of the logical domain.
-     * @param[in] advection_field_xy_centre
-     *      The advection field along the physical index range axes, XY
-     *      at the centre point.
+     * @param [in] advection_field_xy_centre
+     *      A vector in the Cartesian basis, containing the value of the advection
+     *      field at the O-point.
      * @param[in] dt
      *      The time step.
      *

--- a/src/geometryRTheta/advection/iadvection_rtheta.hpp
+++ b/src/geometryRTheta/advection/iadvection_rtheta.hpp
@@ -51,6 +51,6 @@ public:
     virtual DFieldRTheta operator()(
             DFieldRTheta allfdistribu,
             DConstVectorFieldRTheta<R, Theta> advection_field,
-            CoordXY const& advection_field_xy_centre,
+            DVector<X, Y> const& advection_field_xy_centre,
             double const dt) const = 0;
 };

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -351,7 +351,7 @@ public:
      * @param[out] advection_field_rtheta
      *      The advection field on the logical axis. It is expressed on the contravariant basis. 
      * @param[out] advection_field_xy_centre
-     *      The advection field on the physical axis at the O-point. 
+     *      The advection field at the centre point on the Cartesian basis.
      */
     void operator()(
             host_t<DFieldRTheta> electrostatic_potential,
@@ -383,6 +383,8 @@ public:
      *      The advection field on the logical axis. It is expressed on the contravariant basis. 
      * @param[out] advection_field_xy_centre
      *      The advection field on the physical axis at the O-point.  
+     * @param[out] advection_field_xy_centre
+     *      The advection field at the centre point on the Cartesian basis.
      */
     void operator()(
             host_t<Spline2D> electrostatic_potential_coef,
@@ -406,7 +408,7 @@ public:
      * @param[out] advection_field_rtheta
      *      The advection field on the logical axis. It is expressed on the contravariant basis. 
      * @param[out] advection_field_xy_centre
-     *      The advection field on the physical axis at the O-point. 
+     *      The advection field at the centre point on the Cartesian basis.
      */
     void operator()(
             host_t<PolarSplineMemRTheta>& electrostatic_potential_coef,
@@ -433,8 +435,8 @@ private:
      * @param[out] advection_field_rtheta
      *      The advection field on the logical axis on an domain without O-point.
      *      It is expressed on the contravariant basis. 
-     * @param[out] advection_field_xy_centre
-     *      The advection field on the physical axis at the O-point. 
+     * @param [in] advection_field_xy_centre
+     *      The advection field at the centre point on the Cartesian basis.
      */
     template <class SplineType, class Evaluator>
     void compute_advection_field_RTheta(

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -382,8 +382,6 @@ public:
      * @param[out] advection_field_rtheta
      *      The advection field on the logical axis. It is expressed on the contravariant basis. 
      * @param[out] advection_field_xy_centre
-     *      The advection field on the physical axis at the O-point.  
-     * @param[out] advection_field_xy_centre
      *      The advection field at the centre point on the Cartesian basis.
      */
     void operator()(

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -356,7 +356,7 @@ public:
     void operator()(
             host_t<DFieldRTheta> electrostatic_potential,
             host_t<DVectorFieldRTheta<R, Theta>> advection_field_rtheta,
-            CoordXY& advection_field_xy_centre) const
+            DVector<X, Y>& advection_field_xy_centre) const
     {
         IdxRangeRTheta const grid = get_idx_range(electrostatic_potential);
 
@@ -387,7 +387,7 @@ public:
     void operator()(
             host_t<Spline2D> electrostatic_potential_coef,
             host_t<DVectorFieldRTheta<R, Theta>> advection_field_rtheta,
-            CoordXY& advection_field_xy_centre) const
+            DVector<X, Y>& advection_field_xy_centre) const
     {
         compute_advection_field_RTheta(
                 m_spline_evaluator,
@@ -411,7 +411,7 @@ public:
     void operator()(
             host_t<PolarSplineMemRTheta>& electrostatic_potential_coef,
             host_t<DVectorFieldRTheta<R, Theta>> advection_field_rtheta,
-            CoordXY& advection_field_xy_centre) const
+            DVector<X, Y>& advection_field_xy_centre) const
     {
         compute_advection_field_RTheta(
                 m_polar_spline_evaluator,
@@ -441,7 +441,7 @@ private:
             Evaluator evaluator,
             SplineType& electrostatic_potential_coef,
             host_t<DVectorFieldRTheta<R, Theta>> advection_field_rtheta,
-            CoordXY& advection_field_xy_centre) const
+            DVector<X, Y>& advection_field_xy_centre) const
     {
         static_assert(
                 (std::is_same_v<
@@ -536,6 +536,6 @@ private:
         double const deriv_y_phi_0
                 = (-dr_x_2 * deriv_r_phi_1 + dr_x_1 * deriv_r_phi_2) / determinant;
 
-        advection_field_xy_centre = CoordXY(-deriv_y_phi_0, deriv_x_phi_0);
+        advection_field_xy_centre = DVector<X, Y>(-deriv_y_phi_0, deriv_x_phi_0);
     }
 };

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -274,7 +274,7 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
         ddcHelper::assign_vector_field_element(
                 get_field(difference_between_fields_xy_and_rtheta),
                 irtheta,
-                advection_field_xy_from_rtheta(irtheta));
+                advection_field_xy_from_rtheta(irtheta) - advection_field_xy(irtheta));
     });
 
     // --- Check the difference on advection fields  --------------------------------------------------

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -189,7 +189,7 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     host_t<DVectorFieldMemRTheta<R, Theta>> advection_field_rtheta_alloc(grid_without_Opoint);
     host_t<DVectorFieldMemRTheta<X, Y>> advection_field_xy_alloc(grid);
     host_t<DVectorFieldMemRTheta<X, Y>> advection_field_xy_from_rtheta_alloc(grid);
-    CoordXY advection_field_xy_centre;
+    DVector<X, Y> advection_field_xy_centre;
 
     host_t<DFieldMemRTheta> electrostatic_potential_alloc(grid);
 
@@ -214,9 +214,10 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
         allfdistribu_xy(irtheta) = allfdistribu_rtheta(irtheta);
         electrostatic_potential(irtheta) = simulation.electrostatical_potential(coord_xy, 0);
 
-        CoordXY const evaluated_advection_field = simulation.advection_field(coord_xy, 0);
-        ddcHelper::get<X>(advection_field_exact)(irtheta) = CoordX(evaluated_advection_field);
-        ddcHelper::get<Y>(advection_field_exact)(irtheta) = CoordY(evaluated_advection_field);
+        ddcHelper::assign_vector_field_element(
+                advection_field_exact,
+                irtheta,
+                simulation.advection_field(coord_xy, 0));
     });
 
 
@@ -232,12 +233,10 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     host_t<DVectorFieldMemRTheta<X, Y>> difference_between_fields_exact_and_xy(grid);
     // > Compare the advection field computed on XY to the exact advection field
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
-        ddcHelper::get<X>(difference_between_fields_exact_and_xy)(irtheta)
-                = ddcHelper::get<X>(advection_field_exact)(irtheta)
-                  - ddcHelper::get<X>(advection_field_xy)(irtheta);
-        ddcHelper::get<Y>(difference_between_fields_exact_and_xy)(irtheta)
-                = ddcHelper::get<Y>(advection_field_exact)(irtheta)
-                  - ddcHelper::get<Y>(advection_field_xy)(irtheta);
+        ddcHelper::assign_vector_field_element(
+                get_field(difference_between_fields_exact_and_xy),
+                irtheta,
+                advection_field_exact(irtheta) - advection_field_xy(irtheta));
     });
 
 
@@ -251,36 +250,31 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
         DTensor<VectorIndexSet<X, Y>, VectorIndexSet<R_cov, Theta_cov>> J
                 = to_physical_mapping.jacobian_matrix(coord_rtheta);
 
-        DVector<X, Y> adv_field
-                = tensor_mul(index<'i', 'j'>(J), index<'j'>(advection_field_rtheta(irtheta)));
-
         // computation made in BslAdvectionRTheta operator:
-        ddcHelper::get<X>(advection_field_xy_from_rtheta)(irtheta) = ddcHelper::get<X>(adv_field);
-        ddcHelper::get<Y>(advection_field_xy_from_rtheta)(irtheta) = ddcHelper::get<Y>(adv_field);
+        ddcHelper::assign_vector_field_element(
+                advection_field_xy_from_rtheta,
+                irtheta,
+                tensor_mul(index<'i', 'j'>(J), index<'j'>(advection_field_rtheta(irtheta))));
 
         // compare
-        ddcHelper::get<X>(difference_between_fields_xy_and_rtheta)(irtheta)
-                = ddcHelper::get<X>(advection_field_xy_from_rtheta)(irtheta)
-                  - ddcHelper::get<X>(advection_field_xy)(irtheta);
-        ddcHelper::get<Y>(difference_between_fields_xy_and_rtheta)(irtheta)
-                = ddcHelper::get<Y>(advection_field_xy_from_rtheta)(irtheta)
-                  - ddcHelper::get<Y>(advection_field_xy)(irtheta);
+        ddcHelper::assign_vector_field_element(
+                get_field(difference_between_fields_xy_and_rtheta),
+                irtheta,
+                advection_field_xy_from_rtheta(irtheta) - advection_field_xy(irtheta));
     });
 
     ddc::for_each(Opoint_grid, [&](IdxRTheta const irtheta) {
         // computation made in BslAdvectionRTheta operator:
-        ddcHelper::get<X>(advection_field_xy_from_rtheta)(irtheta)
-                = CoordX(advection_field_xy_centre);
-        ddcHelper::get<Y>(advection_field_xy_from_rtheta)(irtheta)
-                = CoordY(advection_field_xy_centre);
+        ddcHelper::assign_vector_field_element(
+                advection_field_xy_from_rtheta,
+                irtheta,
+                advection_field_xy_centre);
 
         // compare
-        ddcHelper::get<X>(difference_between_fields_xy_and_rtheta)(irtheta)
-                = ddcHelper::get<X>(advection_field_xy_from_rtheta)(irtheta)
-                  - ddcHelper::get<X>(advection_field_xy)(irtheta);
-        ddcHelper::get<Y>(difference_between_fields_xy_and_rtheta)(irtheta)
-                = ddcHelper::get<Y>(advection_field_xy_from_rtheta)(irtheta)
-                  - ddcHelper::get<Y>(advection_field_xy)(irtheta);
+        ddcHelper::assign_vector_field_element(
+                get_field(difference_between_fields_xy_and_rtheta),
+                irtheta,
+                advection_field_xy_from_rtheta(irtheta));
     });
 
     // --- Check the difference on advection fields  --------------------------------------------------

--- a/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
@@ -386,11 +386,12 @@ void simulate(
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
         // Moving the coordinates in the physical domain:
         CoordXY const coord_xy = to_physical_mapping_host(ddc::coordinate(irtheta));
-        CoordXY const advection_field = simulation.advection_field(coord_xy, 0.);
 
         // Define the advection field on the physical domain:
-        ddcHelper::get<X>(advection_field_test_vec_host)(irtheta) = ddc::get<X>(advection_field);
-        ddcHelper::get<Y>(advection_field_test_vec_host)(irtheta) = ddc::get<Y>(advection_field);
+        ddcHelper::assign_vector_field_element(
+                get_field(advection_field_test_vec_host),
+                irtheta,
+                simulation.advection_field(coord_xy, 0.));
     });
 
     auto allfdistribu = ddc::create_mirror_view_and_copy(

--- a/tests/geometryRTheta/advection_rtheta/test_cases.hpp
+++ b/tests/geometryRTheta/advection_rtheta/test_cases.hpp
@@ -239,11 +239,11 @@ public:
 ￼     *
 ￼     * @return The advection field in the physical index range.
 ￼     */
-    KOKKOS_FUNCTION CoordXY operator()(CoordXY const coord, double const t) const
+    KOKKOS_FUNCTION DVector<X, Y> operator()(CoordXY const coord, double const t) const
     {
         double const x = m_omega * (m_yc - ddc::get<Y>(coord));
         double const y = m_omega * (ddc::get<X>(coord) - m_xc);
-        return CoordXY(x, y);
+        return DVector<X, Y>(x, y);
     }
 
     /**
@@ -318,9 +318,9 @@ public:
 ￼     *
 ￼     * @return The advection field in the physical index range.
 ￼     */
-    KOKKOS_FUNCTION CoordXY operator()(CoordXY const coord, double const t) const
+    KOKKOS_FUNCTION DVector<X, Y> operator()(CoordXY const coord, double const t) const
     {
-        return m_velocity;
+        return DVector<X, Y>(m_velocity);
     }
 
     /**
@@ -397,12 +397,11 @@ public:
 ￼     *
 ￼     * @return The advection field in the physical index range.
 ￼     */
-    KOKKOS_FUNCTION CoordXY operator()(CoordXY const coord, double const t) const
+    KOKKOS_FUNCTION DVector<X, Y> operator()(CoordXY const coord, double const t) const
     {
         CoordRTheta const coord_rtheta(m_physical_to_logical_mapping(coord));
         Tensor jacobian = m_logical_to_physical_mapping.jacobian_matrix(coord_rtheta);
-        DVector<X, Y> v = tensor_mul(index<'i', 'j'>(jacobian), index<'j'>(m_v));
-        return CoordXY(ddcHelper::get<X>(v), ddcHelper::get<Y>(v));
+        return tensor_mul(index<'i', 'j'>(jacobian), index<'j'>(m_v));
     }
 
     /**


### PR DESCRIPTION
This PR replaces the use of `CoordXY` with `DVector<X,Y>` to store the advection field in the Cartesian coordinate system. The advection field is not a coordinate so this type is not logical (it was used previously as Vector did not yet exist). Related to #39.