### PR TITLE
Rename fdistribu -> density in r,theta geometry

### DIFF
--- a/src/geometryRTheta/poisson/iqnsolver.hpp
+++ b/src/geometryRTheta/poisson/iqnsolver.hpp
@@ -22,11 +22,11 @@ public:
      *      The solution of the Quasi-Neutrality equation.
      * @param[out] electric_field
      *      The electric field @f$E = -\nabla \phi@f$.
-     * @param[in] allfdistribu
+     * @param[in] density
      *      The rhs of the Quasi-Neutrality equation.
      */
     virtual void operator()(
             host_t<DFieldRTheta> electrostatic_potential,
             host_t<DVectorFieldRTheta<X, Y>> electric_field,
-            host_t<DConstFieldRTheta> allfdistribu) const = 0;
+            host_t<DConstFieldRTheta> density) const = 0;
 };

--- a/src/geometryRTheta/time_solver/bsl_predcorr.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr.hpp
@@ -114,7 +114,7 @@ public:
     }
 
     host_t<DFieldRTheta> operator()(
-            host_t<DFieldRTheta> allfdistribu_host,
+            host_t<DFieldRTheta> density_host,
             double const dt,
             int const steps) const override
     {
@@ -123,7 +123,7 @@ public:
 
 
         // Grid. ------------------------------------------------------------------------------------------
-        IdxRangeRTheta grid(get_idx_range<GridR, GridTheta>(allfdistribu_host));
+        IdxRangeRTheta grid(get_idx_range<GridR, GridTheta>(density_host));
         AdvectionFieldFinder advection_field_computer(m_mapping);
 
         IdxRangeBSR radial_bsplines(ddc::discrete_space<BSplinesR>().full_domain().remove_first(
@@ -140,25 +140,25 @@ public:
 
         host_t<DFieldMemRTheta> electrical_potential0_host(grid);
         DFieldMemRTheta electrical_potential0(grid);
-        host_t<Spline2DMem> allfdistribu_coef(get_spline_idx_range(m_builder));
-        m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_host));
+        host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
+        m_builder(get_field(density_coef), get_const_field(density_host));
         PoissonLikeRHSFunction const
-                charge_density_coord(get_const_field(allfdistribu_coef), m_spline_evaluator);
+                charge_density_coord(get_const_field(density_coef), m_spline_evaluator);
         m_poisson_solver(charge_density_coord, get_field(electrical_potential0));
         ddc::parallel_deepcopy(electrical_potential0, electrical_potential0_host);
         ddc::PdiEvent("iteration")
                 .with("iter", 0)
                 .with("time", 0)
-                .with("density", allfdistribu_host)
+                .with("density", density_host)
                 .with("electrical_potential", electrical_potential0_host);
 
 
         std::function<void(host_t<DVectorFieldRTheta<X, Y>>, host_t<DConstFieldRTheta>)>
                 define_advection_field = [&](host_t<DVectorFieldRTheta<X, Y>> advection_field_host,
-                                             host_t<DConstFieldRTheta> allfdistribu_host) {
+                                             host_t<DConstFieldRTheta> density_host) {
                     // --- compute electrostatic potential:
-                    host_t<Spline2DMem> allfdistribu_coef(get_spline_idx_range(m_builder));
-                    m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_host));
+                    host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
+                    m_builder(get_field(density_coef), get_const_field(density_host));
                     m_poisson_solver(charge_density_coord, electrostatic_potential_coef);
 
                     // --- compute advection field:
@@ -166,21 +166,21 @@ public:
                 };
 
         std::function<void(host_t<DFieldRTheta>, host_t<DConstVectorFieldRTheta<X, Y>>, double)>
-                advect_allfdistribu
-                = [&](host_t<DFieldRTheta> allfdistribu_host,
+                advect_density
+                = [&](host_t<DFieldRTheta> density_host,
                       host_t<DConstVectorFieldRTheta<X, Y>> advection_field_host,
                       double dt) {
-                      auto allfdistribu = ddc::create_mirror_view_and_copy(
+                      auto density = ddc::create_mirror_view_and_copy(
                               Kokkos::DefaultExecutionSpace(),
-                              allfdistribu_host);
+                              density_host);
                       auto advection_field = ddcHelper::create_mirror_view_and_copy(
                               Kokkos::DefaultExecutionSpace(),
                               advection_field_host);
                       m_advection_solver(
-                              get_field(allfdistribu),
+                              get_field(density),
                               get_const_field(advection_field),
                               dt);
-                      ddc::parallel_deepcopy(allfdistribu_host, allfdistribu);
+                      ddc::parallel_deepcopy(density_host, density);
                   };
 
         RK2<host_t<DFieldMemRTheta>,
@@ -193,19 +193,19 @@ public:
         for (int iter(0); iter < steps; ++iter) {
             time_stepper
                     .update(Kokkos::DefaultHostExecutionSpace(),
-                            allfdistribu_host,
+                            density_host,
                             dt,
                             define_advection_field,
-                            advect_allfdistribu);
+                            advect_density);
 
 
-            m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_host));
+            m_builder(get_field(density_coef), get_const_field(density_host));
             m_poisson_solver(charge_density_coord, get_field(electrical_potential));
             ddc::parallel_deepcopy(electrical_potential_host, electrical_potential);
             ddc::PdiEvent("iteration")
                     .with("iter", iter + 1)
                     .with("time", iter * dt)
-                    .with("density", allfdistribu_host)
+                    .with("density", density_host)
                     .with("electrical_potential", electrical_potential_host);
         }
         end_time = std::chrono::system_clock::now();
@@ -214,6 +214,6 @@ public:
         display_time_difference("Iterations time: ", start_time, end_time);
 
 
-        return allfdistribu_host;
+        return density_host;
     }
 };

--- a/src/geometryRTheta/time_solver/bsl_predcorr.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr.hpp
@@ -166,22 +166,18 @@ public:
                 };
 
         std::function<void(host_t<DFieldRTheta>, host_t<DConstVectorFieldRTheta<X, Y>>, double)>
-                advect_density
-                = [&](host_t<DFieldRTheta> density_host,
-                      host_t<DConstVectorFieldRTheta<X, Y>> advection_field_host,
-                      double dt) {
-                      auto density = ddc::create_mirror_view_and_copy(
-                              Kokkos::DefaultExecutionSpace(),
-                              density_host);
-                      auto advection_field = ddcHelper::create_mirror_view_and_copy(
-                              Kokkos::DefaultExecutionSpace(),
-                              advection_field_host);
-                      m_advection_solver(
-                              get_field(density),
-                              get_const_field(advection_field),
-                              dt);
-                      ddc::parallel_deepcopy(density_host, density);
-                  };
+                advect_density = [&](host_t<DFieldRTheta> density_host,
+                                     host_t<DConstVectorFieldRTheta<X, Y>> advection_field_host,
+                                     double dt) {
+                    auto density = ddc::create_mirror_view_and_copy(
+                            Kokkos::DefaultExecutionSpace(),
+                            density_host);
+                    auto advection_field = ddcHelper::create_mirror_view_and_copy(
+                            Kokkos::DefaultExecutionSpace(),
+                            advection_field_host);
+                    m_advection_solver(get_field(density), get_const_field(advection_field), dt);
+                    ddc::parallel_deepcopy(density_host, density);
+                };
 
         RK2<host_t<DFieldMemRTheta>,
             host_t<DVectorFieldMemRTheta<X, Y>>,

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
@@ -163,7 +163,7 @@ public:
 
 
     host_t<DFieldRTheta> operator()(
-            host_t<DFieldRTheta> allfdistribu_host,
+            host_t<DFieldRTheta> density_host,
             double const dt,
             int const steps) const final
     {
@@ -171,7 +171,7 @@ public:
         std::chrono::time_point<std::chrono::system_clock> end_time;
 
         // Grid. ------------------------------------------------------------------------------------------
-        IdxRangeRTheta const grid(get_idx_range<GridR, GridTheta>(allfdistribu_host));
+        IdxRangeRTheta const grid(get_idx_range<GridR, GridTheta>(density_host));
 
         host_t<FieldMemRTheta<CoordRTheta>> coords(grid);
         ddc::for_each(grid, [&](IdxRTheta const irtheta) {
@@ -205,10 +205,10 @@ public:
         start_time = std::chrono::system_clock::now();
         for (int iter(0); iter < steps; ++iter) {
             // STEP 1: From rho^n, we compute phi^n: Poisson equation
-            host_t<Spline2DMem> allfdistribu_coef(get_spline_idx_range(m_builder));
-            m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_host));
+            host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
+            m_builder(get_field(density_coef), get_const_field(density_host));
             PoissonLikeRHSFunction const
-                    charge_density_coord_1(get_const_field(allfdistribu_coef), m_evaluator);
+                    charge_density_coord_1(get_const_field(density_coef), m_evaluator);
             m_poisson_solver(charge_density_coord_1, electrostatic_potential_coef);
 
             polar_spline_evaluator(
@@ -219,7 +219,7 @@ public:
             ddc::PdiEvent("iteration")
                     .with("iter", iter)
                     .with("time", iter * dt)
-                    .with("density", allfdistribu_host)
+                    .with("density", density_host)
                     .with("electrical_potential", electrical_potential_host);
 
 
@@ -282,13 +282,13 @@ public:
 
             // X^P = X^n - dt/2 * ( E^n(X^n) + E^n(X^P) )/2:
             // --- Copy rho^n because it will be modified:
-            DFieldMemRTheta allfdistribu_predicted(grid);
-            ddc::parallel_deepcopy(allfdistribu_predicted, allfdistribu_host);
+            DFieldMemRTheta density_predicted(grid);
+            ddc::parallel_deepcopy(density_predicted, density_host);
             auto advection_field_k_tot = ddcHelper::create_mirror_view_and_copy(
                     Kokkos::DefaultExecutionSpace(),
                     get_field(advection_field_k_tot_host));
             m_advection_solver(
-                    get_field(allfdistribu_predicted),
+                    get_field(density_predicted),
                     get_const_field(advection_field_k_tot),
                     dt / 2.);
 
@@ -303,11 +303,11 @@ public:
 
 
             // STEP 4: From rho^P, we compute phi^P: Poisson equation
-            auto allfdistribu_predicted_host
-                    = ddc::create_mirror_view_and_copy(get_field(allfdistribu_predicted));
-            m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_predicted_host));
+            auto density_predicted_host
+                    = ddc::create_mirror_view_and_copy(get_field(density_predicted));
+            m_builder(get_field(density_coef), get_const_field(density_predicted_host));
             PoissonLikeRHSFunction const
-                    charge_density_coord_4(get_const_field(allfdistribu_coef), m_evaluator);
+                    charge_density_coord_4(get_const_field(density_coef), m_evaluator);
             m_poisson_solver(charge_density_coord_4, electrostatic_potential_coef);
 
             // STEP 5: From phi^P, we compute A^P:
@@ -357,38 +357,37 @@ public:
                           / 2.;
             });
             // X^k = X^n - dt * ( A^P(X^n) + A^P(X^P) )/2
-            auto allfdistribu = ddc::
-                    create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), allfdistribu_host);
+            auto density = ddc::
+                    create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_host);
             ddc::parallel_deepcopy(
                     ddcHelper::get<X>(advection_field_k_tot),
                     ddcHelper::get<X>(advection_field_k_tot_host));
             ddc::parallel_deepcopy(
                     ddcHelper::get<Y>(advection_field_k_tot),
                     ddcHelper::get<Y>(advection_field_k_tot_host));
-            m_advection_solver(get_field(allfdistribu), get_const_field(advection_field_k_tot), dt);
-            ddc::parallel_deepcopy(allfdistribu_host, get_const_field(allfdistribu));
+            m_advection_solver(get_field(density), get_const_field(advection_field_k_tot), dt);
+            ddc::parallel_deepcopy(density_host, get_const_field(density));
         }
 
         // STEP 1: From rho^n, we compute phi^n: Poisson equation
-        host_t<Spline2DMem> allfdistribu_coef(get_spline_idx_range(m_builder));
-        m_builder(get_field(allfdistribu_coef), get_const_field(allfdistribu_host));
+        host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
+        m_builder(get_field(density_coef), get_const_field(density_host));
         PoissonLikeRHSFunction const
-                charge_density_coord(get_const_field(allfdistribu_coef), m_evaluator);
+                charge_density_coord(get_const_field(density_coef), m_evaluator);
         m_poisson_solver(charge_density_coord, get_field(electrical_potential));
         ddc::parallel_deepcopy(electrical_potential_host, electrical_potential);
 
         ddc::PdiEvent("last_iteration")
                 .with("iter", steps)
                 .with("time", steps * dt)
-                .with("density", allfdistribu_host)
+                .with("density", density_host)
                 .with("electrical_potential", electrical_potential_host);
 
         end_time = std::chrono::system_clock::now();
         display_time_difference("Iterations time: ", start_time, end_time);
 
 
-
-        return allfdistribu_host;
+        return density_host;
     }
 
 

--- a/src/geometryRTheta/time_solver/itimesolver.hpp
+++ b/src/geometryRTheta/time_solver/itimesolver.hpp
@@ -15,7 +15,7 @@ public:
     /**
      * @brief Solves on @f$ T = dt*N @f$ the equations system.
      *
-     * @param[in, out] allfdistribu
+     * @param[in, out] density
      *      On input: the initial condition.
      *      On output: the solution at @f$ dt *N@f$.
      * @param[in] dt
@@ -23,10 +23,10 @@ public:
      * @param[in] steps
      *      The number @f$ N@f$ of time interactions.
      *
-     * @return A Field toward allfdistribu.
+     * @return A Field toward density.
      */
     virtual host_t<DFieldRTheta> operator()(
-            host_t<DFieldRTheta> allfdistribu,
+            host_t<DFieldRTheta> density,
             double const dt,
             int const steps = 1) const = 0;
 

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -291,8 +291,8 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     auto advection_field_xy_device = ddcHelper::
             create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_xy);
 
-    auto density_rtheta_device = ddc::
-            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_rtheta);
+    auto density_rtheta_device
+            = ddc::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_rtheta);
     auto advection_field_rtheta_device = ddcHelper::
             create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_rtheta);
 

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -182,8 +182,8 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     // ================================================================================================
     // INITIALISATION                                                                                 |
     // ================================================================================================
-    host_t<DFieldMemRTheta> allfdistribu_rtheta_alloc(grid);
-    host_t<DFieldMemRTheta> allfdistribu_xy_alloc(grid);
+    host_t<DFieldMemRTheta> density_rtheta_alloc(grid);
+    host_t<DFieldMemRTheta> density_xy_alloc(grid);
 
     host_t<DVectorFieldMemRTheta<X, Y>> advection_field_exact_alloc(grid);
     host_t<DVectorFieldMemRTheta<R, Theta>> advection_field_rtheta_alloc(grid_without_Opoint);
@@ -193,8 +193,8 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
 
     host_t<DFieldMemRTheta> electrostatic_potential_alloc(grid);
 
-    host_t<DFieldRTheta> allfdistribu_rtheta(allfdistribu_rtheta_alloc);
-    host_t<DFieldRTheta> allfdistribu_xy(allfdistribu_xy_alloc);
+    host_t<DFieldRTheta> density_rtheta(density_rtheta_alloc);
+    host_t<DFieldRTheta> density_xy(density_xy_alloc);
     host_t<DFieldRTheta> electrostatic_potential(electrostatic_potential_alloc);
 
     host_t<DVectorFieldRTheta<X, Y>> advection_field_exact(advection_field_exact_alloc);
@@ -210,8 +210,8 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
         CoordRTheta const coord_rtheta(ddc::coordinate(irtheta));
         CoordXY const coord_xy(to_physical_mapping(coord_rtheta));
 
-        allfdistribu_rtheta(irtheta) = simulation.function(coord_rtheta);
-        allfdistribu_xy(irtheta) = allfdistribu_rtheta(irtheta);
+        density_rtheta(irtheta) = simulation.function(coord_rtheta);
+        density_xy(irtheta) = density_rtheta(irtheta);
         electrostatic_potential(irtheta) = simulation.electrostatical_potential(coord_xy, 0);
 
         ddcHelper::assign_vector_field_element(
@@ -286,13 +286,13 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
         EXPECT_LE(abs(ddcHelper::get<Y>(difference_between_fields_xy_and_rtheta)(irtheta)), 1e-13);
     });
 
-    auto allfdistribu_xy_device
-            = ddc::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), allfdistribu_xy);
+    auto density_xy_device
+            = ddc::create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_xy);
     auto advection_field_xy_device = ddcHelper::
             create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_xy);
 
-    auto allfdistribu_rtheta_device = ddc::
-            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), allfdistribu_rtheta);
+    auto density_rtheta_device = ddc::
+            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_rtheta);
     auto advection_field_rtheta_device = ddcHelper::
             create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), advection_field_rtheta);
 
@@ -301,21 +301,21 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     // ================================================================================================
     for (int iter(0); iter < iter_nb; ++iter) {
         advection_operator(
-                get_field(allfdistribu_rtheta_device),
+                get_field(density_rtheta_device),
                 get_const_field(advection_field_rtheta_device),
                 advection_field_xy_centre,
                 dt);
         advection_operator(
-                get_field(allfdistribu_xy_device),
+                get_field(density_xy_device),
                 get_const_field(advection_field_xy_device),
                 dt);
 
-        ddc::parallel_deepcopy(allfdistribu_xy, get_const_field(allfdistribu_xy_device));
-        ddc::parallel_deepcopy(allfdistribu_rtheta, get_const_field(allfdistribu_rtheta_device));
+        ddc::parallel_deepcopy(density_xy, get_const_field(density_xy_device));
+        ddc::parallel_deepcopy(density_rtheta, get_const_field(density_rtheta_device));
 
         // Check the advected functions ---
         ddc::for_each(grid, [&](IdxRTheta const irtheta) {
-            EXPECT_NEAR(allfdistribu_rtheta(irtheta), allfdistribu_xy(irtheta), 5e-13);
+            EXPECT_NEAR(density_rtheta(irtheta), density_xy(irtheta), 5e-13);
         });
     }
 

--- a/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
@@ -213,7 +213,7 @@ host_t<FieldMemRTheta<CoordRTheta>> compute_exact_feet_rtheta(
  *      domain.
  * @param[in] grid
  *      An index range spanning the logical domain where the function is defined.
- * @param[in] allfdistribu_advected
+ * @param[in] density_advected
  *      The computed function.
  * @param[in] function_to_be_advected
  *      The exact function.
@@ -227,7 +227,7 @@ template <class LogicalToPhysicalMapping, class Function>
 double compute_difference_L2_norm(
         LogicalToPhysicalMapping const& to_physical_mapping,
         IdxRangeRTheta const& grid,
-        host_t<DFieldRTheta> allfdistribu_advected,
+        host_t<DFieldRTheta> density_advected,
         Function& function_to_be_advected,
         host_t<FieldRTheta<CoordRTheta>> const& feet_coord)
 {
@@ -235,7 +235,7 @@ double compute_difference_L2_norm(
     host_t<DFieldMemRTheta> difference_function(grid);
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
         exact_function(irtheta) = function_to_be_advected(feet_coord(irtheta));
-        difference_function(irtheta) = exact_function(irtheta) - allfdistribu_advected(irtheta);
+        difference_function(irtheta) = exact_function(irtheta) - density_advected(irtheta);
     });
 
     host_t<DFieldMemRTheta> const quadrature_coeffs = compute_coeffs_on_mapping(
@@ -363,7 +363,7 @@ void simulate(
     double const end_time = dt * iteration_number;
 
 
-    host_t<DFieldMemRTheta> allfdistribu_test(grid);
+    host_t<DFieldMemRTheta> density_test(grid);
 
     host_t<DVectorFieldMemRTheta<X, Y>> advection_field_test_vec_host(grid);
 
@@ -377,7 +377,7 @@ void simulate(
         if (ddc::get<R>(coord) <= 1e-15) {
             ddc::get<Theta>(coord) = 0;
         }
-        allfdistribu_test(irtheta) = simulation.advected_function(coord);
+        density_test(irtheta) = simulation.advected_function(coord);
     });
 
 
@@ -394,9 +394,9 @@ void simulate(
                 simulation.advection_field(coord_xy, 0.));
     });
 
-    auto allfdistribu = ddc::create_mirror_view_and_copy(
+    auto density = ddc::create_mirror_view_and_copy(
             Kokkos::DefaultExecutionSpace(),
-            get_field(allfdistribu_test));
+            get_field(density_test));
 
     auto advection_field_xy = ddcHelper::create_mirror_view_and_copy(
             Kokkos::DefaultExecutionSpace(),
@@ -405,16 +405,16 @@ void simulate(
     // SIMULATION -------------------------------------------------------------------------------
     // Advect "iteration_number" times:
     for (int i(0); i < iteration_number; ++i) {
-        advection_operator(get_field(allfdistribu), get_const_field(advection_field_xy), dt);
+        advection_operator(get_field(density), get_const_field(advection_field_xy), dt);
 
         // Save the advected function for each iteration:
         if (save_curves) {
-            ddc::parallel_deepcopy(allfdistribu_test, allfdistribu);
+            ddc::parallel_deepcopy(density_test, density);
             std::string const name = output_folder + "/after_" + std::to_string(i + 1) + ".txt";
-            saving_computed(to_physical_mapping_host, get_field(allfdistribu_test), name);
+            saving_computed(to_physical_mapping_host, get_field(density_test), name);
         }
     }
-    ddc::parallel_deepcopy(allfdistribu_test, allfdistribu);
+    ddc::parallel_deepcopy(density_test, density);
 
 
 
@@ -440,7 +440,7 @@ void simulate(
     double max_err = 0.;
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
         double const err
-                = fabs(allfdistribu_test(irtheta)
+                = fabs(density_test(irtheta)
                        - simulation.advected_function(feet_coords_rtheta_end_time(irtheta)));
         max_err = max_err > err ? max_err : err;
     });
@@ -456,7 +456,7 @@ void simulate(
               << compute_difference_L2_norm(
                          to_physical_mapping_host,
                          grid,
-                         get_field(allfdistribu_test),
+                         get_field(density_test),
                          simulation.advected_function,
                          get_field(feet_coords_rtheta_end_time))
               << std::endl;

--- a/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
@@ -394,9 +394,8 @@ void simulate(
                 simulation.advection_field(coord_xy, 0.));
     });
 
-    auto density = ddc::create_mirror_view_and_copy(
-            Kokkos::DefaultExecutionSpace(),
-            get_field(density_test));
+    auto density = ddc::
+            create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), get_field(density_test));
 
     auto advection_field_xy = ddcHelper::create_mirror_view_and_copy(
             Kokkos::DefaultExecutionSpace(),


### PR DESCRIPTION
Rename `fdistribu` which indicates a distribution function (i.e. a function defined in phase space so on spatial **and** velocity dimensions) and `allfdistribu` which indicates a distribution function defined for all the different species to `density` in the r, theta geometry. This is done because the function of interest in the r, theta geometry has no dependency on velocity space or on species. Fixes #148 