### PR TITLE
Batch the polar spline foot finder

### DIFF
--- a/src/advection/ipolar_foot_finder.hpp
+++ b/src/advection/ipolar_foot_finder.hpp
@@ -14,8 +14,10 @@
  *
  * @tparam GridRadial The radial grid on which the distribution function is defined.
  * @tparam GridPoloidal The poloidial grid on which the distribution function is defined.
- * @tparam AdvectionDim1 The first dimension of the advection field vector.
- * @tparam AdvectionDim2 The second dimension of the advection field vector.
+ * @tparam VectorIndexSetAdvDims A vector index set containing the set of dimensions
+ *                              that can be used to index the advection dimensions.
+ * @tparam IdxRangeBatched The index range on which this batched operator operates.
+ *                              I.e. the index range of the distribution function.
  * @tparam MemorySpace The memory space where the data is saved (CPU/GPU).
  */
 template <

--- a/src/advection/ipolar_foot_finder.hpp
+++ b/src/advection/ipolar_foot_finder.hpp
@@ -22,7 +22,7 @@ template <
         class GridRadial,
         class GridPoloidal,
         class VectorIndexSetAdvDims,
-        class BatchedIdxRange,
+        class IdxRangeBatched,
         class MemorySpace>
 class IPolarFootFinder
 {
@@ -34,15 +34,15 @@ class IPolarFootFinder
             (ddc::is_non_uniform_point_sampling_v<GridPoloidal>)
             || (ddc::is_uniform_point_sampling_v<GridPoloidal>));
     static_assert(is_vector_index_set_v<VectorIndexSetAdvDims>);
-    static_assert(ddc::is_discrete_domain_v<BatchedIdxRange>);
+    static_assert(ddc::is_discrete_domain_v<IdxRangeBatched>);
     static_assert(Kokkos::is_memory_space_v<MemorySpace>);
 
     // Check that grids make sense
     static_assert(
-            ddc::in_tags_v<GridRadial, ddc::to_type_seq_t<BatchedIdxRange>>,
+            ddc::in_tags_v<GridRadial, ddc::to_type_seq_t<IdxRangeBatched>>,
             "The radial grid must be found in the batched index range");
     static_assert(
-            ddc::in_tags_v<GridPoloidal, ddc::to_type_seq_t<BatchedIdxRange>>,
+            ddc::in_tags_v<GridPoloidal, ddc::to_type_seq_t<IdxRangeBatched>>,
             "The poloidal grid must be found in the batched index range");
 
     // Check that VectorIndexSetAdvDims makes sense
@@ -67,7 +67,7 @@ public:
     using memory_space = MemorySpace;
 
     /// The type of the index range over which the operator works.
-    using IdxRangeOperator = BatchedIdxRange;
+    using IdxRangeOperator = IdxRangeBatched;
 
 public:
     virtual ~IPolarFootFinder() = default;

--- a/src/advection/ipolar_foot_finder.hpp
+++ b/src/advection/ipolar_foot_finder.hpp
@@ -21,11 +21,33 @@
 template <
         class GridRadial,
         class GridPoloidal,
-        class AdvectionDim1,
-        class AdvectionDim2,
+        class VectorIndexSetAdvDims,
+        class BatchedIdxRange,
         class MemorySpace>
 class IPolarFootFinder
 {
+    // Check types
+    static_assert(
+            (ddc::is_non_uniform_point_sampling_v<GridRadial>)
+            || (ddc::is_uniform_point_sampling_v<GridRadial>));
+    static_assert(
+            (ddc::is_non_uniform_point_sampling_v<GridPoloidal>)
+            || (ddc::is_uniform_point_sampling_v<GridPoloidal>));
+    static_assert(is_vector_index_set_v<VectorIndexSetAdvDims>);
+    static_assert(ddc::is_discrete_domain_v<BatchedIdxRange>);
+    static_assert(Kokkos::is_memory_space_v<MemorySpace>);
+
+    // Check that grids make sense
+    static_assert(
+            ddc::in_tags_v<GridRadial, ddc::to_type_seq_t<BatchedIdxRange>>,
+            "The radial grid must be found in the batched index range");
+    static_assert(
+            ddc::in_tags_v<GridPoloidal, ddc::to_type_seq_t<BatchedIdxRange>>,
+            "The poloidal grid must be found in the batched index range");
+
+    // Check that VectorIndexSetAdvDims makes sense
+    static_assert(ddc::type_seq_size_v<VectorIndexSetAdvDims> == 2);
+
 protected:
     /// The continuous radial dimension.
     using GridR = GridRadial;
@@ -38,15 +60,14 @@ protected:
     using Theta = typename GridTheta::continuous_dimension_type;
 
     /// The continuous radial dimension.
-    using X = AdvectionDim1;
-    /// The continuous poloidal dimension.
-    using Y = AdvectionDim2;
+    using VectorIndexSetAdvectionDims = VectorIndexSetAdvDims;
 
+public:
     /// The type of the memory space where the field is saved (CPU vs GPU).
     using memory_space = MemorySpace;
 
     /// The type of the index range over which the operator works.
-    using IdxRangeRTheta = IdxRange<GridR, GridTheta>;
+    using IdxRangeOperator = BatchedIdxRange;
 
 public:
     virtual ~IPolarFootFinder() = default;
@@ -63,7 +84,8 @@ public:
      *      The time step.
      */
     virtual void operator()(
-            Field<Coord<R, Theta>, IdxRangeRTheta, memory_space> feet,
-            DVectorConstField<IdxRangeRTheta, VectorIndexSet<X, Y>, memory_space> advection_field,
+            Field<Coord<R, Theta>, IdxRangeOperator, memory_space> feet,
+            DVectorConstField<IdxRangeOperator, VectorIndexSetAdvectionDims, memory_space>
+                    advection_field,
             double dt) const = 0;
 };

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -128,7 +128,7 @@ private:
     using BSplinesR = typename SplineRThetaBuilderAdvection::bsplines_type1;
     using BSplinesTheta = typename SplineRThetaBuilderAdvection::bsplines_type2;
 
-    using BatchedSplineIdxRange
+    using IdxRangeSplineBatched
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
                     ddc::to_type_seq_t<IdxRangeOperator>,
                     ddc::detail::TypeSeq<GridR, GridTheta>,
@@ -175,7 +175,7 @@ public:
      * on the polar plane on a compatible memory space.
      */
     using VectorSplineCoeffsMem
-            = DVectorFieldMem<BatchedSplineIdxRange, PseudoCartesianBasis, memory_space>;
+            = DVectorFieldMem<IdxRangeSplineBatched, PseudoCartesianBasis, memory_space>;
 
 public:
     /**

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -33,9 +33,9 @@
  *      A mapping from the logical domain to the domain where the advection is
  *      carried out. This may be a pseudo-physical domain or the physical domain
  *      itself.
- * @tparam SplineRThetaBuilder
+ * @tparam SplineRThetaBuilderAdvection
  *      A 2D SplineBuilder to construct a spline on a polar domain.
- * @tparam SplineRThetaEvaluatorConstBound
+ * @tparam SplineRThetaEvaluatorAdvection
  *      A 2D SplineEvaluator to evaluate a spline on a polar domain.
  *      A boundary condition must be provided in case the foot of the characteristic
  *      is found outside the domain.
@@ -46,34 +46,41 @@ template <
         class TimeStepper,
         class LogicalToPhysicalMapping,
         class LogicalToPseudoPhysicalMapping,
-        class SplineRThetaBuilder,
-        class SplineRThetaEvaluatorConstBound>
+        class SplineRThetaBuilderAdvection,
+        class SplineRThetaEvaluatorAdvection>
 class SplinePolarFootFinder
     : public IPolarFootFinder<
-              typename SplineRThetaBuilder::interpolation_discrete_dimension_type1,
-              typename SplineRThetaBuilder::interpolation_discrete_dimension_type2,
+              typename SplineRThetaBuilderAdvection::interpolation_discrete_dimension_type1,
+              typename SplineRThetaBuilderAdvection::interpolation_discrete_dimension_type2,
               ddc::to_type_seq_t<typename LogicalToPhysicalMapping::CoordResult>,
-              typename SplineRThetaBuilder::batched_interpolation_domain_type,
-              typename SplineRThetaBuilder::memory_space>
+              typename SplineRThetaBuilderAdvection::batched_interpolation_domain_type,
+              typename SplineRThetaBuilderAdvection::memory_space>
 {
     static_assert(is_mapping_v<LogicalToPhysicalMapping>);
     static_assert(is_mapping_v<LogicalToPseudoPhysicalMapping>);
     static_assert(is_analytical_mapping_v<LogicalToPseudoPhysicalMapping>);
     static_assert(std::is_same_v<
-                  typename SplineRThetaBuilder::memory_space,
-                  typename SplineRThetaEvaluatorConstBound::memory_space>);
-    static_assert(
-            is_accessible_v<typename SplineRThetaBuilder::exec_space, LogicalToPhysicalMapping>);
+                  typename SplineRThetaBuilderAdvection::memory_space,
+                  typename SplineRThetaEvaluatorAdvection::memory_space>);
     static_assert(is_accessible_v<
-                  typename SplineRThetaBuilder::exec_space,
+                  typename SplineRThetaBuilderAdvection::exec_space,
+                  LogicalToPhysicalMapping>);
+    static_assert(is_accessible_v<
+                  typename SplineRThetaBuilderAdvection::exec_space,
                   LogicalToPseudoPhysicalMapping>);
+    static_assert(
+            std::is_same_v<
+                    typename SplineRThetaBuilderAdvection::batched_interpolation_domain_type,
+                    typename TimeStepper::IdxRange>,
+            "The SplinePolarFootFinder is designed to work with an advection field defined on the "
+            "same grid as the distribution function.");
 
     using base_type = IPolarFootFinder<
-            typename SplineRThetaBuilder::interpolation_discrete_dimension_type1,
-            typename SplineRThetaBuilder::interpolation_discrete_dimension_type2,
+            typename SplineRThetaBuilderAdvection::interpolation_discrete_dimension_type1,
+            typename SplineRThetaBuilderAdvection::interpolation_discrete_dimension_type2,
             ddc::to_type_seq_t<typename LogicalToPhysicalMapping::CoordResult>,
-            typename SplineRThetaBuilder::batched_interpolation_domain_type,
-            typename SplineRThetaBuilder::memory_space>;
+            typename SplineRThetaBuilderAdvection::batched_interpolation_domain_type,
+            typename SplineRThetaBuilderAdvection::memory_space>;
 
 public:
     using typename base_type::memory_space;
@@ -84,10 +91,11 @@ private:
 private:
     using typename base_type::GridR;
     using typename base_type::GridTheta;
+    using typename base_type::IdxRangeOperator;
     using typename base_type::R;
     using typename base_type::Theta;
     using typename base_type::VectorIndexSetAdvectionDims;
-    using ExecSpace = typename SplineRThetaBuilder::exec_space;
+    using ExecSpace = typename SplineRThetaBuilderAdvection::exec_space;
     /**
      * @brief Tag the first dimension in the advection index range.
      */
@@ -101,21 +109,30 @@ private:
      */
     using CoordXY_adv = typename LogicalToPseudoPhysicalMapping::CoordResult;
 
+    using PseudoCartesianBasis = ddc::to_type_seq_t<CoordXY_adv>;
+
     using CoordRTheta = Coord<R, Theta>;
 
-    using IdxRangeRTheta = typename base_type::IdxRangeOperator;
+    using IdxRangeRTheta = IdxRange<GridR, GridTheta>;
     using IdxRangeR = IdxRange<GridR>;
     using IdxRangeTheta = IdxRange<GridTheta>;
     using IdxRTheta = Idx<GridR, GridTheta>;
     using IdxR = Idx<GridR>;
     using IdxTheta = Idx<GridTheta>;
+    using IdxOperator = typename IdxRangeOperator::discrete_element_type;
 
     using PseudoCartesianToCircular = CartesianToCircular<X_adv, Y_adv, R, Theta>;
     using PseudoPhysicalToPhysicalMapping
             = CombinedMapping<LogicalToPhysicalMapping, PseudoCartesianToCircular>;
 
-    using BSplinesR = typename SplineRThetaBuilder::bsplines_type1;
-    using BSplinesTheta = typename SplineRThetaBuilder::bsplines_type2;
+    using BSplinesR = typename SplineRThetaBuilderAdvection::bsplines_type1;
+    using BSplinesTheta = typename SplineRThetaBuilderAdvection::bsplines_type2;
+
+    using BatchedSplineIdxRange
+            = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
+                    ddc::to_type_seq_t<IdxRangeOperator>,
+                    ddc::detail::TypeSeq<GridR, GridTheta>,
+                    ddc::detail::TypeSeq<BSplinesR, BSplinesTheta>>>;
 
     TimeStepper const& m_time_stepper;
 
@@ -123,35 +140,42 @@ private:
     PseudoPhysicalToLogicalMapping m_pseudo_physical_to_logical;
     PseudoPhysicalToPhysicalMapping m_pseudo_physical_to_physical;
 
-    SplineRThetaBuilder const& m_builder_advection_field;
-    SplineRThetaEvaluatorConstBound const& m_evaluator_advection_field;
+    SplineRThetaBuilderAdvection const& m_builder_advection_field;
+    SplineRThetaEvaluatorAdvection const& m_evaluator_advection_field;
 
 public:
-    /// The type of a field on the polar plane on a compatible memory space.
-    template <class ElementType>
-    using FieldRTheta = Field<ElementType, IdxRangeRTheta, memory_space>;
+    /**
+     * @brief The type of a field of (r, theta) coordinates at every grid point, saved
+     * on a compatible memory space.
+     */
+    using CFieldFeet = Field<CoordRTheta, IdxRangeOperator, memory_space>;
 
-    /// The type of a constant field on the polar plane on a compatible memory space.
-    template <class ElementType>
-    using ConstFieldRTheta = ConstField<ElementType, IdxRangeRTheta, memory_space>;
+    /**
+     * @brief The type of a constant field of (r, theta) coordinates at every grid point,
+     * saved on a compatible memory space.
+     */
+    using CConstFieldFeet = ConstField<CoordRTheta, IdxRangeOperator, memory_space>;
 
-    /// The type of a vector (x,y) field on the polar plane on a compatible memory space.
-    template <class Dim1, class Dim2>
-    using DVectorFieldRTheta
-            = DVectorField<IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>, memory_space>;
+    /**
+     * @brief The type of a vector field defined on the pseudo-Cartesian basis at every
+     * grid point, saved on a compatible memory space.
+     */
+    using DVectorFieldAdvection
+            = DVectorField<IdxRangeOperator, PseudoCartesianBasis, memory_space>;
 
-    /// The type of a constant vector (x,y) field on the polar plane on a compatible memory space.
-    template <class Dim1, class Dim2>
-    using DVectorConstFieldRTheta
-            = DVectorConstField<IdxRangeRTheta, VectorIndexSet<Dim1, Dim2>, memory_space>;
+    /**
+     * @brief The type of a constant vector field defined on the pseudo-Cartesian basis
+     * at every grid point, saved on a compatible memory space.
+     */
+    using DVectorConstFieldAdvection
+            = DVectorConstField<IdxRangeOperator, PseudoCartesianBasis, memory_space>;
 
-    /// The type of 2 splines representing the x and y components of a vector on the polar plane on a compatible memory space.
-    template <class Dim1, class Dim2>
-    using VectorSplineCoeffsMem2D = VectorFieldMem<
-            double,
-            IdxRange<BSplinesR, BSplinesTheta>,
-            VectorIndexSet<Dim1, Dim2>,
-            memory_space>;
+    /**
+     * @brief The type of 2 batched splines representing the x and y components of a vector
+     * on the polar plane on a compatible memory space.
+     */
+    using VectorSplineCoeffsMem
+            = DVectorFieldMem<BatchedSplineIdxRange, PseudoCartesianBasis, memory_space>;
 
 public:
     /**
@@ -180,8 +204,8 @@ public:
             TimeStepper const& time_stepper,
             LogicalToPhysicalMapping const& logical_to_physical_mapping,
             LogicalToPseudoPhysicalMapping const& logical_to_pseudo_physical_mapping,
-            SplineRThetaBuilder const& builder_advection_field,
-            SplineRThetaEvaluatorConstBound const& evaluator_advection_field,
+            SplineRThetaBuilderAdvection const& builder_advection_field,
+            SplineRThetaEvaluatorAdvection const& evaluator_advection_field,
             double epsilon = 1e-12)
         : m_time_stepper(time_stepper)
         , m_logical_to_pseudo_physical(logical_to_pseudo_physical_mapping)
@@ -212,12 +236,12 @@ public:
      *      The time step.
      */
     void operator()(
-            FieldRTheta<CoordRTheta> feet,
-            DVectorConstField<IdxRangeRTheta, VectorIndexSetAdvectionDims, memory_space>
+            CFieldFeet feet,
+            DVectorConstField<IdxRangeOperator, VectorIndexSetAdvectionDims, memory_space>
                     advection_field,
             double dt) const final
     {
-        VectorSplineCoeffsMem2D<X_adv, Y_adv> advection_field_in_adv_domain_coefs(
+        VectorSplineCoeffsMem advection_field_in_adv_domain_coefs(
                 get_spline_idx_range(m_builder_advection_field));
 
         // Compute the advection field in the advection domain.
@@ -236,9 +260,8 @@ public:
 
 
         // The function describing how the derivative of the evolve function is calculated.
-        std::function<void(DVectorFieldRTheta<X_adv, Y_adv>, ConstFieldRTheta<CoordRTheta>)> dy
-                = [&](DVectorFieldRTheta<X_adv, Y_adv> updated_advection_field,
-                      ConstFieldRTheta<CoordRTheta> feet) {
+        std::function<void(DVectorFieldAdvection, CConstFieldFeet)> dy
+                = [&](DVectorFieldAdvection updated_advection_field, CConstFieldFeet feet) {
                       m_evaluator_advection_field(
                               get_field(ddcHelper::get<X_adv>(updated_advection_field)),
                               get_const_field(feet),
@@ -251,47 +274,45 @@ public:
                                       ddcHelper::get<Y_adv>(advection_field_in_adv_domain_coefs)));
                   };
 
-        IdxRangeRTheta const idx_range_rp = get_idx_range<GridR, GridTheta>(feet);
-
         CoordXY_adv coord_centre(m_logical_to_pseudo_physical(CoordRTheta(0, 0)));
         LogicalToPseudoPhysicalMapping logical_to_pseudo_physical_proxy
                 = m_logical_to_pseudo_physical;
         PseudoPhysicalToLogicalMapping pseudo_physical_to_logical_proxy
                 = m_pseudo_physical_to_logical;
 
+        IdxRangeOperator idx_range = get_idx_range(feet);
+        IdxRangeTheta idx_range_theta(idx_range);
+
         // The function describing how the value(s) are updated using the derivative.
-        std::function<void(FieldRTheta<CoordRTheta>, DVectorConstFieldRTheta<X_adv, Y_adv>, double)>
-                update_function = [&](FieldRTheta<CoordRTheta> feet,
-                                      DVectorConstFieldRTheta<X_adv, Y_adv> advection_field,
-                                      double dt) {
-                    // Compute the characteristic feet at t^n:
-                    ddc::parallel_for_each(
-                            ExecSpace(),
-                            idx_range_rp,
-                            KOKKOS_LAMBDA(IdxRTheta const irtheta) {
-                                CoordRTheta const coord_rtheta(feet(irtheta));
-                                CoordXY_adv const coord_xy
-                                        = logical_to_pseudo_physical_proxy(coord_rtheta);
+        std::function<void(CFieldFeet, DVectorConstFieldAdvection, double)> update_function
+                = [&](CFieldFeet feet, DVectorConstFieldAdvection advection_field, double dt) {
+                      // Compute the characteristic feet at t^n:
+                      ddc::parallel_for_each(
+                              ExecSpace(),
+                              get_idx_range(feet),
+                              KOKKOS_LAMBDA(IdxOperator const idx) {
+                                  CoordRTheta const coord_rtheta(feet(idx));
+                                  CoordXY_adv const coord_xy
+                                          = logical_to_pseudo_physical_proxy(coord_rtheta);
 
-                                CoordXY_adv const feet_xy
-                                        = coord_xy - dt * advection_field(irtheta);
+                                  CoordXY_adv const feet_xy = coord_xy - dt * advection_field(idx);
 
-                                if (norm_inf(feet_xy - coord_centre) < 1e-15) {
-                                    feet(irtheta) = CoordRTheta(0, 0);
-                                } else {
-                                    feet(irtheta) = pseudo_physical_to_logical_proxy(feet_xy);
-                                    ddc::select<Theta>(feet(irtheta))
-                                            = ddcHelper::restrict_to_idx_range(
-                                                    ddc::select<Theta>(feet(irtheta)),
-                                                    IdxRangeTheta(idx_range_rp));
-                                }
-                            });
+                                  if (norm_inf(feet_xy - coord_centre) < 1e-15) {
+                                      feet(idx) = CoordRTheta(0, 0);
+                                  } else {
+                                      feet(idx) = pseudo_physical_to_logical_proxy(feet_xy);
+                                      ddc::select<Theta>(feet(idx))
+                                              = ddcHelper::restrict_to_idx_range(
+                                                      ddc::select<Theta>(feet(idx)),
+                                                      idx_range_theta);
+                                  }
+                              });
 
-                    // Treatment to conserve the C0 property of the advected function:
-                    unify_value_at_centre_pt(feet);
-                    // Test if the values are the same at the centre point
-                    is_unified(feet);
-                };
+                      // Treatment to conserve the C0 property of the advected function:
+                      unify_value_at_centre_pt(feet);
+                      // Test if the values are the same at the centre point
+                      is_unified(feet);
+                  };
 
 
         // Solve the characteristic equation


### PR DESCRIPTION
Add batch dimensions to the polar spline foot finder. This will allow it to be used in high dimensional geometries without requiring a large loop around the GPU calls