### PR TITLE
Correct cartesian to circular equations

### DIFF
--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -116,7 +116,9 @@ public:
         const double x = ddc::get<X>(coord);
         const double y = ddc::get<Y>(coord);
         const double r = Kokkos::sqrt(x * x + y * y);
-        const double theta = Kokkos::fmod(Kokkos::atan2(y, x), 2 * M_PI);
+        const double theta_pi_to_pi(Kokkos::atan2(y, x));
+        const double theta = theta_pi_to_pi * (theta_pi_to_pi >= 0)
+                             + (theta_pi_to_pi + 2 * M_PI) * (theta_pi_to_pi < 0);
         return Coord<R, Theta>(r, theta);
     }
 

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -25,15 +25,15 @@ class CircularToCartesian;
  *
  * The Jacobian matrix coefficients are defined as follow
  *
- * @f$ J_{11}(x,y)  =\frac{2x}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{11}(x,y)  =\frac{x}{\sqrt{x^2+y^2}}  @f$
  *
- * @f$ J_{12}(x,y)  =\frac{2y}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{12}(x,y)  =\frac{y}{\sqrt{x^2+y^2}}  @f$
  *
- * @f$ J_{21}(x,y)  =\frac{-y}{(x^2+y^2)^2}  @f$
+ * @f$ J_{21}(x,y)  =\frac{-y}{x^2+y^2}  @f$
  *
- * @f$ J_{22}(x,y)  =\frac{x}{(x^2+y^2)^2}  @f$
+ * @f$ J_{22}(x,y)  =\frac{x}{x^2+y^2}  @f$
  *
- * and the matrix determinant: @f$ det(J) = r @f$.
+ * and the matrix determinant: @f$ det(J) = 1/(x^2+y^2) @f$.
  *
  */
 template <class X, class Y, class R, class Theta>
@@ -132,7 +132,7 @@ public:
     {
         const double x = ddc::get<X>(coord);
         const double y = ddc::get<Y>(coord);
-        return 2. * (x * x - y * y) / Kokkos::pow(x * x + y * y, 1.5);
+        return 1. / Kokkos::sqrt(x * x + y * y);
     }
 
     /**
@@ -153,10 +153,12 @@ public:
         const double x = ddc::get<X>(coord);
         const double y = ddc::get<Y>(coord);
         DTensor<VectorIndexSet<R, Theta>, VectorIndexSet<X_cov, Y_cov>> jacobian_matrix;
-        ddcHelper::get<R, X_cov>(jacobian_matrix) = 2 * x / Kokkos::pow(x * x + y * y, 0.5);
-        ddcHelper::get<R, Y_cov>(jacobian_matrix) = 2 * y / Kokkos::pow(x * x + y * y, 0.5);
-        ddcHelper::get<Theta, X_cov>(jacobian_matrix) = -y / Kokkos::pow(x * x + y * y, 2.);
-        ddcHelper::get<Theta, Y_cov>(jacobian_matrix) = x / Kokkos::pow(x * x + y * y, 2.);
+        const double r2 = x * x + y * y;
+        const double r = Kokkos::sqrt(r2);
+        ddcHelper::get<R, X_cov>(jacobian_matrix) = x / r;
+        ddcHelper::get<R, Y_cov>(jacobian_matrix) = y / r;
+        ddcHelper::get<Theta, X_cov>(jacobian_matrix) = -y / r2;
+        ddcHelper::get<Theta, Y_cov>(jacobian_matrix) = x / r2;
         return jacobian_matrix;
     }
 
@@ -178,16 +180,16 @@ public:
         const double y = ddc::get<Y>(coord);
         if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, X_cov>) {
             // Component (1,1), i.e dr/dx
-            return 2 * x / Kokkos::pow(x * x + y * y, 0.5);
+            return x / Kokkos::pow(x * x + y * y, 0.5);
         } else if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, Y_cov>) {
             // Component (1,2), i.e dr/dy
-            return 2 * y / Kokkos::pow(x * x + y * y, 0.5);
+            return y / Kokkos::pow(x * x + y * y, 0.5);
         } else if constexpr (std::is_same_v<IndexTag1, Theta> && std::is_same_v<IndexTag2, X_cov>) {
             // Component (2,1), i.e dtheta/dy
-            return -y / Kokkos::pow(x * x + y * y, 2.);
+            return -y / (x * x + y * y);
         } else {
             // Component (2,2), i.e dtheta/dy
-            return x / Kokkos::pow(x * x + y * y, 2.);
+            return x / (x * x + y * y);
         }
     }
 

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -116,7 +116,7 @@ public:
         const double x = ddc::get<X>(coord);
         const double y = ddc::get<Y>(coord);
         const double r = Kokkos::sqrt(x * x + y * y);
-        const double theta = Kokkos::atan2(y, x);
+        const double theta = Kokkos::fmod(Kokkos::atan2(y, x), 2 * M_PI);
         return Coord<R, Theta>(r, theta);
     }
 

--- a/tests/mapping/CMakeLists.txt
+++ b/tests/mapping/CMakeLists.txt
@@ -2,6 +2,7 @@ include(GoogleTest)
 
 add_executable(unit_tests_mapping
     ../main.cpp
+    mapping_analytical_inverse.cpp
     mapping_execution_space_access.cpp
     mapping_jacobian.cpp
     mapping_jacobian_matrix_coef.cpp

--- a/tests/mapping/mapping_analytical_inverse.cpp
+++ b/tests/mapping/mapping_analytical_inverse.cpp
@@ -6,11 +6,12 @@
 
 #include <gtest/gtest.h>
 
-#include "circular_to_cartesian.hpp"
-#include "czarny_to_cartesian.hpp"
 #include "cartesian_to_circular.hpp"
 #include "cartesian_to_czarny.hpp"
+#include "circular_to_cartesian.hpp"
+#include "czarny_to_cartesian.hpp"
 #include "geometry_mapping_tests.hpp"
+#include "math_tools.hpp"
 
 template <class Mapping>
 void test_analytical_inverse(Mapping map)
@@ -40,8 +41,13 @@ void test_analytical_inverse_jacobian(Mapping map)
     CoordRTheta coord_rtheta(double(rand()) / RAND_MAX, double(rand()) / RAND_MAX * 2.0 * M_PI);
     CoordXY coord_xy = map(coord_rtheta);
 
-    check_inverse_tensor(map.jacobian_matrix(coord_rtheta), inv_map.jacobian_matrix(coord_xy), 1e-14);
+    check_inverse_tensor(
+            map.jacobian_matrix(coord_rtheta),
+            inv_map.jacobian_matrix(coord_xy),
+            1e-14);
     EXPECT_NEAR(map.jacobian(coord_rtheta) * inv_map.jacobian(coord_xy), 1.0, 1e-14);
+    EXPECT_NEAR(map.jacobian(coord_rtheta), determinant(map.jacobian_matrix(coord_rtheta)), 1e-14);
+    EXPECT_NEAR(inv_map.jacobian(coord_xy), determinant(inv_map.jacobian_matrix(coord_xy)), 1e-14);
 }
 
 TEST(AnalyticalMappingTests, Circular)

--- a/tests/mapping/mapping_analytical_inverse.cpp
+++ b/tests/mapping/mapping_analytical_inverse.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+#include <cstdlib>
+#include <ctime>
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "circular_to_cartesian.hpp"
+#include "czarny_to_cartesian.hpp"
+#include "cartesian_to_circular.hpp"
+#include "cartesian_to_czarny.hpp"
+#include "geometry_mapping_tests.hpp"
+
+template <class Mapping>
+void test_analytical_inverse(Mapping map)
+{
+    static_assert(is_analytical_mapping_v<Mapping>);
+    using InverseMapping = inverse_mapping_t<Mapping>;
+    InverseMapping inv_map = map.get_inverse_mapping();
+    std::srand(std::time(nullptr)); // Seed with random value (the time)
+
+    // Choose a theta value with no chance of a modulo issue
+    CoordRTheta
+    coord_start(double(rand()) / RAND_MAX, double(rand()) / RAND_MAX * M_PI + M_PI * 0.5);
+    CoordXY coord_xy = map(coord_start);
+    CoordRTheta coord_end = inv_map(coord_xy);
+    EXPECT_NEAR(ddc::get<R>(coord_start), ddc::get<R>(coord_end), 1e-14);
+    EXPECT_NEAR(ddc::get<Theta>(coord_start), ddc::get<Theta>(coord_end), 1e-14);
+}
+
+template <class Mapping>
+void test_analytical_inverse_jacobian(Mapping map)
+{
+    static_assert(is_analytical_mapping_v<Mapping>);
+    using InverseMapping = inverse_mapping_t<Mapping>;
+    InverseMapping inv_map = map.get_inverse_mapping();
+    std::srand(std::time(nullptr)); // Seed with random value (the time)
+
+    CoordRTheta coord_rtheta(double(rand()) / RAND_MAX, double(rand()) / RAND_MAX * 2.0 * M_PI);
+    CoordXY coord_xy = map(coord_rtheta);
+
+    check_inverse_tensor(map.jacobian_matrix(coord_rtheta), inv_map.jacobian_matrix(coord_xy), 1e-14);
+    EXPECT_NEAR(map.jacobian(coord_rtheta) * inv_map.jacobian(coord_xy), 1.0, 1e-14);
+}
+
+TEST(AnalyticalMappingTests, Circular)
+{
+    CircularToCartesian<R, Theta, X, Y> mapping;
+    test_analytical_inverse(mapping);
+    test_analytical_inverse_jacobian(mapping);
+}
+
+TEST(AnalyticalMappingTests, Czarny)
+{
+    CzarnyToCartesian<R, Theta, X, Y> mapping(0.3, 0.4);
+    test_analytical_inverse(mapping);
+}

--- a/tests/mapping/mapping_analytical_inverse.cpp
+++ b/tests/mapping/mapping_analytical_inverse.cpp
@@ -26,8 +26,8 @@ void test_analytical_inverse(Mapping map)
     coord_start(double(rand()) / RAND_MAX, double(rand()) / RAND_MAX * M_PI + M_PI * 0.5);
     CoordXY coord_xy = map(coord_start);
     CoordRTheta coord_end = inv_map(coord_xy);
-    EXPECT_NEAR(ddc::get<R>(coord_start), ddc::get<R>(coord_end), 1e-14);
-    EXPECT_NEAR(ddc::get<Theta>(coord_start), ddc::get<Theta>(coord_end), 1e-14);
+    EXPECT_NEAR(ddc::get<R>(coord_start), ddc::get<R>(coord_end), 1e-13);
+    EXPECT_NEAR(ddc::get<Theta>(coord_start), ddc::get<Theta>(coord_end), 1e-13);
 }
 
 template <class Mapping>
@@ -45,9 +45,9 @@ void test_analytical_inverse_jacobian(Mapping map)
             map.jacobian_matrix(coord_rtheta),
             inv_map.jacobian_matrix(coord_xy),
             1e-14);
-    EXPECT_NEAR(map.jacobian(coord_rtheta) * inv_map.jacobian(coord_xy), 1.0, 1e-14);
-    EXPECT_NEAR(map.jacobian(coord_rtheta), determinant(map.jacobian_matrix(coord_rtheta)), 1e-14);
-    EXPECT_NEAR(inv_map.jacobian(coord_xy), determinant(inv_map.jacobian_matrix(coord_xy)), 1e-14);
+    EXPECT_NEAR(map.jacobian(coord_rtheta) * inv_map.jacobian(coord_xy), 1.0, 1e-13);
+    EXPECT_NEAR(map.jacobian(coord_rtheta), determinant(map.jacobian_matrix(coord_rtheta)), 1e-13);
+    EXPECT_NEAR(inv_map.jacobian(coord_xy), determinant(inv_map.jacobian_matrix(coord_xy)), 1e-13);
 }
 
 TEST(AnalyticalMappingTests, Circular)

--- a/tests/mapping/mapping_jacobian.cpp
+++ b/tests/mapping/mapping_jacobian.cpp
@@ -1,6 +1,4 @@
-#include <array>
-#include <cassert>
-
+// SPDX-License-Identifier: MIT
 #include <ddc/ddc.hpp>
 
 #include <gtest/gtest.h>

--- a/tests/mapping/mapping_jacobian_matrix_coef.cpp
+++ b/tests/mapping/mapping_jacobian_matrix_coef.cpp
@@ -106,6 +106,7 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixCzarMap)
                 = mapping.template jacobian_component<Y, Theta_cov>(coords(irtheta));
 
         EXPECT_TRUE(Jacobian_matrix == Jacobian_matrix_coeff);
+        EXPECT_NEAR(determinant(Jacobian_matrix), mapping.jacobian(coords(irtheta)), 1e-14);
     });
 
     InverseJacobianMatrix inv_jacobian(mapping);


### PR DESCRIPTION
Correct the equations for the cartesian to circular mapping and add tests for analytical inverses.

- All calculations associated with the Jacobian matrix were incorrect
- The theta component of the transformation was not provided in the expected range (0, 2pi)