### PR TITLE
Increase timeout for polar Poisson tests

### DIFF
--- a/tests/geometryRTheta/polar_poisson/CMakeLists.txt
+++ b/tests/geometryRTheta/polar_poisson/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(MAPPING_TYPE "CIRCULAR_MAPPING" "CZARNY_MAPPING")
     add_test(NAME TestPoissonConvergence_${MAPPING_TYPE}_${SOLUTION}
         COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/test_poisson.py"
             "$<TARGET_FILE:${test_name}>")
-    set_property(TEST TestPoissonConvergence_${MAPPING_TYPE}_${SOLUTION} PROPERTY TIMEOUT 300)
+    set_property(TEST TestPoissonConvergence_${MAPPING_TYPE}_${SOLUTION} PROPERTY TIMEOUT 400)
     set_property(TEST TestPoissonConvergence_${MAPPING_TYPE}_${SOLUTION} PROPERTY COST 100)
   endforeach()
 endforeach()


### PR DESCRIPTION
Increase timeout for polar Poisson tests. A larger timeout is needed when running with coverage flags as this slows the execution. Fixes #166 