### PR TITLE
Add a fence before communication

### DIFF
--- a/src/geometryXYVxVy/poisson/mpichargedensitycalculator.cpp
+++ b/src/geometryXYVxVy/poisson/mpichargedensitycalculator.cpp
@@ -25,6 +25,8 @@ void MpiChargeDensityCalculator::operator()(DFieldXY rho, DConstFieldSpVxVyXY al
 
     m_local_charge_density_calculator(rho_local, allfdistribu);
 
+    Kokkos::DefaultExecutionSpace().fence("Fence local ChargeDensityCalculator");
+
     MPI_Allreduce(
             rho_local.data_handle(),
             rho.data_handle(),


### PR DESCRIPTION
Correct me if I am wrong, I don't think we promise a that `rho_local` is ready after calling `m_local_charge_density_calculator`. This can lead to a race condition between an asynchronous backend and the MPI communication. I think we need to add a fence before `MPI_Allreduce`.

Note that it should not affect the benchmark results done with Kokkos Tools as regions will block.