### PR TITLE
Fix bugs in the mappings

### DIFF
--- a/src/mapping/barycentric_to_cartesian.hpp
+++ b/src/mapping/barycentric_to_cartesian.hpp
@@ -6,6 +6,9 @@
 #include "ddc_aliases.hpp"
 #include "mapping_tools.hpp"
 
+template <class X, class Y, class Corner1Tag, class Corner2Tag, class Corner3Tag>
+class CartesianToBarycentric;
+
 /**
  * @brief A class to convert barycentric coordinates to Cartesian coordinates
  * on a triangle.
@@ -108,5 +111,20 @@ public:
         const double y = y1 * l1 + y2 * l2 + y3 * l3;
 
         return CartesianCoord(x, y);
+    }
+
+    /**
+     * @brief Get the inverse mapping.
+     *
+     * @return The inverse mapping.
+     */
+    CartesianToBarycentric<X, Y, Corner1Tag, Corner2Tag, Corner3Tag> get_inverse_mapping() const
+    {
+        return CartesianToBarycentric<
+                X,
+                Y,
+                Corner1Tag,
+                Corner2Tag,
+                Corner3Tag>(m_corner1, m_corner2, m_corner3);
     }
 };

--- a/src/mapping/cartesian_to_barycentric.hpp
+++ b/src/mapping/cartesian_to_barycentric.hpp
@@ -6,6 +6,9 @@
 #include "ddc_aliases.hpp"
 #include "mapping_tools.hpp"
 
+template <class Corner1Tag, class Corner2Tag, class Corner3Tag, class X, class Y>
+class BarycentricToCartesian;
+
 /**
  * @brief A class to convert Cartesian coordinates to barycentric coordinates
  * on a triangle.
@@ -108,5 +111,20 @@ public:
         const double lam2 = ((y - y3) * (x1 - x3) + (x3 - x) * (y1 - y3)) / div;
         const double lam3 = 1 - lam1 - lam2;
         return BarycentricCoord(lam1, lam2, lam3);
+    }
+
+    /**
+     * @brief Get the inverse mapping.
+     *
+     * @return The inverse mapping.
+     */
+    BarycentricToCartesian<Corner1Tag, Corner2Tag, Corner3Tag, X, Y> get_inverse_mapping() const
+    {
+        return BarycentricToCartesian<
+                Corner1Tag,
+                Corner2Tag,
+                Corner3Tag,
+                X,
+                Y>(m_corner1, m_corner2, m_corner3);
     }
 };

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -25,13 +25,13 @@ class CircularToCartesian;
  *
  * The Jacobian matrix coefficients are defined as follow
  *
- * @f$ J_{11}(r,\theta)  =\frac{2x}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{11}(x,y)  =\frac{2x}{\sqrt{x^2+y^2}}  @f$
  *
- * @f$ J_{12}(r,\theta)  =\frac{2y}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{12}(x,y)  =\frac{2y}{\sqrt{x^2+y^2}}  @f$
  *
- * @f$ J_{21}(r,\theta)  =\frac{-y}{(x^2+y^2)^2}  @f$
+ * @f$ J_{21}(x,y)  =\frac{-y}{(x^2+y^2)^2}  @f$
  *
- * @f$ J_{22}(r,\theta)  =\frac{x}{(x^2+y^2)^2}  @f$
+ * @f$ J_{22}(x,y)  =\frac{x}{(x^2+y^2)^2}  @f$
  *
  * and the matrix determinant: @f$ det(J) = r @f$.
  *
@@ -146,7 +146,7 @@ public:
      * 				The coordinate where we evaluate the Jacobian matrix.
      * @return The Jacobian matrix.
      */
-    KOKKOS_FUNCTION DTensor<VectorIndexSet<X, Y>, VectorIndexSet<R_cov, Theta_cov>> jacobian_matrix(
+    KOKKOS_FUNCTION DTensor<VectorIndexSet<R, Theta>, VectorIndexSet<X_cov, Y_cov>> jacobian_matrix(
             Coord<X, Y> const& coord) const
 
     {
@@ -171,22 +171,22 @@ public:
     template <class IndexTag1, class IndexTag2>
     KOKKOS_INLINE_FUNCTION double jacobian_component(Coord<X, Y> const& coord) const
     {
-        static_assert(ddc::in_tags_v<IndexTag1, VectorIndexSet<X, Y>>);
-        static_assert(ddc::in_tags_v<IndexTag2, VectorIndexSet<R_cov, Theta_cov>>);
+        static_assert(ddc::in_tags_v<IndexTag1, VectorIndexSet<R, Theta>>);
+        static_assert(ddc::in_tags_v<IndexTag2, VectorIndexSet<X_cov, Y_cov>>);
 
         const double x = ddc::get<X>(coord);
         const double y = ddc::get<Y>(coord);
-        if constexpr (std::is_same_v<IndexTag1, X> && std::is_same_v<IndexTag2, R_cov>) {
-            // Component (1,1), i.e dx/dr
+        if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, X_cov>) {
+            // Component (1,1), i.e dr/dx
             return 2 * x / Kokkos::pow(x * x + y * y, 0.5);
-        } else if constexpr (std::is_same_v<IndexTag1, X> && std::is_same_v<IndexTag2, Theta_cov>) {
-            // Component (1,2), i.e dx/dtheta
+        } else if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, Y_cov>) {
+            // Component (1,2), i.e dr/dy
             return 2 * y / Kokkos::pow(x * x + y * y, 0.5);
-        } else if constexpr (std::is_same_v<IndexTag1, Y> && std::is_same_v<IndexTag2, R_cov>) {
-            // Component (2,1), i.e dy/dr
+        } else if constexpr (std::is_same_v<IndexTag1, Theta> && std::is_same_v<IndexTag2, X_cov>) {
+            // Component (2,1), i.e dtheta/dy
             return -y / Kokkos::pow(x * x + y * y, 2.);
         } else {
-            // Component (2,2), i.e dy/dtheta
+            // Component (2,2), i.e dtheta/dy
             return x / Kokkos::pow(x * x + y * y, 2.);
         }
     }

--- a/src/mapping/combined_mapping.hpp
+++ b/src/mapping/combined_mapping.hpp
@@ -55,8 +55,8 @@ private:
 private:
     using InverseMapping2 = inverse_mapping_t<Mapping2>;
 
-    static_assert(has_2d_jacobian_v<Mapping1, CoordJacobian>);
-    static_assert(has_2d_jacobian_v<InverseMapping2, CoordJacobian>);
+    static_assert(has_jacobian_v<Mapping1, CoordJacobian>);
+    static_assert(has_jacobian_v<InverseMapping2, CoordJacobian>);
 
 private:
     Mapping1 m_mapping_1;

--- a/src/mapping/inverse_jacobian_matrix.hpp
+++ b/src/mapping/inverse_jacobian_matrix.hpp
@@ -17,6 +17,8 @@
 template <class Mapping, class PositionCoordinate = typename Mapping::CoordArg>
 class InverseJacobianMatrix
 {
+    static_assert(Mapping::CoordArg::size() == 2);
+
 private:
     using ValidArgIndices = ddc::to_type_seq_t<typename Mapping::CoordArg>;
     using ValidResultIndices = ddc::to_type_seq_t<typename Mapping::CoordResult>;
@@ -56,10 +58,10 @@ public:
      */
     KOKKOS_INLINE_FUNCTION InverseJacobianTensor operator()(PositionCoordinate const& coord) const
     {
-        if constexpr (has_2d_inv_jacobian_v<Mapping, PositionCoordinate>) {
+        if constexpr (has_inv_jacobian_v<Mapping, PositionCoordinate, false>) {
             return m_mapping.inv_jacobian_matrix(coord);
         } else {
-            static_assert(has_2d_jacobian_v<Mapping, PositionCoordinate>);
+            static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
             DTensor<ValidResultIndices, vector_index_set_dual_t<ValidArgIndices>> jacobian
                     = m_mapping.jacobian_matrix(coord);
             assert(fabs(determinant(jacobian)) > 1e-15);
@@ -84,10 +86,10 @@ public:
         static_assert(ddc::in_tags_v<IndexTag1, VectorIndexSet<DimArg0, DimArg1>>);
         static_assert(ddc::in_tags_v<IndexTag2, VectorIndexSet<DimRes0_cov, DimRes1_cov>>);
 
-        if constexpr (has_2d_inv_jacobian_v<Mapping, PositionCoordinate>) {
+        if constexpr (has_inv_jacobian_v<Mapping, PositionCoordinate, false>) {
             return m_mapping.template inv_jacobian_component<IndexTag1, IndexTag2>(coord);
         } else {
-            static_assert(has_2d_jacobian_v<Mapping, PositionCoordinate>);
+            static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
             double jacob = m_mapping.jacobian(coord);
             assert(fabs(jacob) > 1e-15);
             if constexpr (

--- a/src/mapping/mapping_tools.hpp
+++ b/src/mapping/mapping_tools.hpp
@@ -5,6 +5,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "tensor.hpp"
+#include "vector_index_tools.hpp"
 #include "view.hpp"
 
 namespace mapping_detail {
@@ -70,199 +72,146 @@ public:
     static constexpr bool value = is_mapping();
 };
 
-template <typename Type, typename CoordinateType>
-class Defines2DJacobian
+template <typename Type, typename CoordinateType, bool HideError>
+class DefinesJacobian
 {
-    using DimArg0 = ddc::type_seq_element_t<0, ddc::to_type_seq_t<CoordinateType>>;
-    using DimArg1 = ddc::type_seq_element_t<1, ddc::to_type_seq_t<CoordinateType>>;
-    using DimRes0_cov =
-            typename ddc::type_seq_element_t<0, ddc::to_type_seq_t<CoordinateType>>::Dual;
-    using DimRes1_cov =
-            typename ddc::type_seq_element_t<1, ddc::to_type_seq_t<CoordinateType>>::Dual;
-
+    struct IdxTag;
     template <typename ClassType>
-    using jacobian_type = decltype(&ClassType::jacobian_matrix);
+    using jacobian_matrix = decltype(&ClassType::jacobian_matrix);
     template <typename ClassType>
-    using jacobian_11 = decltype(&ClassType::template jacobian_component<DimArg0, DimRes0_cov>);
-    template <typename ClassType>
-    using jacobian_12 = decltype(&ClassType::template jacobian_component<DimArg0, DimRes1_cov>);
-    template <typename ClassType>
-    using jacobian_21 = decltype(&ClassType::template jacobian_component<DimArg1, DimRes0_cov>);
-    template <typename ClassType>
-    using jacobian_22 = decltype(&ClassType::template jacobian_component<DimArg1, DimRes1_cov>);
+    using jacobian_component = decltype(&ClassType::template jacobian_component<IdxTag, IdxTag>);
     template <typename ClassType>
     using jacobian = decltype(&ClassType::jacobian);
 
-    static std::tuple<bool, const char*> constexpr has_2d_jacobian_methods()
+    static bool constexpr has_jacobian_methods()
     {
-        if (!CheckClassAttributeExistence<Type, jacobian_type>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian_matrix function");
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian_matrix>::has_attribute) {
+            static_assert(HideError, "A Mapping must define the jacobian_matrix function");
+            return false;
         }
-        if (!CheckClassAttributeExistence<Type, jacobian_11>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian_11 function");
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian_component>::has_attribute) {
+            static_assert(HideError, "A Mapping must define the jacobian_component function");
+            return false;
         }
-        if (!CheckClassAttributeExistence<Type, jacobian_12>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian_12 function");
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian>::has_attribute) {
+            static_assert(HideError, "A Mapping must define the jacobian function");
+            return false;
         }
-        if (!CheckClassAttributeExistence<Type, jacobian_21>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian_21 function");
-        }
-        if (!CheckClassAttributeExistence<Type, jacobian_22>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian_22 function");
-        }
-        if (!CheckClassAttributeExistence<Type, jacobian>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the jacobian function");
-        }
-        return std::make_tuple(true, "");
+        return true;
     }
 
-    static std::tuple<bool, const char*> constexpr has_2d_jacobian()
+    static bool constexpr has_jacobian()
     {
-        constexpr std::tuple<bool, const char*> success = has_2d_jacobian_methods();
-        if constexpr (std::get<bool>(success)) {
-            if (!std::is_invocable_v<decltype(&Type::jacobian_matrix), Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian_matrix method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a 2D Tensor.");
+        static_assert(mapping_detail::IsMapping<Type>::value);
+        constexpr bool success = has_jacobian_methods();
+        if constexpr (success) {
+            using ArgBasisCov = get_covariant_dims_t<ddc::to_type_seq_t<typename Type::CoordArg>>;
+            using ResultBasis
+                    = get_contravariant_dims_t<ddc::to_type_seq_t<typename Type::CoordResult>>;
+            if constexpr (!std::is_invocable_r_v<
+                                  DTensor<ResultBasis, ArgBasisCov>,
+                                  decltype(&Type::jacobian_matrix),
+                                  Type,
+                                  CoordinateType>) {
+                static_assert(
+                        HideError,
+                        "The jacobian_matrix method of a Mapping must take a Coordinate as an "
+                        "argument and return a Tensor.");
+                return false;
             }
-            if (!std::is_invocable_r_v<double, jacobian_11<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian_11 method of a 2D Mapping must take a Coordinate as an "
+            if constexpr (!std::is_invocable_r_v<
+                                  double,
+                                  jacobian_component<Type>,
+                                  Type,
+                                  CoordinateType>) {
+                static_assert(
+                        HideError,
+                        "The jacobian_component method of a Mapping must take a Coordinate as an "
                         "argument and return a double.");
+                return false;
             }
-            if (!std::is_invocable_r_v<double, jacobian_12<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian_12 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            if (!std::is_invocable_r_v<double, jacobian_21<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian_21 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            if (!std::is_invocable_r_v<double, jacobian_22<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian_22 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            if (!std::is_invocable_r_v<double, decltype(&Type::jacobian), Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The jacobian method of a 2D Mapping must take a Coordinate as an argument "
+            if constexpr (!std::is_invocable_r_v<
+                                  double,
+                                  decltype(&Type::jacobian),
+                                  Type,
+                                  CoordinateType>) {
+                static_assert(
+                        HideError,
+                        "The jacobian method of a Mapping must take a Coordinate as an argument "
                         "and return a double.");
+                return false;
             }
-            return std::make_tuple(true, "");
+            return true;
         }
         return success;
     }
 
-    static constexpr std::tuple<bool, const char*> has_2d_jacobian_output = has_2d_jacobian();
-
 public:
-    /// True if the type describes a 2d mapping, false otherwise
-    static constexpr bool value = std::get<bool>(has_2d_jacobian_output);
-    /// A string containing any explanation for why the type is not a jacobian (for debugging)
-    static constexpr const char* error_msg = std::get<const char*>(has_2d_jacobian_output);
+    /// True if the type describes a mapping with a Jacobian, false otherwise
+    static constexpr bool value = has_jacobian();
 };
 
-template <typename Type, typename CoordinateType>
-class Defines2DInvJacobian
+template <typename Type, typename CoordinateType, bool HideError>
+class DefinesInvJacobian
 {
-    using DimRes0 = ddc::type_seq_element_t<0, ddc::to_type_seq_t<CoordinateType>>;
-    using DimRes1 = ddc::type_seq_element_t<1, ddc::to_type_seq_t<CoordinateType>>;
-    using DimArg0_cov =
-            typename ddc::type_seq_element_t<0, ddc::to_type_seq_t<CoordinateType>>::Dual;
-    using DimArg1_cov =
-            typename ddc::type_seq_element_t<1, ddc::to_type_seq_t<CoordinateType>>::Dual;
-
+    struct IdxTag;
     template <typename ClassType>
     using inv_jacobian_type = decltype(&ClassType::inv_jacobian_matrix);
     template <typename ClassType>
-    using inv_jacobian_11
-            = decltype(&ClassType::template inv_jacobian_component<DimRes0, DimArg0_cov>);
-    template <typename ClassType>
-    using inv_jacobian_12
-            = decltype(&ClassType::template inv_jacobian_component<DimRes0, DimArg1_cov>);
-    template <typename ClassType>
-    using inv_jacobian_21
-            = decltype(&ClassType::template inv_jacobian_component<DimRes1, DimArg0_cov>);
-    template <typename ClassType>
-    using inv_jacobian_22
-            = decltype(&ClassType::template inv_jacobian_component<DimRes1, DimArg1_cov>);
+    using inv_jacobian_component
+            = decltype(&ClassType::template inv_jacobian_component<IdxTag, IdxTag>);
 
-    static std::tuple<bool, const char*> constexpr has_2d_inv_jacobian_methods()
+    static bool constexpr has_inv_jacobian_methods()
     {
-        if (!CheckClassAttributeExistence<Type, inv_jacobian_type>::has_attribute) {
-            return std::
-                    make_tuple(false, "A 2D Mapping must define the inv_jacobian_matrix function");
+        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_type>::has_attribute) {
+            static_assert(HideError, "A Mapping must define the inv_jacobian_matrix function");
+            return false;
         }
-        if (!CheckClassAttributeExistence<Type, inv_jacobian_11>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the inv_jacobian_11 function");
+        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_component>::has_attribute) {
+            static_assert(HideError, "A Mapping must define the inv_jacobian_component function");
+            return false;
         }
-        if (!CheckClassAttributeExistence<Type, inv_jacobian_12>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the inv_jacobian_12 function");
-        }
-        if (!CheckClassAttributeExistence<Type, inv_jacobian_21>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the inv_jacobian_21 function");
-        }
-        if (!CheckClassAttributeExistence<Type, inv_jacobian_22>::has_attribute) {
-            return std::make_tuple(false, "A 2D Mapping must define the inv_jacobian_22 function");
-        }
-        return std::make_tuple(true, "");
+        return true;
     }
 
-    static std::tuple<bool, const char*> constexpr has_2d_inv_jacobian()
+    static bool constexpr has_inv_jacobian()
     {
-        constexpr std::tuple<bool, const char*> success = has_2d_inv_jacobian_methods();
-        if constexpr (std::get<bool>(success)) {
-            if (!std::is_invocable_v<decltype(&Type::inv_jacobian_matrix), Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The inv_jacobian_matrix method of a 2D Mapping must take a Coordinate as "
-                        "an argument and return a Tensor.");
+        static_assert(mapping_detail::IsMapping<Type>::value);
+        constexpr bool success = has_inv_jacobian_methods();
+        if constexpr (success) {
+            using ResultBasisCov
+                    = get_covariant_dims_t<ddc::to_type_seq_t<typename Type::CoordResult>>;
+            using ArgBasis = get_contravariant_dims_t<ddc::to_type_seq_t<typename Type::CoordArg>>;
+            if constexpr (!std::is_invocable_r_v<
+                                  DTensor<ArgBasis, ResultBasisCov>,
+                                  decltype(&Type::inv_jacobian_matrix),
+                                  Type,
+                                  CoordinateType>) {
+                static_assert(
+                        HideError,
+                        "The inv_jacobian_matrix method of a Mapping must take a Coordinate as an "
+                        "argument and return a Tensor.");
+                return false;
             }
-            if (!std::is_invocable_r_v<double, inv_jacobian_11<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The inv_jacobian_11 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
+            if constexpr (!std::is_invocable_r_v<
+                                  double,
+                                  inv_jacobian_component<Type>,
+                                  Type,
+                                  CoordinateType>) {
+                static_assert(
+                        HideError,
+                        "The inv_jacobian_component method of a Mapping must take a Coordinate as "
+                        "an argument and return a double.");
+                return false;
             }
-            if (!std::is_invocable_r_v<double, inv_jacobian_12<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The inv_jacobian_12 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            if (!std::is_invocable_r_v<double, inv_jacobian_21<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The inv_jacobian_21 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            if (!std::is_invocable_r_v<double, inv_jacobian_22<Type>, Type, CoordinateType>) {
-                return std::make_tuple(
-                        false,
-                        "The inv_jacobian_22 method of a 2D Mapping must take a Coordinate as an "
-                        "argument and return a double.");
-            }
-            return std::make_tuple(true, "");
+            return true;
         }
         return success;
     }
 
-    static constexpr std::tuple<bool, const char*> has_2d_inv_jacobian_output
-            = has_2d_inv_jacobian();
-
 public:
-    /// True if the type describes a 2d mapping, false otherwise
-    static constexpr bool value = std::get<bool>(has_2d_inv_jacobian_output);
-    /// A string containing any explanation for why the type is not an inverse jacobian (for debugging)
-    static constexpr const char* error_msg = std::get<const char*>(has_2d_inv_jacobian_output);
+    /// True if the type describes a mapping with an inverse jacobian, false otherwise
+    static constexpr bool value = has_inv_jacobian();
 };
 
 template <class Mapping>
@@ -305,13 +254,13 @@ static constexpr bool is_accessible_v = mapping_detail::
 template <class Mapping>
 static constexpr bool is_mapping_v = mapping_detail::IsMapping<Mapping>::value;
 
-template <class Mapping, class CoordinateType>
-static constexpr bool has_2d_jacobian_v
-        = mapping_detail::Defines2DJacobian<Mapping, CoordinateType>::value;
+template <class Mapping, class CoordinateType, bool RaiseError = true>
+static constexpr bool has_jacobian_v
+        = mapping_detail::DefinesJacobian<Mapping, CoordinateType, !RaiseError>::value;
 
-template <class Mapping, class CoordinateType>
-static constexpr bool has_2d_inv_jacobian_v
-        = mapping_detail::Defines2DInvJacobian<Mapping, CoordinateType>::value;
+template <class Mapping, class CoordinateType, bool RaiseError = true>
+static constexpr bool has_inv_jacobian_v
+        = mapping_detail::DefinesInvJacobian<Mapping, CoordinateType, !RaiseError>::value;
 
 template <class Mapping>
 static constexpr bool is_curvilinear_2d_mapping_v = mapping_detail::IsCurvilinear2DMapping<

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -19,7 +19,7 @@ template <class Mapping, class PositionCoordinate = typename Mapping::CoordArg>
 class MetricTensorEvaluator
 {
     static_assert(is_mapping_v<Mapping>);
-    static_assert(has_2d_jacobian_v<Mapping, PositionCoordinate>);
+    static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
 
     using Dims = ddc::to_type_seq_t<typename Mapping::CoordArg>;
     using Dims_cov = vector_index_set_dual_t<Dims>;

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -330,7 +330,7 @@ public:
                   ddc::discrete_space<PolarBSplinesRTheta>().nbasis()
                           - ddc::discrete_space<BSplinesTheta>().nbasis())
     {
-        static_assert(has_2d_jacobian_v<Mapping, CoordRTheta>);
+        static_assert(has_jacobian_v<Mapping, CoordRTheta>);
         //initialise x_init
         Kokkos::deep_copy(m_x_init, 0);
         // Get break points

--- a/src/quadrature/volume_quadrature_nd.hpp
+++ b/src/quadrature/volume_quadrature_nd.hpp
@@ -52,7 +52,7 @@ DFieldMem<IdxRangeCoeffs, typename ExecSpace::memory_space> compute_coeffs_on_ma
     using R = typename Mapping::curvilinear_tag_r;
     using Theta = typename Mapping::curvilinear_tag_theta;
 
-    static_assert(has_2d_jacobian_v<Mapping, Coord<R, Theta>>);
+    static_assert(has_jacobian_v<Mapping, Coord<R, Theta>>);
 
     using IdxCoeffs = typename IdxRangeCoeffs::discrete_element_type;
     IdxRangeCoeffs grid = get_idx_range(coefficients_alloc);

--- a/tests/mapping/CMakeLists.txt
+++ b/tests/mapping/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(unit_tests_mapping
     mapping_execution_space_access.cpp
     mapping_jacobian.cpp
     mapping_jacobian_matrix_coef.cpp
+    mapping_static_properties.cpp
     metric_tensor_evaluator.cpp
     pseudo_cartesian_jacobian_matrix.cpp
     refined_discrete_mapping.cpp

--- a/tests/mapping/CMakeLists.txt
+++ b/tests/mapping/CMakeLists.txt
@@ -1,88 +1,20 @@
 include(GoogleTest)
 
-add_executable(metric_tensor_tests_sll
-    ../main.cpp
-    metric_tensor_evaluator.cpp
-)
-target_compile_features(metric_tensor_tests_sll PUBLIC cxx_std_17)
-target_link_libraries(metric_tensor_tests_sll
-    PUBLIC
-        GTest::gtest
-        GTest::gmock
-        gslx::mapping
-        gslx::utils
-)
-gtest_discover_tests(metric_tensor_tests_sll DISCOVERY_MODE PRE_TEST)
-
-add_executable(jacobian_mapping_tests_sll
-    ../main.cpp
-    mapping_jacobian.cpp
-)
-target_compile_features(jacobian_mapping_tests_sll PUBLIC cxx_std_17)
-target_link_libraries(jacobian_mapping_tests_sll
-    PUBLIC
-        GTest::gtest
-        GTest::gmock
-        gslx::mapping
-        gslx::math_tools
-        gslx::utils
-)
-gtest_discover_tests(jacobian_mapping_tests_sll DISCOVERY_MODE PRE_TEST)
-
-add_executable(jacobian_mapping_matrix_coef_tests_sll
-    ../main.cpp
-    mapping_jacobian_matrix_coef.cpp
-)
-target_compile_features(jacobian_mapping_matrix_coef_tests_sll PUBLIC cxx_std_17)
-target_link_libraries(jacobian_mapping_matrix_coef_tests_sll
-    PUBLIC
-        GTest::gtest
-        GTest::gmock
-        gslx::mapping
-        gslx::utils
-)
-gtest_discover_tests(jacobian_mapping_matrix_coef_tests_sll DISCOVERY_MODE PRE_TEST)
-
-add_executable(pseudo_cartesian_tests_sll
-    ../main.cpp
-    pseudo_cartesian_jacobian_matrix.cpp
-)
-target_compile_features(pseudo_cartesian_tests_sll PUBLIC cxx_std_17)
-target_link_libraries(pseudo_cartesian_tests_sll
-    PUBLIC
-        GTest::gtest
-        GTest::gmock
-        gslx::mapping
-        gslx::utils
-)
-gtest_discover_tests(pseudo_cartesian_tests_sll DISCOVERY_MODE PRE_TEST)
-
-add_executable(refined_discrete_mapping_test
-    ../main.cpp
-    refined_discrete_mapping.cpp
-)
-target_compile_features(refined_discrete_mapping_test PUBLIC cxx_std_17)
-target_link_libraries(refined_discrete_mapping_test
-    PUBLIC
-        GTest::gtest
-        GTest::gmock
-        gslx::mapping
-        gslx::utils
-)
-gtest_discover_tests(refined_discrete_mapping_test DISCOVERY_MODE PRE_TEST)
-
-add_executable(mapping_execution_space_access
+add_executable(unit_tests_mapping
     ../main.cpp
     mapping_execution_space_access.cpp
+    mapping_jacobian.cpp
+    mapping_jacobian_matrix_coef.cpp
+    metric_tensor_evaluator.cpp
+    pseudo_cartesian_jacobian_matrix.cpp
+    refined_discrete_mapping.cpp
 )
-target_compile_features(mapping_execution_space_access PUBLIC cxx_std_17)
-target_link_libraries(mapping_execution_space_access
+target_compile_features(unit_tests_mapping PUBLIC cxx_std_17)
+target_link_libraries(unit_tests_mapping
     PUBLIC
         GTest::gtest
         GTest::gmock
         gslx::mapping
         gslx::utils
 )
-gtest_discover_tests(mapping_execution_space_access DISCOVERY_MODE PRE_TEST)
-
-
+gtest_discover_tests(unit_tests_mapping DISCOVERY_MODE PRE_TEST)

--- a/tests/mapping/mapping_jacobian.cpp
+++ b/tests/mapping/mapping_jacobian.cpp
@@ -35,7 +35,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixCircMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_2d_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix
@@ -56,8 +56,8 @@ TEST_P(InvJacobianMatrix, InverseMatrixCzarMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_2d_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
-    static_assert(has_2d_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
@@ -112,7 +112,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixDiscCzarMap)
                     evaluator);
     DiscreteToCartesian mapping = mapping_builder();
 
-    static_assert(has_2d_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix

--- a/tests/mapping/mapping_jacobian_matrix_coef.cpp
+++ b/tests/mapping/mapping_jacobian_matrix_coef.cpp
@@ -36,8 +36,8 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixCircMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_2d_jacobian_v<decltype(mapping), CoordRTheta>);
-    static_assert(has_2d_inv_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_inv_jacobian_v<decltype(mapping), CoordRTheta>);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions
     //are the same as the coefficients in the matrix function.
@@ -87,7 +87,7 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixCzarMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_2d_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions
     //are the same as the coefficients in the matrix function.
@@ -175,7 +175,7 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixDiscCzarMap)
                     evaluator);
     DiscreteToCartesian mapping = mapping_builder();
 
-    static_assert(has_2d_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include "barycentric_to_cartesian.hpp"
+#include "cartesian_to_barycentric.hpp"
+#include "cartesian_to_circular.hpp"
+#include "cartesian_to_czarny.hpp"
+#include "circular_to_cartesian.hpp"
+#include "combined_mapping.hpp"
+#include "czarny_to_cartesian.hpp"
+#include "discrete_to_cartesian.hpp"
+#include "geometry_mapping_tests.hpp"
+#include "mapping_tools.hpp"
+
+
+TEST(MappingStaticAsserts, CirctoCart)
+{
+    static_assert(is_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
+    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(is_curvilinear_2d_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
+    static_assert(is_analytical_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
+    static_assert(has_singular_o_point_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
+}
+
+TEST(MappingStaticAsserts, CartToCirc)
+{
+    static_assert(is_mapping_v<CartesianToCircular<X, Y, R, Theta>>);
+    static_assert(has_jacobian_v<CartesianToCircular<X, Y, R, Theta>, CoordXY>);
+    static_assert(is_analytical_mapping_v<CartesianToCircular<X, Y, R, Theta>>);
+}
+
+
+TEST(MappingStaticAsserts, CzarnytoCart)
+{
+    static_assert(is_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(is_curvilinear_2d_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(is_analytical_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(has_singular_o_point_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
+}
+
+TEST(MappingStaticAsserts, CartToCzarny)
+{
+    static_assert(is_mapping_v<CartesianToCzarny<X, Y, R, Theta>>);
+    static_assert(is_analytical_mapping_v<CartesianToCzarny<X, Y, R, Theta>>);
+}
+
+TEST(MappingStaticAsserts, DiscToCart)
+{
+    using Mapping = DiscreteToCartesian<X, Y, SplineRThetaEvaluator_host>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(is_curvilinear_2d_mapping_v<Mapping>);
+    static_assert(!is_analytical_mapping_v<Mapping>);
+    static_assert(has_singular_o_point_inv_jacobian_v<Mapping>);
+}
+
+TEST(MappingStaticAsserts, CombinedMapping)
+{
+    using Mapping = CombinedMapping<
+            CircularToCartesian<R, Theta, X, Y>,
+            CartesianToCzarny<X, Y, R, Theta>>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(has_inv_jacobian_v<Mapping, CoordRTheta>);
+}
+
+TEST(MappingStaticAsserts, BarycentricToCart)
+{
+    struct Corner1;
+    struct Corner2;
+    struct Corner3;
+    using Mapping = BarycentricToCartesian<Corner1, Corner2, Corner3, X, Y>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(is_analytical_mapping_v<Mapping>);
+}
+
+TEST(MappingStaticAsserts, CartToBarycentric)
+{
+    struct Corner1;
+    struct Corner2;
+    struct Corner3;
+    using Mapping = CartesianToBarycentric<X, Y, Corner1, Corner2, Corner3>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(is_analytical_mapping_v<Mapping>);
+}

--- a/tests/mapping/refined_discrete_mapping.cpp
+++ b/tests/mapping/refined_discrete_mapping.cpp
@@ -185,7 +185,7 @@ double check_Jacobian_on_grid(
         Mapping const& analytical_mapping,
         IdxRangeRTheta const& idx_range)
 {
-    static_assert(has_2d_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
     double max_err = 0.;
     ddc::for_each(idx_range, [&](IdxRTheta const irtheta) {
         const CoordRTheta coord(ddc::coordinate(irtheta));


### PR DESCRIPTION
Add a `mapping_static_properties.cpp` test for mappings to ensure that they correctly implement the expected properties. This shows that the jacobian methods for `CartesianToCircular` were incorrectly implemented in #213. The indices are fixed. Additionally the missing property is added to `BarycentricToCartesian` to show that it is an analytically invertible mapping.


To merge after #241 