### PR TITLE
Add x0 and y0 parameters to circular and czarny coordinate change operators

### DIFF
--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -38,7 +38,7 @@ runs:
       echo "CHANGED_FILES=${changed_files}" >> $GITHUB_ENV
       FOUND_POLAR_SPLINES=$(grep "src/interpolation/polar_splines/.*" -x changed_files.txt || true)
       if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> build.env; echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV; fi
-      FOUND_POISSON_2D=$(grep "src/geometryRTheta/poisson/.*" -x changed_files.txt || true)
+      FOUND_POISSON_2D=$(grep -P "(src/geometryRTheta/poisson/.*)|(tests/geometryRTheta/polar_poisson/.*)" -x changed_files.txt || true)
       if [ -z "$FOUND_POISSON_2D" ]; then echo "POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "POISSON_2D_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
       FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
       if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "DDC_BUILD_TESTING=ON" >> $GITHUB_ENV; fi

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -68,6 +68,12 @@ private:
     double m_y0;
 
 public:
+    /**
+     * @brief Instantiate a CartesianToCircular from parameters.
+     *
+     * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
+     * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
+     */
     CartesianToCircular(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -17,23 +17,23 @@ class CircularToCartesian;
  *
  * The mapping @f$ (x,y)\mapsto (r,\theta) @f$ is defined as follow :
  *
- * @f$ r(x,y) = \sqrt x^2+y^2 ,@f$
+ * @f$ r(x,y) = \sqrt (x-x_0)^2+(y-y_0)^2 ,@f$
  *
- * @f$ \theta(x,y) = atan2(\frac{y}{x}) .@f$
+ * @f$ \theta(x,y) = atan2(\frac{y-y_0}{x-x_0}) .@f$
  *
  * It and its Jacobian matrix are invertible everywhere except for @f$ r = 0 @f$.
  *
  * The Jacobian matrix coefficients are defined as follow
  *
- * @f$ J_{11}(x,y)  =\frac{x}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{11}(x,y)  =\frac{x-x_0}{\sqrt{(x-x_0)^2+(y-y_0)^2}}  @f$
  *
- * @f$ J_{12}(x,y)  =\frac{y}{\sqrt{x^2+y^2}}  @f$
+ * @f$ J_{12}(x,y)  =\frac{y-y_0}{\sqrt{(x-x_0)^2+(y-y_0)^2}}  @f$
  *
- * @f$ J_{21}(x,y)  =\frac{-y}{x^2+y^2}  @f$
+ * @f$ J_{21}(x,y)  =\frac{-(y-y_0)}{(x-x_0)^2+(y-y_0)^2}  @f$
  *
- * @f$ J_{22}(x,y)  =\frac{x}{x^2+y^2}  @f$
+ * @f$ J_{22}(x,y)  =\frac{x-x_0}{(x-x_0)^2+(y-y_0)^2}  @f$
  *
- * and the matrix determinant: @f$ det(J) = 1/(x^2+y^2) @f$.
+ * and the matrix determinant: @f$ det(J) = 1/((x-x_0)^2+(y-y_0)^2) @f$.
  *
  */
 template <class X, class Y, class R, class Theta>
@@ -63,8 +63,12 @@ public:
     /// @brief The covariant form of the second logical coordinate.
     using Theta_cov = typename Theta::Dual;
 
+private:
+    double m_x0;
+    double m_y0;
+
 public:
-    CartesianToCircular() = default;
+    CartesianToCircular(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**
      * @brief Instantiate a CartesianToCircular from another CartesianToCircular (lvalue).
@@ -72,7 +76,7 @@ public:
      * @param[in] other
      * 		CartesianToCircular mapping used to instantiate the new one.
      */
-    KOKKOS_FUNCTION CartesianToCircular(CartesianToCircular const& other) {}
+    KOKKOS_DEFAULTED_FUNCTION CartesianToCircular(CartesianToCircular const& other) = default;
 
     /**
      * @brief Instantiate a Curvilinear2DToCartesian from another temporary CartesianToCircular (rvalue).
@@ -82,7 +86,7 @@ public:
      */
     CartesianToCircular(CartesianToCircular&& x) = default;
 
-    ~CartesianToCircular() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~CartesianToCircular() = default;
 
     /**
      * @brief Assign a CartesianToCircular from another CartesianToCircular (lvalue).
@@ -113,8 +117,8 @@ public:
      */
     KOKKOS_FUNCTION Coord<R, Theta> operator()(Coord<X, Y> const& coord) const
     {
-        const double x = ddc::get<X>(coord);
-        const double y = ddc::get<Y>(coord);
+        const double x = ddc::get<X>(coord) - m_x0;
+        const double y = ddc::get<Y>(coord) - m_y0;
         const double r = Kokkos::sqrt(x * x + y * y);
         const double theta_pi_to_pi(Kokkos::atan2(y, x));
         const double theta = theta_pi_to_pi * (theta_pi_to_pi >= 0)
@@ -132,8 +136,8 @@ public:
      */
     KOKKOS_FUNCTION double jacobian(Coord<X, Y> const& coord)
     {
-        const double x = ddc::get<X>(coord);
-        const double y = ddc::get<Y>(coord);
+        const double x = ddc::get<X>(coord) - m_x0;
+        const double y = ddc::get<Y>(coord) - m_y0;
         return 1. / Kokkos::sqrt(x * x + y * y);
     }
 
@@ -152,8 +156,8 @@ public:
             Coord<X, Y> const& coord) const
 
     {
-        const double x = ddc::get<X>(coord);
-        const double y = ddc::get<Y>(coord);
+        const double x = ddc::get<X>(coord) - m_x0;
+        const double y = ddc::get<Y>(coord) - m_y0;
         DTensor<VectorIndexSet<R, Theta>, VectorIndexSet<X_cov, Y_cov>> jacobian_matrix;
         const double r2 = x * x + y * y;
         const double r = Kokkos::sqrt(r2);
@@ -178,8 +182,8 @@ public:
         static_assert(ddc::in_tags_v<IndexTag1, VectorIndexSet<R, Theta>>);
         static_assert(ddc::in_tags_v<IndexTag2, VectorIndexSet<X_cov, Y_cov>>);
 
-        const double x = ddc::get<X>(coord);
-        const double y = ddc::get<Y>(coord);
+        const double x = ddc::get<X>(coord) - m_x0;
+        const double y = ddc::get<Y>(coord) - m_y0;
         if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, X_cov>) {
             // Component (1,1), i.e dr/dx
             return x / Kokkos::pow(x * x + y * y, 0.5);
@@ -202,7 +206,7 @@ public:
      */
     CircularToCartesian<R, Theta, X, Y> get_inverse_mapping() const
     {
-        return CircularToCartesian<R, Theta, X, Y>();
+        return CircularToCartesian<R, Theta, X, Y>(m_x0, m_y0);
     }
 };
 

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -74,7 +74,7 @@ public:
      * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
      * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
      */
-    CartesianToCircular(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
+    explicit CartesianToCircular(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**
      * @brief Instantiate a CartesianToCircular from another CartesianToCircular (lvalue).

--- a/src/mapping/cartesian_to_czarny.hpp
+++ b/src/mapping/cartesian_to_czarny.hpp
@@ -59,7 +59,7 @@ public:
      *
      * @see CartesianToCzarny
      */
-    CartesianToCzarny(double epsilon, double e, double x0 = 0.0, double y0 = 0.0)
+    explicit CartesianToCzarny(double epsilon, double e, double x0 = 0.0, double y0 = 0.0)
         : m_epsilon(epsilon)
         , m_e(e)
         , m_x0(x0)

--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -71,6 +71,12 @@ private:
     double m_y0;
 
 public:
+    /**
+     * @brief Instantiate a CircularToCartesian from parameters.
+     *
+     * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
+     * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
+     */
     CircularToCartesian(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**

--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -77,7 +77,7 @@ public:
      * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
      * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
      */
-    CircularToCartesian(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
+    explicit CircularToCartesian(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**
      * @brief Instantiate a CircularToCartesian from another CircularToCartesian (lvalue).

--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -20,9 +20,9 @@ class CartesianToCircular;
  *
  * The mapping @f$ (r,\theta)\mapsto (x,y) @f$ is defined as follow :
  *
- * @f$ x(r,\theta) = r \cos(\theta),@f$
+ * @f$ x(r,\theta) = r \cos(\theta) + x_0,@f$
  *
- * @f$ y(r,\theta) = r \sin(\theta).@f$
+ * @f$ y(r,\theta) = r \sin(\theta) + y_0.@f$
  *
  * It and its Jacobian matrix are invertible everywhere except for @f$ r = 0 @f$.
  *
@@ -66,8 +66,12 @@ public:
     /// @brief The covariant form of the second logical coordinate.
     using Theta_cov = typename Theta::Dual;
 
+private:
+    double m_x0;
+    double m_y0;
+
 public:
-    CircularToCartesian() = default;
+    CircularToCartesian(double x0 = 0.0, double y0 = 0.0) : m_x0(x0), m_y0(y0) {}
 
     /**
      * @brief Instantiate a CircularToCartesian from another CircularToCartesian (lvalue).
@@ -75,7 +79,7 @@ public:
      * @param[in] other
      * 		CircularToCartesian mapping used to instantiate the new one.
      */
-    KOKKOS_FUNCTION CircularToCartesian(CircularToCartesian const& other) {}
+    KOKKOS_DEFAULTED_FUNCTION CircularToCartesian(CircularToCartesian const& other) = default;
 
     /**
      * @brief Instantiate a CircularToCartesian from another temporary CircularToCartesian (rvalue).
@@ -85,7 +89,7 @@ public:
      */
     CircularToCartesian(CircularToCartesian&& x) = default;
 
-    ~CircularToCartesian() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~CircularToCartesian() = default;
 
     /**
      * @brief Assign a CircularToCartesian from another CircularToCartesian (lvalue).
@@ -118,8 +122,8 @@ public:
     {
         const double r = ddc::get<R>(coord);
         const double theta = ddc::get<Theta>(coord);
-        const double x = r * Kokkos::cos(theta);
-        const double y = r * Kokkos::sin(theta);
+        const double x = r * Kokkos::cos(theta) + m_x0;
+        const double y = r * Kokkos::sin(theta) + m_y0;
         return Coord<X, Y>(x, y);
     }
 
@@ -267,7 +271,7 @@ public:
      */
     CartesianToCircular<X, Y, R, Theta> get_inverse_mapping() const
     {
-        return CartesianToCircular<X, Y, R, Theta>();
+        return CartesianToCircular<X, Y, R, Theta>(m_x0, m_y0);
     }
 };
 

--- a/src/mapping/czarny_to_cartesian.hpp
+++ b/src/mapping/czarny_to_cartesian.hpp
@@ -92,7 +92,7 @@ public:
      *
      * @see CzarnyToCartesian
      */
-    CzarnyToCartesian(double epsilon, double e, double x0 = 0.0, double y0 = 0.0)
+    explicit CzarnyToCartesian(double epsilon, double e, double x0 = 0.0, double y0 = 0.0)
         : m_epsilon(epsilon)
         , m_e(e)
         , m_x0(x0)

--- a/src/mapping/czarny_to_cartesian.hpp
+++ b/src/mapping/czarny_to_cartesian.hpp
@@ -19,9 +19,9 @@ class CartesianToCzarny;
  *
  * The mapping @f$ (r,\theta)\mapsto (x,y) @f$ is defined by
  *
- * @f$ x(r,\theta) = \frac{1}{\epsilon} \left( 1 - \sqrt{1 + \epsilon(\epsilon + 2 r \cos(\theta))} \right),@f$
+ * @f$ x(r,\theta) = \frac{1}{\epsilon} \left( 1 - \sqrt{1 + \epsilon(\epsilon + 2 r \cos(\theta))} \right) + x_0,@f$
  *
- * @f$ y(r,\theta) = \frac{e\xi r \sin(\theta)}{2 -\sqrt{1 + \epsilon(\epsilon + 2 r \cos(\theta))} },@f$
+ * @f$ y(r,\theta) = \frac{e\xi r \sin(\theta)}{2 -\sqrt{1 + \epsilon(\epsilon + 2 r \cos(\theta))} } + y_0,@f$
  *
  * with @f$ \xi = 1/\sqrt{1 - \epsilon^2 /4} @f$ and @f$ e @f$ and @f$ \epsilon @f$ given as parameters.
  * It and its Jacobian matrix are invertible everywhere except for @f$ r = 0 @f$.
@@ -76,6 +76,8 @@ public:
 private:
     double m_epsilon;
     double m_e;
+    double m_x0;
+    double m_y0;
 
 public:
     /**
@@ -83,13 +85,20 @@ public:
      *
      * @param[in] epsilon
      * 			The @f$ \epsilon @f$ parameter in the definition of the mapping CzarnyToCartesian.
-     *
      * @param[in] e
      * 			The @f$ e @f$ parameter in the definition of the mapping CzarnyToCartesian.
+     * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
+     * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
      *
      * @see CzarnyToCartesian
      */
-    CzarnyToCartesian(double epsilon, double e) : m_epsilon(epsilon), m_e(e) {}
+    CzarnyToCartesian(double epsilon, double e, double x0 = 0.0, double y0 = 0.0)
+        : m_epsilon(epsilon)
+        , m_e(e)
+        , m_x0(x0)
+        , m_y0(y0)
+    {
+    }
 
     /**
      * @brief Instantiate a CzarnyToCartesian from another CzarnyToCartesian (lvalue).
@@ -97,11 +106,7 @@ public:
      * @param[in] other
      * 		CzarnyToCartesian mapping used to instantiate the new one.
      */
-    KOKKOS_FUNCTION CzarnyToCartesian(CzarnyToCartesian const& other)
-        : m_epsilon(other.epsilon())
-        , m_e(other.e())
-    {
-    }
+    KOKKOS_DEFAULTED_FUNCTION CzarnyToCartesian(CzarnyToCartesian const& other) = default;
 
     /**
      * @brief Instantiate a CzarnyToCartesian from another temporary CzarnyToCartesian (rvalue).
@@ -111,7 +116,7 @@ public:
      */
     CzarnyToCartesian(CzarnyToCartesian&& x) = default;
 
-    ~CzarnyToCartesian() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~CzarnyToCartesian() = default;
 
     /**
      * @brief Assign a CzarnyToCartesian from another CzarnyToCartesian (lvalue).
@@ -171,9 +176,10 @@ public:
         const double tmp1
                 = Kokkos::sqrt(m_epsilon * (m_epsilon + 2.0 * r * Kokkos::cos(theta)) + 1.0);
 
-        const double x = (1.0 - tmp1) / m_epsilon;
+        const double x = (1.0 - tmp1) / m_epsilon + m_x0;
         const double y = m_e * r * Kokkos::sin(theta)
-                         / (Kokkos::sqrt(1.0 - 0.25 * m_epsilon * m_epsilon) * (2.0 - tmp1));
+                                 / (Kokkos::sqrt(1.0 - 0.25 * m_epsilon * m_epsilon) * (2.0 - tmp1))
+                         + m_y0;
 
         return Coord<X, Y>(x, y);
     }

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -347,11 +347,12 @@ int main(int argc, char** argv)
 
 
     // SET THE DIFFERENT PARAMETERS OF THE TESTS ------------------------------------------------
-    CircularToCartMapping const from_circ_map(6.2);
-    CircularToPseudoCartMapping const to_pseudo_circ_map(6.2);
-    CartesianToCircular<X, Y, R, Theta> to_circ_map(6.2);
-    CzarnyToCartMapping const from_czarny_map(0.3, 1.4, 6.2);
-    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4, 6.2);
+    // Offset the centre of the circle to ensure that this is correctly handled
+    CircularToCartMapping const from_circ_map(6.2, 0.8);
+    CircularToPseudoCartMapping const to_pseudo_circ_map(6.2, 0.8);
+    CartesianToCircular<X, Y, R, Theta> to_circ_map(6.2, 0.8);
+    CzarnyToCartMapping const from_czarny_map(0.3, 1.4, 6.2, 0.8);
+    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4, 6.2, 0.8);
     DiscreteMappingBuilderHost const discrete_czarny_map_builder_host(
             Kokkos::DefaultHostExecutionSpace(),
             from_czarny_map,

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -347,11 +347,11 @@ int main(int argc, char** argv)
 
 
     // SET THE DIFFERENT PARAMETERS OF THE TESTS ------------------------------------------------
-    CircularToCartMapping const from_circ_map;
-    CircularToPseudoCartMapping const to_pseudo_circ_map;
-    CartesianToCircular<X, Y, R, Theta> to_circ_map;
-    CzarnyToCartMapping const from_czarny_map(0.3, 1.4);
-    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4);
+    CircularToCartMapping const from_circ_map(6.2);
+    CircularToPseudoCartMapping const to_pseudo_circ_map(6.2);
+    CartesianToCircular<X, Y, R, Theta> to_circ_map(6.2);
+    CzarnyToCartMapping const from_czarny_map(0.3, 1.4, 6.2);
+    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4, 6.2);
     DiscreteMappingBuilderHost const discrete_czarny_map_builder_host(
             Kokkos::DefaultHostExecutionSpace(),
             from_czarny_map,

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -105,10 +105,11 @@ int main(int argc, char** argv)
     SplineRThetaBuilder_host const builder_host(grid);
 
     double major_radius = 6.1;
+    double vertical_offset = 0.3;
 #if defined(CIRCULAR_MAPPING)
-    const Mapping mapping(major_radius);
+    const Mapping mapping(major_radius, vertical_offset);
 #elif defined(CZARNY_MAPPING)
-    const Mapping mapping(0.3, 1.4, major_radius);
+    const Mapping mapping(0.3, 1.4, major_radius, vertical_offset);
 #endif
 
     ddc::NullExtrapolationRule bv_r_min;
@@ -193,7 +194,7 @@ int main(int argc, char** argv)
                          .count()
               << "ms" << std::endl;
 
-    LHSFunction lhs(mapping, major_radius, 0.0);
+    LHSFunction lhs(mapping, major_radius, vertical_offset);
     RHSFunction rhs(mapping);
     host_t<FieldMemRTheta<CoordRTheta>> coords(grid);
     DFieldMemRTheta result_alloc(grid);

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -104,11 +104,11 @@ int main(int argc, char** argv)
     SplineRThetaBuilder const builder(grid);
     SplineRThetaBuilder_host const builder_host(grid);
 
-
+    double major_radius = 6.1;
 #if defined(CIRCULAR_MAPPING)
-    const Mapping mapping(4.5);
+    const Mapping mapping(major_radius);
 #elif defined(CZARNY_MAPPING)
-    const Mapping mapping(0.3, 1.4, 6.1);
+    const Mapping mapping(0.3, 1.4, major_radius);
 #endif
 
     ddc::NullExtrapolationRule bv_r_min;
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
                          .count()
               << "ms" << std::endl;
 
-    LHSFunction lhs(mapping);
+    LHSFunction lhs(mapping, major_radius, 0.0);
     RHSFunction rhs(mapping);
     host_t<FieldMemRTheta<CoordRTheta>> coords(grid);
     DFieldMemRTheta result_alloc(grid);

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -106,9 +106,9 @@ int main(int argc, char** argv)
 
 
 #if defined(CIRCULAR_MAPPING)
-    const Mapping mapping;
+    const Mapping mapping(4.5);
 #elif defined(CZARNY_MAPPING)
-    const Mapping mapping(0.3, 1.4);
+    const Mapping mapping(0.3, 1.4, 6.1);
 #endif
 
     ddc::NullExtrapolationRule bv_r_min;

--- a/tests/geometryRTheta/polar_poisson/test_cases.hpp
+++ b/tests/geometryRTheta/polar_poisson/test_cases.hpp
@@ -85,7 +85,10 @@ public:
      *      The mapping function which converts the logical (polar)
      *      coordinates into the physical (Cartesian) coordinates.
      */
-    explicit CurvilinearSolution(CurvilinearToCartesian const& coordinate_converter)
+    explicit CurvilinearSolution(
+            CurvilinearToCartesian const& coordinate_converter,
+            double x0,
+            double y0)
         : PoissonSolution<CurvilinearToCartesian>(coordinate_converter)
     {
     }
@@ -102,7 +105,7 @@ public:
  * @brief Define a Cartesian solution of the Poisson equation.
  *
  * The solution is given by
- * * @f$ \phi (x,y) = C (1+r(x,y))^6  (1 - r(x,y))^6 \cos(2\pi x) \sin(2\pi y) @f$,
+ * * @f$ \phi (x,y) = C (1+r(x,y))^6  (1 - r(x,y))^6 \cos(2\pi x-x0) \sin(2\pi y-y0) @f$,
  *
  * with @f$C = 2^{12}1e-4 @f$.
  *
@@ -119,6 +122,8 @@ class CartesianSolution : public PoissonSolution<CurvilinearToCartesian>
 {
 private:
     InverseJacobianMatrix<CurvilinearToCartesian, Coord<R, Theta>> m_inverse_jacobian;
+    double m_x0;
+    double m_y0;
 
 public:
     /**
@@ -128,9 +133,14 @@ public:
      *      The mapping function which converts the logical (polar)
      *      coordinates into the physical (Cartesian) coordinates.
      */
-    explicit CartesianSolution(CurvilinearToCartesian const& coordinate_converter)
+    explicit CartesianSolution(
+            CurvilinearToCartesian const& coordinate_converter,
+            double x0,
+            double y0)
         : PoissonSolution<CurvilinearToCartesian>(coordinate_converter)
         , m_inverse_jacobian(coordinate_converter)
+        , m_x0(x0)
+        , m_y0(y0)
     {
     }
 
@@ -139,8 +149,8 @@ public:
         const double s = ddc::get<R>(coord);
         const Coord<X, Y> cart_coord
                 = PoissonSolution<CurvilinearToCartesian>::m_coordinate_converter(coord);
-        const double x = ddc::get<X>(cart_coord);
-        const double y = ddc::get<Y>(cart_coord);
+        const double x = ddc::get<X>(cart_coord) - m_x0;
+        const double y = ddc::get<Y>(cart_coord) - m_y0;
         return 1e-4 * ipow(1 + s, 6) * ipow(1 - s, 6) * std::cos(2 * M_PI * x)
                * std::sin(2 * M_PI * y) / ipow(0.5, 12);
     }


### PR DESCRIPTION
Add x0 and y0 parameters to circular and czarny coordinate change operators. Fixes #271 