### PR TITLE
Improve docker build trigger

### DIFF
--- a/.github/actions/changed_files/action.yml
+++ b/.github/actions/changed_files/action.yml
@@ -5,12 +5,14 @@ runs:
   steps:
     - if: github.event_name == 'pull_request'
       run: |
+        git config --global --add safe.directory $(pwd)
+        git fetch --no-recurse-submodules origin ${{ github.event.pull_request.base.sha }}
         git diff --name-only ${{ github.event.pull_request.base.sha }} > changed_files.txt
       shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
     - if: github.event_name == 'merge_group'
       run: |
+        git config --global --add safe.directory $(pwd)
+        git fetch --no-recurse-submodules origin ${{ github.event.merge_group.base_sha }}
         git diff --name-only ${{ github.event.merge_group.base_sha }} > changed_files.txt
       shell: bash
     - if: github.event_name != 'pull_request' && github.event_name != 'merge_group'

--- a/.github/actions/changed_files/action.yml
+++ b/.github/actions/changed_files/action.yml
@@ -1,0 +1,19 @@
+name: "Check which files have been changed"
+
+runs:
+  using: "composite"
+  steps:
+    - if: github.event_name == 'pull_request'
+      run: |
+        gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+    - if: github.event_name == 'merge_group'
+      run: |
+        git diff --name-only origin/devel > changed_files.txt
+      shell: bash
+    - if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+      run: |
+        git show ${{ github.sha }} --name-only --pretty= > changed_files.txt
+      shell: bash

--- a/.github/actions/changed_files/action.yml
+++ b/.github/actions/changed_files/action.yml
@@ -5,13 +5,13 @@ runs:
   steps:
     - if: github.event_name == 'pull_request'
       run: |
-        gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
+        git diff --name-only ${{ github.event.pull_request.base.sha }} > changed_files.txt
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
     - if: github.event_name == 'merge_group'
       run: |
-        git diff --name-only origin/devel > changed_files.txt
+        git diff --name-only ${{ github.event.merge_group.base_sha }} > changed_files.txt
       shell: bash
     - if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
       run: |

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -1,12 +1,13 @@
 name: Docker update
 
 inputs:
-  release:
-    required: true
-    type: bool
   rebuild:
     required: true
     type: bool
+  release_tags:
+    description: 'A list of tags for release versions'
+    required: false
+    default: '[]'
 secrets:
   GITHUB_TOKEN:
     required: true
@@ -24,6 +25,14 @@ runs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final tags
+        id: get-tags
+        runs: |
+          import os
+          release_tags = ${{ inputs.release_tags }}
+          full_tags = ["ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"] + [f"ghcr.io/gyselax/gyselalibxx_env:{t}" for t in release_tags]
+          print("full_tags='", ','.join(full_tags), "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
+        shell: python
       - name: Build and push to tag
         uses: docker/build-push-action@v3
         with:
@@ -32,5 +41,5 @@ runs:
           pull: true
           push: true
           call: ${{ inputs.rebuild && 'build' || 'call' }}
-          tags: 'ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}${{ inputs.release && ',ghcr.io/gyselax/gyselalibxx_env:latest' || ''}}'
+          tags: ${{ steps.get-tags.outputs.full_tags }}
 

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -13,6 +13,7 @@ inputs:
 outputs:
   image_tag:
     description: "The image tag that should be used after this action"
+    value: ${{ steps.image_tag.outputs.image_tag }}
 
 runs:
   using: "composite"
@@ -31,6 +32,12 @@ runs:
         else
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
+      shell: bash
+    - name: Test
+      run: |
+        echo ${{ inputs.always_push }}
+        echo ${{ (steps.rebuild-check.outputs.rebuild == 'true') }}
+        echo ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
       shell: bash
     - name: Build final tags
       id: get-tags
@@ -68,6 +75,7 @@ runs:
         call: ${{ (steps.rebuild-check.outputs.rebuild == 'true') && 'build' || 'check' }}
         tags: ${{ steps.get-tags.outputs.full_tags }}
     - name: Pick image tag for subsequent jobs
+      id: image_tag
       run: |
         if [ "${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
         then

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -10,9 +10,6 @@ inputs:
     type: string
     required: false
     default: ''
-secrets:
-  GITHUB_TOKEN:
-    required: true
 outputs:
   image_tag:
     description: "The image tag that should be used after this action"
@@ -32,10 +29,11 @@ runs:
         else
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
+      shell: bash
     - name: Build final tags
       id: get-tags
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-      runs: |
+      run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
         release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
@@ -56,7 +54,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ github.token }}
     - name: Build and push to tag
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild
       uses: docker/build-push-action@v3
@@ -68,7 +66,7 @@ runs:
         call: ${{ steps.rebuild-check.outputs.rebuild && 'build' || 'call' }}
         tags: ${{ steps.get-tags.outputs.full_tags }}
     - name: Pick image tag for subsequent jobs
-      runs: |
+      run: |
         if [ "${{ inputs.always_push || steps.rebuild-check.outputs.rebuild }}" == "true" ]
         then
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -84,3 +84,7 @@ runs:
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
         fi
       shell: bash
+    - name: Debug
+      run: |
+        echo ${{ steps.image_tag.outputs.image_tag }}
+      shell: bash

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -1,31 +1,37 @@
 name: Docker update
 
 inputs:
-  rebuild:
-    required: true
-    type: bool
   release_tag:
     description: 'A tag for the release version'
     type: string
     required: false
     default: ''
+  always_push:
+    description: 'Indicates if the docker should be pushed and tagged with the SHA regardless of whether it was rebuilt or not'
+    type: bool
+    required: true
 secrets:
   GITHUB_TOKEN:
     required: true
+outputs:
+  image_tag:
+    description: "The image tag that should be used after this action"
 
 runs:
   using: "composite"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/changed_files
+      - id: docker-check
+        run: |
+          # Check if docker/gyselalibxx_env/Dockerfile has been modified
+          changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
+          # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
+          if [ -n "${changed_docker_file}" ]
+          then
+            echo "rebuild=true" >> $GITHUB_OUTPUT
+          else
+            echo "rebuild=false" >> $GITHUB_OUTPUT
+          fi
       - name: Build final tags
         id: get-tags
         runs: |
@@ -37,13 +43,35 @@ runs:
           # Save the CSV to the outputs for use in the build-push-action
           print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
         shell: python
+      - name: Set up QEMU
+        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push to tag
+        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
         uses: docker/build-push-action@v3
         with:
           context: ./docker/gyselalibxx_env
           cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
           pull: true
           push: true
-          call: ${{ inputs.rebuild && 'build' || 'call' }}
+          call: ${{ steps.rebuild-check.outputs.rebuild && 'build' || 'call' }}
           tags: ${{ steps.get-tags.outputs.full_tags }}
-
+      - name: Pick image tag for subsequent jobs
+        runs: |
+          if [ "${{ inputs.always_push || steps.rebuild-check.outputs.rebuild }}" == "true" ]
+          then
+            echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+          else
+            echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
+          fi
+        shell: bash

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -46,13 +46,13 @@ runs:
       shell: python
     - name: Set up QEMU
       if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
       if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -21,10 +21,8 @@ runs:
     - uses: ./.github/actions/changed_files
     - id: rebuild-check
       run: |
-        echo cat changed_files.txt
         # Check if docker/gyselalibxx_env/Dockerfile has been modified
         changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
-        echo "${changed_docker_file}"
         # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
         if [ -n "${changed_docker_file}" ]
         then
@@ -32,12 +30,6 @@ runs:
         else
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
-      shell: bash
-    - name: Test
-      run: |
-        echo ${{ inputs.always_push }}
-        echo ${{ (steps.rebuild-check.outputs.rebuild == 'true') }}
-        echo ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
       shell: bash
     - name: Build final tags
       id: get-tags
@@ -83,8 +75,4 @@ runs:
         else
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest" >> $GITHUB_OUTPUT
         fi
-      shell: bash
-    - name: Debug
-      run: |
-        echo ${{ steps.image_tag.outputs.image_tag }}
       shell: bash

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -1,15 +1,15 @@
 name: Docker update
 
 inputs:
+  always_push:
+    description: 'Indicates if the docker should be pushed and tagged with the SHA regardless of whether it was rebuilt or not'
+    type: bool
+    required: true
   release_tag:
     description: 'A tag for the release version'
     type: string
     required: false
     default: ''
-  always_push:
-    description: 'Indicates if the docker should be pushed and tagged with the SHA regardless of whether it was rebuilt or not'
-    type: bool
-    required: true
 secrets:
   GITHUB_TOKEN:
     required: true

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -27,16 +27,14 @@ runs:
         # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
         if [ -n "${changed_docker_file}" ]
         then
-          echo "rebuild=True"
-          echo "rebuild=True" >> $GITHUB_OUTPUT
+          echo "rebuild=true" >> $GITHUB_OUTPUT
         else
-          echo "rebuild=False"
-          echo "rebuild=False" >> $GITHUB_OUTPUT
+          echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Build final tags
       id: get-tags
-      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
@@ -47,31 +45,31 @@ runs:
         print("full_tags=", full_tags, file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python
     - name: Set up QEMU
-      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
-      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-      uses: docker/setup-buildx-action@v2
+      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
     - name: Build and push to tag
-      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/build-push-action@v6
       with:
         context: ./docker/gyselalibxx_env
         cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
         pull: true
         push: true
-        call: ${{ steps.rebuild-check.outputs.rebuild && 'build' || 'call' }}
+        call: ${{ (steps.rebuild-check.outputs.rebuild == 'true') && 'build' || 'call' }}
         tags: ${{ steps.get-tags.outputs.full_tags }}
     - name: Pick image tag for subsequent jobs
       run: |
-        if [ "${{ inputs.always_push || steps.rebuild-check.outputs.rebuild }}" == "true" ]
+        if [ "${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
         then
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
         else

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -34,6 +34,7 @@ runs:
           fi
       - name: Build final tags
         id: get-tags
+        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
         runs: |
           import os
           sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
     - name: Build final tags
       id: get-tags
-      if: ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
+      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"
@@ -52,20 +52,20 @@ runs:
         print("full_tags=", full_tags, file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python
     - name: Set up QEMU
-      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
       uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
     - name: Build and push to tag
-      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
       uses: docker/build-push-action@v6
       with:
         context: ./docker/gyselalibxx_env
@@ -79,9 +79,9 @@ runs:
       run: |
         if [ "${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
         then
-          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"
+          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}" >> $GITHUB_OUTPUT
         else
-          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
+          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Debug

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/changed_files
-    - id: docker-check
+    - id: rebuild-check
       run: |
         echo cat changed_files.txt
         # Check if docker/gyselalibxx_env/Dockerfile has been modified
@@ -31,12 +31,6 @@ runs:
         else
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
-      shell: bash
-    - name: "Check"
-      run: |
-        echo ${{ steps.rebuild-check.outputs.rebuild }}
-        echo ${{ inputs.always_push }}
-        echo ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
       shell: bash
     - name: Build final tags
       id: get-tags

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -20,13 +20,17 @@ runs:
     - uses: ./.github/actions/changed_files
     - id: docker-check
       run: |
+        echo cat changed_files.txt
         # Check if docker/gyselalibxx_env/Dockerfile has been modified
         changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
+        echo "${changed_docker_file}"
         # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
         if [ -n "${changed_docker_file}" ]
         then
+          echo "rebuild=true"
           echo "rebuild=true" >> $GITHUB_OUTPUT
         else
+          echo "rebuild=false"
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
@@ -57,7 +61,7 @@ runs:
         password: ${{ github.token }}
     - name: Build and push to tag
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: ./docker/gyselalibxx_env
         cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -65,7 +65,7 @@ runs:
         cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
         pull: true
         push: true
-        call: ${{ (steps.rebuild-check.outputs.rebuild == 'true') && 'build' || 'call' }}
+        call: ${{ (steps.rebuild-check.outputs.rebuild == 'true') && 'build' || 'check' }}
         tags: ${{ steps.get-tags.outputs.full_tags }}
     - name: Pick image tag for subsequent jobs
       run: |

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -40,7 +40,7 @@ runs:
         # Build a CSV representation of the tags
         full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
         # Save the CSV to the outputs for use in the build-push-action
-        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
+        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"]), sep='')
       shell: python
     - name: Set up QEMU
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
     - name: Build final tags
       id: get-tags
-      if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
+      if: ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
     - name: Build final tags
       id: get-tags
-      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
+      if: (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true')
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"
@@ -44,20 +44,20 @@ runs:
         print("full_tags=", full_tags, file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python
     - name: Set up QEMU
-      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
+      if: (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
-      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
+      if: (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
+      if: (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
     - name: Build and push to tag
-      if: (inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')) == 'true'
+      if: (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true')
       uses: docker/build-push-action@v6
       with:
         context: ./docker/gyselalibxx_env
@@ -69,7 +69,7 @@ runs:
     - name: Pick image tag for subsequent jobs
       id: image_tag
       run: |
-        if [ "${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
+        if [ "${{ (inputs.always_push == 'true') || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
         then
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -19,60 +19,60 @@ outputs:
 
 runs:
   using: "composite"
-    steps:
-      - uses: ./.github/actions/changed_files
-      - id: docker-check
-        run: |
-          # Check if docker/gyselalibxx_env/Dockerfile has been modified
-          changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
-          # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
-          if [ -n "${changed_docker_file}" ]
-          then
-            echo "rebuild=true" >> $GITHUB_OUTPUT
-          else
-            echo "rebuild=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Build final tags
-        id: get-tags
-        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-        runs: |
-          import os
-          sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
-          release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
-          # Build a CSV representation of the tags
-          full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
-          # Save the CSV to the outputs for use in the build-push-action
-          print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
-        shell: python
-      - name: Set up QEMU
-        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push to tag
-        if: inputs.always_push || steps.rebuild-check.outputs.rebuild
-        uses: docker/build-push-action@v3
-        with:
-          context: ./docker/gyselalibxx_env
-          cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
-          pull: true
-          push: true
-          call: ${{ steps.rebuild-check.outputs.rebuild && 'build' || 'call' }}
-          tags: ${{ steps.get-tags.outputs.full_tags }}
-      - name: Pick image tag for subsequent jobs
-        runs: |
-          if [ "${{ inputs.always_push || steps.rebuild-check.outputs.rebuild }}" == "true" ]
-          then
-            echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
-          else
-            echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
-          fi
-        shell: bash
+  steps:
+    - uses: ./.github/actions/changed_files
+    - id: docker-check
+      run: |
+        # Check if docker/gyselalibxx_env/Dockerfile has been modified
+        changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
+        # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
+        if [ -n "${changed_docker_file}" ]
+        then
+          echo "rebuild=true" >> $GITHUB_OUTPUT
+        else
+          echo "rebuild=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Build final tags
+      id: get-tags
+      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      runs: |
+        import os
+        sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+        release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
+        # Build a CSV representation of the tags
+        full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
+        # Save the CSV to the outputs for use in the build-push-action
+        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
+      shell: python
+    - name: Set up QEMU
+      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      uses: docker/setup-buildx-action@v2
+    - name: Login to GitHub Container Registry
+      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push to tag
+      if: inputs.always_push || steps.rebuild-check.outputs.rebuild
+      uses: docker/build-push-action@v3
+      with:
+        context: ./docker/gyselalibxx_env
+        cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
+        pull: true
+        push: true
+        call: ${{ steps.rebuild-check.outputs.rebuild && 'build' || 'call' }}
+        tags: ${{ steps.get-tags.outputs.full_tags }}
+    - name: Pick image tag for subsequent jobs
+      runs: |
+        if [ "${{ inputs.always_push || steps.rebuild-check.outputs.rebuild }}" == "true" ]
+        then
+          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+        else
+          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
+        fi
+      shell: bash

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -4,10 +4,11 @@ inputs:
   rebuild:
     required: true
     type: bool
-  release_tags:
-    description: 'A list of tags for release versions'
+  release_tag:
+    description: 'A tag for the release version'
+    type: string
     required: false
-    default: '[]'
+    default: ''
 secrets:
   GITHUB_TOKEN:
     required: true
@@ -29,9 +30,12 @@ runs:
         id: get-tags
         runs: |
           import os
-          release_tags = ${{ inputs.release_tags }}
-          full_tags = ["ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"] + [f"ghcr.io/gyselax/gyselalibxx_env:{t}" for t in release_tags]
-          print("full_tags='", ','.join(full_tags), "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
+          sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+          release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
+          # Build a CSV representation of the tags
+          full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
+          # Save the CSV to the outputs for use in the build-push-action
+          print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], sep='')
         shell: python
       - name: Build and push to tag
         uses: docker/build-push-action@v3

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -40,7 +40,7 @@ runs:
         # Build a CSV representation of the tags
         full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
         # Save the CSV to the outputs for use in the build-push-action
-        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"]), sep='')
+        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python
     - name: Set up QEMU
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -32,6 +32,12 @@ runs:
           echo "rebuild=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
+    - name: "Check"
+      run: |
+        echo ${{ steps.rebuild-check.outputs.rebuild }}
+        echo ${{ inputs.always_push }}
+        echo ${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}
+      shell: bash
     - name: Build final tags
       id: get-tags
       if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -27,11 +27,11 @@ runs:
         # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
         if [ -n "${changed_docker_file}" ]
         then
-          echo "rebuild=true"
-          echo "rebuild=true" >> $GITHUB_OUTPUT
+          echo "rebuild=True"
+          echo "rebuild=True" >> $GITHUB_OUTPUT
         else
-          echo "rebuild=false"
-          echo "rebuild=false" >> $GITHUB_OUTPUT
+          echo "rebuild=False"
+          echo "rebuild=False" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: Build final tags
@@ -40,11 +40,11 @@ runs:
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
-        release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
+        release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}".strip()
         # Build a CSV representation of the tags
         full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
         # Save the CSV to the outputs for use in the build-push-action
-        print("full_tags='", full_tags, "'", file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
+        print("full_tags=", full_tags, file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python
     - name: Set up QEMU
       if: inputs.always_push || steps.rebuild-check.outputs.rebuild

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -37,7 +37,7 @@ runs:
       if: inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true')
       run: |
         import os
-        sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+        sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"
         release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
         # Build a CSV representation of the tags
         full_tags = sha_tag + ('' if release_tag.endswith(":") else (','+release_tag))
@@ -71,7 +71,7 @@ runs:
       run: |
         if [ "${{ inputs.always_push || (steps.rebuild-check.outputs.rebuild == 'true') }}" == "true" ]
         then
-          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
+          echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:${{ github.event.pull_request.head.sha || github.SHA }}"
         else
           echo "image_tag=ghcr.io/gyselax/gyselalibxx_env:latest"
         fi

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -1,0 +1,36 @@
+name: Docker update
+
+inputs:
+  release:
+    required: true
+    type: bool
+  rebuild:
+    required: true
+    type: bool
+secrets:
+  GITHUB_TOKEN:
+    required: true
+
+runs:
+  using: "composite"
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push to tag
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker/gyselalibxx_env
+          cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
+          pull: true
+          push: true
+          call: ${{ inputs.rebuild && 'build' || 'call' }}
+          tags: 'ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}${{ inputs.release && ',ghcr.io/gyselax/gyselalibxx_env:latest' || ''}}'
+

--- a/.github/actions/docker_update/action.yml
+++ b/.github/actions/docker_update/action.yml
@@ -40,9 +40,9 @@ runs:
       run: |
         import os
         sha_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ github.SHA }}"
-        release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}".strip()
+        release_tag = "ghcr.io/gyselax/gyselalibxx_env:${{ inputs.release_tag }}"
         # Build a CSV representation of the tags
-        full_tags = sha_tag + ((','+release_tag) if release_tag.endswith(":") else '')
+        full_tags = sha_tag + ('' if release_tag.endswith(":") else (','+release_tag))
         # Save the CSV to the outputs for use in the build-push-action
         print("full_tags=", full_tags, file=open(os.environ["GITHUB_OUTPUT"], 'a'), sep='')
       shell: python

--- a/.github/actions/duplicate_check/action.yml
+++ b/.github/actions/duplicate_check/action.yml
@@ -7,10 +7,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        MATCHING_PATHS='["src/**/*.hpp", "src/**/*.cpp", "tests/**/*.hpp", "tests/**/*.cpp", "simulations/**/*.hpp", "simulations/**/*.cpp", "**/CMakeLists.txt", "vendor/**", ".github/actions/**", ".github/workflows/**", "toolchains/docker.gyselalibxx_env/**", "toolchains/v100.persee/**"]'
-        echo "MATCHING_PATHS=${MATCHING_PATHS}" >> ${GITHUB_ENV}
-      shell: bash
     - uses: .github/actions/changed_files
     - id: changes_check
       run: |
@@ -18,7 +14,7 @@ runs:
         import os
         with open("changed_files.txt") as f:
           lines = [l.strip() for l in f.readlines()]
-        matching_paths = [si.strip('"') for si in os.environ['MATCHING_PATHS'].split('[')[1].split(']')[0].split(', ')]
+        matching_paths=[ "src/**/*.hpp", "src/**/*.cpp", "tests/**/*.hpp", "tests/**/*.cpp", "simulations/**/*.hpp", "simulations/**/*.cpp", "**/CMakeLists.txt", "vendor/**", ".github/actions/**", ".github/workflows/**", "toolchains/docker.gyselalibxx_env/**", "toolchains/v100.persee/**" ]
         matches = [m for pat in matching_paths for m in fnmatch.filter(lines, pat)]
         print(matches)
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
@@ -31,9 +27,10 @@ runs:
         skip_after_successful_duplicate: 'true'
     - id: outcome
       run: |
+        echo "Trigger anyway : ${{ github.event_name == 'push' || github.event_name == 'release' }}"
         echo "Found match : ${{ steps.changes_check.outputs.found_match }}"
         echo "Should skip : ${{ steps.duplicate_check.outputs.should_skip }}"
-        SHOULD_SKIP=${{ github.event_name != 'push' && ((steps.changes_check.outputs.found_match == 'False') || (steps.duplicate_check.outputs.should_skip == 'true')) }}
+        SHOULD_SKIP=${{ github.event_name != 'push' && github.event_name != 'release' && ((steps.changes_check.outputs.found_match == 'False') || (steps.duplicate_check.outputs.should_skip == 'true')) }}
         echo "should_skip=${SHOULD_SKIP}" >> $GITHUB_OUTPUT
         echo "should_skip=${SHOULD_SKIP}"
       shell: bash

--- a/.github/actions/duplicate_check/action.yml
+++ b/.github/actions/duplicate_check/action.yml
@@ -11,20 +11,7 @@ runs:
         MATCHING_PATHS='["src/**/*.hpp", "src/**/*.cpp", "tests/**/*.hpp", "tests/**/*.cpp", "simulations/**/*.hpp", "simulations/**/*.cpp", "**/CMakeLists.txt", "vendor/**", ".github/actions/**", ".github/workflows/**", "toolchains/docker.gyselalibxx_env/**", "toolchains/v100.persee/**"]'
         echo "MATCHING_PATHS=${MATCHING_PATHS}" >> ${GITHUB_ENV}
       shell: bash
-    - if: github.event_name == 'pull_request'
-      run: |
-        gh pr diff ${{ github.event.pull_request.number }} --name-only > changed_files.txt
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-    - if: github.event_name == 'merge_group'
-      run: |
-        git diff --name-only origin/devel > changed_files.txt
-      shell: bash
-    - if: github.event_name == 'push'
-      run: |
-        git ls-tree --full-tree -r --name-only HEAD > changed_files.txt
-      shell: bash
+    - uses: .github/actions/changed_files
     - id: changes_check
       run: |
         import fnmatch

--- a/.github/actions/duplicate_check/action.yml
+++ b/.github/actions/duplicate_check/action.yml
@@ -7,7 +7,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: .github/actions/changed_files
+    - uses: ./.github/actions/changed_files
     - id: changes_check
       run: |
         import fnmatch

--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -1,17 +1,12 @@
 name: "Filter tests"
 
-inputs:
-  base_sha:
-    description: "The SHA or branch of the PR base"
-    required: true
-
 runs:
   using: "composite"
   steps:
   - name: "Fetch reference case"
     run: |
       git config --global --add safe.directory $(pwd)
-      git fetch --no-recurse-submodules origin ${{ inputs.base_sha }}
+      git fetch --no-recurse-submodules origin
     shell: bash
   - uses: ./.github/actions/changed_files
   - name: "Check filters"

--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -4,9 +4,6 @@ inputs:
   base_sha:
     description: "The SHA or branch of the PR base"
     required: true
-  trigger_type:
-    description: "The SHA of the PR base"
-    required: true
 
 runs:
   using: "composite"
@@ -16,30 +13,25 @@ runs:
       git config --global --add safe.directory $(pwd)
       git fetch --no-recurse-submodules origin ${{ inputs.base_sha }}
     shell: bash
-  - name: "Get changed files"
-    if: inputs.trigger_type == 'workflow_dispatch'
-    run: |
-      base_sha=$(git log -1 ${{ inputs.base_sha }} --pretty=%H)
-      git diff --name-only ${base_sha} > changed_files.txt
-    shell: bash
-  - name: "Get changed files"
-    if: inputs.trigger_type == 'push'
-    run: |
-      git ls-tree --full-tree -r --name-only HEAD > changed_files.txt
-    shell: bash
-  - name: "Get changed files"
-    if: inputs.trigger_type != 'workflow_dispatch' && inputs.trigger_type != 'push'
-    run: |
-      git diff --name-only ${{ inputs.base_sha }} > changed_files.txt
-    shell: bash
+  - uses: .github/actions/changed_files
   - name: "Check filters"
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_request'
     run: |
       changed_files=$(awk '{printf("%s ",$0)} END { printf "\n" }' changed_files.txt)
       echo "CHANGED_FILES=${changed_files}" >> $GITHUB_ENV
       FOUND_POLAR_SPLINES=$(grep "src/interpolation/polar_splines/.*" -x changed_files.txt || true)
-      if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> build.env; echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV; fi
+      if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> $GITHUB_ENV; echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV; fi
       FOUND_POISSON_2D=$(grep -P "(src/geometryRTheta/poisson/.*)|(tests/geometryRTheta/polar_poisson/.*)" -x changed_files.txt || true)
       if [ -z "$FOUND_POISSON_2D" ]; then echo "POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "POISSON_2D_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
+      FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
+      if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "DDC_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
+    shell: bash
+  - name: "Check filters"
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_request'
+    run: |
+      echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> $GITHUB_ENV
+      echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV
+      echo "POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV
       FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
       if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "DDC_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
     shell: bash

--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -3,11 +3,6 @@ name: "Filter tests"
 runs:
   using: "composite"
   steps:
-  - name: "Fetch reference case"
-    run: |
-      git config --global --add safe.directory $(pwd)
-      git fetch --no-recurse-submodules origin
-    shell: bash
   - uses: ./.github/actions/changed_files
   - name: "Check filters"
     if: github.event_name == 'pull_request' || github.event_name == 'merge_request'

--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -13,7 +13,7 @@ runs:
       git config --global --add safe.directory $(pwd)
       git fetch --no-recurse-submodules origin ${{ inputs.base_sha }}
     shell: bash
-  - uses: .github/actions/changed_files
+  - uses: ./.github/actions/changed_files
   - name: "Check filters"
     if: github.event_name == 'pull_request' || github.event_name == 'merge_request'
     run: |

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -69,40 +69,17 @@ jobs:
   docker_update:
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+      image_tag: ${{ steps.dcoker.outputs.image_tag }}
     if: github.repository == 'gyselax/gyselalibxx' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/changed_files
-      - id: docker-check
-        run: |
-          # Check if docker/gyselalibxx_env/Dockerfile has been modified
-          changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
-          # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
-          if [ -n "${changed_docker_file}" ]
-          then
-            echo "rebuild=true" >> $GITHUB_OUTPUT
-          else
-            echo "rebuild=false" >> $GITHUB_OUTPUT
-          fi
-      - uses: ./.github/actions/docker_update
-        if: github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild
+      - id: docker
+        uses: ./.github/actions/docker_update
         with:
-          # Rebuild if Dockerfile has changed
-          rebuild: ${{ steps.rebuild-check.outputs.rebuild }}
+          always_push: github.event_name == 'push' || github.event_name == 'release'
           # Build the release tag with a ternary expression
           # 'latest' if push else (release.tag_name if release else '')
           release_tag: ${{ github.event_name == 'push' && 'latest' || ( github.event_name == 'release' && github.event.release.tag_name || '') }}
-      - id: image_tag
-        run: |
-          # If the file was rebuilt then it must be used. Otherwise latest is sufficient
-          if [ "${{ github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild }}" == "true" ]
-          then
-            echo "image_tag='${{ github.SHA }}'" >> $GITHUB_OUTPUT
-          else
-            echo "image_tag='latest'" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
 
   cpu_tests:
     runs-on: ubuntu-latest
@@ -111,7 +88,7 @@ jobs:
       matrix: ${{fromJson(needs.pre_job.outputs.matrix)}}
       fail-fast: false
     container:
-      image: ghcr.io/gyselax/gyselalibxx_env:${{ needs.docker_update.outputs.image_tag }}
+      image: ${{ needs.docker_update.outputs.image_tag }}
       options: --user root
     name: CPU Test (${{ matrix.toolchain }})
     steps:

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -92,6 +92,10 @@ jobs:
       options: --user root
     name: CPU Test (${{ matrix.toolchain }})
     steps:
+      - name: Debug
+        run: |
+          echo ${{ needs.docker_update.outputs.image_tag }}
+        shell: bash
       - name: Checkout gyselalibxx
         if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
         uses: actions/checkout@v4

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -75,7 +75,9 @@ jobs:
       - uses: .github/actions/changed_files
       - id: docker-check
         run: |
+          # Check if docker/gyselalibxx_env/Dockerfile has been modified
           changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
+          # Use the modification status of docker/gyselalibxx_env/Dockerfile to decide if the docker should be rebuilt
           if [ -n "${changed_docker_file}" ]
           then
             echo "rebuild=true" >> $GITHUB_OUTPUT
@@ -85,10 +87,14 @@ jobs:
       - uses: ./.github/actions/docker_update
         if: github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild
         with:
+          # Rebuild if Dockerfile has changed
           rebuild: ${{ steps.rebuild-check.outputs.rebuild }}
-          release_tags: ${{ github.event_name == 'push' && 'latest' || ( github.event_name == 'release' && github.event.release.tag_name || '') }}
+          # Build the release tag with a ternary expression
+          # 'latest' if push else (release.tag_name if release else '')
+          release_tag: ${{ github.event_name == 'push' && 'latest' || ( github.event_name == 'release' && github.event.release.tag_name || '') }}
       - id: image_tag
         run: |
+          # If the file was rebuilt then it must be used. Otherwise latest is sufficient
           if [ "${{ github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild }}" == "true" ]
           then
             echo "image_tag='${{ github.SHA }}'" >> $GITHUB_OUTPUT

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -83,7 +83,7 @@ jobs:
 
   cpu_tests:
     runs-on: ubuntu-latest
-    needs: pre_job, docker_update
+    needs: [pre_job, docker_update]
     strategy:
       matrix: ${{fromJson(needs.pre_job.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -72,7 +72,7 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v4
-      - uses: .github/actions/changed_files
+      - uses: ./.github/actions/changed_files
       - id: docker-check
         run: |
           # Check if docker/gyselalibxx_env/Dockerfile has been modified

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -100,9 +100,6 @@ jobs:
       - name: "Filter tests"
         if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
         uses: ./.github/actions/test_filter
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || inputs.merge_target }}
-          trigger_type: ${{ github.event_name }}
       - name: Build code
         if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
         uses: ./.github/actions/build_code

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -11,7 +11,9 @@ on:
     types:
       - checks_requested
   push:
-    branches: [main, devel]
+    branches: [devel]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       toolchain:
@@ -64,14 +66,45 @@ jobs:
           echo "matrix={\"toolchain\": $matrix}" >> $GITHUB_OUTPUT
         shell: bash
 
+  docker_update:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: .github/actions/changed_files
+      - id: docker-check
+        run: |
+          changed_docker_file=$(cat changed_files.txt | grep docker/gyselalibxx_env/Dockerfile || true)
+          if [ -n "${changed_docker_file}" ]
+          then
+            echo "rebuild=true" >> $GITHUB_OUTPUT
+          else
+            echo "rebuild=false" >> $GITHUB_OUTPUT
+          fi
+      - uses: ./.github/actions/docker_update
+        if: github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild
+        with:
+          rebuild: ${{ steps.rebuild-check.outputs.rebuild }}
+          release_tags: ${{ github.event_name == 'push' && 'latest' || ( github.event_name == 'release' && github.event.release.tag_name || '') }}
+      - id: image_tag
+        run: |
+          if [ "${{ github.event_name == 'push' || github.event_name == 'release' || steps.rebuild-check.outputs.rebuild }}" == "true" ]
+          then
+            echo "image_tag='${{ github.SHA }}'" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag='latest'" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
   cpu_tests:
     runs-on: ubuntu-latest
-    needs: pre_job
+    needs: pre_job, docker_update
     strategy:
       matrix: ${{fromJson(needs.pre_job.outputs.matrix)}}
       fail-fast: false
     container:
-      image: ghcr.io/gyselax/gyselalibxx_env:latest
+      image: ghcr.io/gyselax/gyselalibxx_env:${{ needs.docker_update.outputs.image_tag }}
       options: --user root
     name: CPU Test (${{ matrix.toolchain }})
     steps:

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -92,10 +92,6 @@ jobs:
       options: --user root
     name: CPU Test (${{ matrix.toolchain }})
     steps:
-      - name: Debug
-        run: |
-          echo ${{ needs.docker_update.outputs.image_tag }}
-        shell: bash
       - name: Checkout gyselalibxx
         if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
         uses: actions/checkout@v4

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -69,7 +69,7 @@ jobs:
   docker_update:
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.dcoker.outputs.image_tag }}
+      image_tag: ${{ steps.docker.outputs.image_tag }}
     if: github.repository == 'gyselax/gyselalibxx' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -70,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.image_tag.outputs.image_tag }}
+    if: github.repository == 'gyselax/gyselalibxx' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/changed_files

--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -76,7 +76,7 @@ jobs:
       - id: docker
         uses: ./.github/actions/docker_update
         with:
-          always_push: github.event_name == 'push' || github.event_name == 'release'
+          always_push: ${{ github.event_name == 'push' || github.event_name == 'release' }}
           # Build the release tag with a ternary expression
           # 'latest' if push else (release.tag_name if release else '')
           release_tag: ${{ github.event_name == 'push' && 'latest' || ( github.event_name == 'release' && github.event.release.tag_name || '') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,32 +13,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - name: "Check if rebuild is necessary"
+        id: rebuild-check
+        run: |
+          changed_docker_file=$(git show ${{ github.sha }} --name-only --pretty= | grep docker/gyselalibxx_env/Dockerfile || true)
+          if [ -n "${changed_docker_file}" ]
+          then
+            echo "rebuild=true" >> $GITHUB_OUTPUT
+          else
+            echo "rebuild=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout
+        uses: ./github/actions/docker_update
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push to tag
-        uses: docker/build-push-action@v3
-        with:
-          context: ./docker/gyselalibxx_env
-          cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
-          pull: true
-          push: true
-          tags: ghcr.io/gyselax/gyselalibxx_env:${{ github.sha }}
-      - name: Build and push latest
-        uses: docker/build-push-action@v3
-        with:
-          context: ./docker/gyselalibxx_env
-          cache-from: type=registry,ref=ghcr.io/gyselax/gyselalibxx_env:latest
-          pull: true
-          push: true
-          tags: ghcr.io/gyselax/gyselalibxx_env:latest
+          release: true
+          rebuild: ${{ steps.rebuild-check.outputs.rebuild }}
 
   Docs:
     if: github.repository == 'gyselax/gyselalibxx'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,28 +7,6 @@ on:
 
 
 jobs:
-  docker:
-    if: github.repository == 'gyselax/gyselalibxx'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: "Check if rebuild is necessary"
-        id: rebuild-check
-        run: |
-          changed_docker_file=$(git show ${{ github.sha }} --name-only --pretty= | grep docker/gyselalibxx_env/Dockerfile || true)
-          if [ -n "${changed_docker_file}" ]
-          then
-            echo "rebuild=true" >> $GITHUB_OUTPUT
-          else
-            echo "rebuild=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Checkout
-        uses: ./github/actions/docker_update
-        with:
-          release: true
-          rebuild: ${{ steps.rebuild-check.outputs.rebuild }}
-
   Docs:
     if: github.repository == 'gyselax/gyselalibxx'
     runs-on: ubuntu-latest

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -1,12 +1,12 @@
 name: GPU acceptance tests
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  #pull_request:
+  #  types:
+  #    - opened
+  #    - reopened
+  #    - synchronize
+  #    - ready_for_review
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -61,9 +61,6 @@ jobs:
         uses: actions/checkout@v4
       - name: "Filter tests"
         uses: ./.github/actions/test_filter
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || inputs.merge_target }}
-          trigger_type: ${{ github.event_name }}
       - name: "Send to persee"
         run: |
           git clone https://ci_bot:${GITLAB_PAT}@gitlab.maisondelasimulation.fr/gysela-developpers/gyselalibxx.git --single-branch --branch trigger_persee
@@ -111,9 +108,6 @@ jobs:
   #    - name: "Filter tests"
   #      if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
   #      uses: ./.github/actions/test_filter
-  #      with:
-  #        base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || inputs.merge_target }}
-  #        trigger_type: ${{ github.event_name }}
   #    - name: Setup environment
   #      if: ${{ needs.pre_job.outputs.should_skip == 'false' }}
   #      run: |

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -1,12 +1,12 @@
 name: GPU acceptance tests
 
 on:
-  #pull_request:
-  #  types:
-  #    - opened
-  #    - reopened
-  #    - synchronize
-  #    - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/static_analyses.yml
+++ b/.github/workflows/static_analyses.yml
@@ -139,9 +139,6 @@ jobs:
       - uses: ./.github/actions/linux_static_analysis_install
       - uses: ./.github/actions/python-static-analysis-setup
       - uses: ./.github/actions/test_filter
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          trigger_type: ${{ github.event_name }}
       - run: |
           python3 bin/ci_tools/gyselalib_static_analysis.py ${CHANGED_FILES} --errors-only
 
@@ -157,9 +154,6 @@ jobs:
       - uses: ./.github/actions/linux_static_analysis_install
       - uses: ./.github/actions/python-static-analysis-setup
       - uses: ./.github/actions/test_filter
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          trigger_type: ${{ github.event_name }}
       - run: |
           python3 bin/ci_tools/gyselalib_static_analysis.py ${CHANGED_FILES}
 

--- a/docker/gyselalibxx_env/Dockerfile
+++ b/docker/gyselalibxx_env/Dockerfile
@@ -25,7 +25,6 @@ RUN chmod +x /bin/bash_run \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends \
     build-essential \
-    clang \
     clang-format \
     doxygen \
     pkg-config \

--- a/docker/gyselalibxx_env/Dockerfile
+++ b/docker/gyselalibxx_env/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod +x /bin/bash_run \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends \
     build-essential \
+    clang \
     clang-format \
     doxygen \
     pkg-config \


### PR DESCRIPTION
Before this PR the docker image was built whenever there is a push on the devel branch. This is problematic for multiple reasons:
- The CPU run on the devel branch does not wait for the docker file so it cannot use the changes
- The docker image is rebuilt even if it was not modified
- If we want to modify the `Dockerfile` we need to have 1 PR to update the file and a second to use the changes. This is awkward for testing.

This PR improves this situation by moving the `docker` job to `cpu_tests.yml`. It now triggers:
- on pushes to devel
- on a release of a new tag
- on pushes to a branch with a pull request
- on a workflow dispatch

It only recompiles if necessary, otherwise it simply runs build checks and retags the container.
The following CPU tests now depend on this runner. This allows them to use the new image if the container is rebuilt. A variable `image_tag` indicates whether the `'latest'` tag should be used or if a commit tag should be used.

**Commit Summary**
- Extract the logic for creating `changed_files.txt` to its own reusable action
- Add a `docker_update` action to group the logic related to docker interactions
- Remove the unnecessary step to create MATCHING_PATHS in the `duplicate_check` action
- Ensure pushes to devel and releases are not marked as duplicates
- Ensure the full test suite is run on pushes to devel and releases
- Trigger `cpu_tests.yml` on pushes to `devel` and releases instead of pushes to `devel` and `main`. This allows the docker container to be tagged with the version without duplicating runs
- Build the docker image before running CPU tests and use the result to determine which image to use