### PR TITLE
Allow overloaded functions in coordinate convertor classes

### DIFF
--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -151,6 +151,15 @@ public:
         return r;
     }
 
+    /**
+     * @brief Compute the Jacobian, the determinant of the Jacobian matrix of the mapping
+     * as a function of the radius.
+     *
+     * @param[in] coord
+     *          The radial coordinate where we evaluate the Jacobian.
+     *
+     * @return A double with the value of the determinant of the Jacobian matrix.
+     */
     KOKKOS_INLINE_FUNCTION double jacobian(Coord<R> const& coord) const
     {
         return ddc::get<R>(coord);

--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -151,6 +151,11 @@ public:
         return r;
     }
 
+    KOKKOS_INLINE_FUNCTION double jacobian(Coord<R> const& coord) const
+    {
+        return ddc::get<R>(coord);
+    }
+
     /**
      * @brief Compute full Jacobian matrix.
      *

--- a/src/mapping/mapping_tools.hpp
+++ b/src/mapping/mapping_tools.hpp
@@ -132,7 +132,7 @@ class DefinesInvJacobian
 {
     struct IdxTag;
     template <typename ClassType>
-    using inv_jacobian_matrix = decltype(std::declval<ClassType>().template inv_jacobian_matrix(
+    using inv_jacobian_matrix = decltype(std::declval<ClassType>().inv_jacobian_matrix(
             std::declval<CoordinateType>()));
     template <typename ClassType>
     using inv_jacobian_component

--- a/src/mapping/mapping_tools.hpp
+++ b/src/mapping/mapping_tools.hpp
@@ -15,7 +15,7 @@ struct MappingAccessibility : std::false_type
 {
 };
 
-template <typename T, template <typename ClassType> typename Attribute>
+template <typename Type, template <typename ClassType> typename Attribute>
 class CheckClassAttributeExistence
 {
     template <typename C, typename = Attribute<C>>
@@ -24,7 +24,7 @@ class CheckClassAttributeExistence
     static std::false_type test(...);
 
 public:
-    static constexpr bool value = decltype(test<T>(0))::value;
+    static constexpr bool value = decltype(test<Type>(0))::value;
 };
 
 /**

--- a/src/mapping/mapping_tools.hpp
+++ b/src/mapping/mapping_tools.hpp
@@ -15,32 +15,16 @@ struct MappingAccessibility : std::false_type
 {
 };
 
-/**
- * @brief A helper class to determine if a class has a given attribute (type alias or method).
- * @tparam Type The type whose attributes are being checked.
- * @tparam Attribute A template which returns the expected attribute when given a compatible class.
- */
-template <typename Type, template <typename ClassType> typename Attribute>
+template <typename T, template <typename ClassType> typename Attribute>
 class CheckClassAttributeExistence
 {
-private:
-    // Class for SFINAE deduction
-    template <typename U>
-    class check
-    {
-    };
-
-    // Function that will be chosen if ClassType has a attribute called idx_range with 0 arguments
-    template <typename ClassType>
-    static char attribute(check<Attribute<ClassType>>*);
-
-    // Function that will be chosen by default
-    template <typename ClassType>
-    static long attribute(...);
+    template <typename C, typename = Attribute<C>>
+    static std::true_type test(int);
+    template <typename C>
+    static std::false_type test(...);
 
 public:
-    /// True if the type has the expected attribute, false otherwise
-    static constexpr bool has_attribute = (sizeof(attribute<Type>(0)) == sizeof(char));
+    static constexpr bool value = decltype(test<T>(0))::value;
 };
 
 /**
@@ -56,9 +40,8 @@ class IsMapping
 
     static bool constexpr is_mapping()
     {
-        constexpr bool success
-                = CheckClassAttributeExistence<Type, coord_arg_type>::has_attribute
-                  && CheckClassAttributeExistence<Type, coord_result_type>::has_attribute;
+        constexpr bool success = CheckClassAttributeExistence<Type, coord_arg_type>::value
+                                 && CheckClassAttributeExistence<Type, coord_result_type>::value;
         if constexpr (success) {
             using CoordArg = typename Type::CoordArg;
             using CoordResult = typename Type::CoordResult;
@@ -77,23 +60,26 @@ class DefinesJacobian
 {
     struct IdxTag;
     template <typename ClassType>
-    using jacobian_matrix = decltype(&ClassType::jacobian_matrix);
+    using jacobian_matrix
+            = decltype(std::declval<ClassType>().jacobian_matrix(std::declval<CoordinateType>()));
     template <typename ClassType>
-    using jacobian_component = decltype(&ClassType::template jacobian_component<IdxTag, IdxTag>);
+    using jacobian_component
+            = decltype(std::declval<ClassType>().template jacobian_component<IdxTag, IdxTag>(
+                    std::declval<CoordinateType>()));
     template <typename ClassType>
-    using jacobian = decltype(&ClassType::jacobian);
+    using jacobian = decltype(std::declval<ClassType>().jacobian(std::declval<CoordinateType>()));
 
     static bool constexpr has_jacobian_methods()
     {
-        if constexpr (!CheckClassAttributeExistence<Type, jacobian_matrix>::has_attribute) {
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian_matrix>::value) {
             static_assert(HideError, "A Mapping must define the jacobian_matrix function");
             return false;
         }
-        if constexpr (!CheckClassAttributeExistence<Type, jacobian_component>::has_attribute) {
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian_component>::value) {
             static_assert(HideError, "A Mapping must define the jacobian_component function");
             return false;
         }
-        if constexpr (!CheckClassAttributeExistence<Type, jacobian>::has_attribute) {
+        if constexpr (!CheckClassAttributeExistence<Type, jacobian>::value) {
             static_assert(HideError, "A Mapping must define the jacobian function");
             return false;
         }
@@ -108,33 +94,23 @@ class DefinesJacobian
             using ArgBasisCov = get_covariant_dims_t<ddc::to_type_seq_t<typename Type::CoordArg>>;
             using ResultBasis
                     = get_contravariant_dims_t<ddc::to_type_seq_t<typename Type::CoordResult>>;
-            if constexpr (!std::is_invocable_r_v<
+            if constexpr (!std::is_same_v<
                                   DTensor<ResultBasis, ArgBasisCov>,
-                                  decltype(&Type::jacobian_matrix),
-                                  Type,
-                                  CoordinateType>) {
+                                  jacobian_matrix<Type>>) {
                 static_assert(
                         HideError,
                         "The jacobian_matrix method of a Mapping must take a Coordinate as an "
                         "argument and return a Tensor.");
                 return false;
             }
-            if constexpr (!std::is_invocable_r_v<
-                                  double,
-                                  jacobian_component<Type>,
-                                  Type,
-                                  CoordinateType>) {
+            if constexpr (!std::is_same_v<double, jacobian_component<Type>>) {
                 static_assert(
                         HideError,
                         "The jacobian_component method of a Mapping must take a Coordinate as an "
                         "argument and return a double.");
                 return false;
             }
-            if constexpr (!std::is_invocable_r_v<
-                                  double,
-                                  decltype(&Type::jacobian),
-                                  Type,
-                                  CoordinateType>) {
+            if constexpr (!std::is_same_v<double, jacobian<Type>>) {
                 static_assert(
                         HideError,
                         "The jacobian method of a Mapping must take a Coordinate as an argument "
@@ -156,18 +132,20 @@ class DefinesInvJacobian
 {
     struct IdxTag;
     template <typename ClassType>
-    using inv_jacobian_type = decltype(&ClassType::inv_jacobian_matrix);
+    using inv_jacobian_matrix = decltype(std::declval<ClassType>().template inv_jacobian_matrix(
+            std::declval<CoordinateType>()));
     template <typename ClassType>
     using inv_jacobian_component
-            = decltype(&ClassType::template inv_jacobian_component<IdxTag, IdxTag>);
+            = decltype(std::declval<ClassType>().template inv_jacobian_component<IdxTag, IdxTag>(
+                    std::declval<CoordinateType>()));
 
     static bool constexpr has_inv_jacobian_methods()
     {
-        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_type>::has_attribute) {
+        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_matrix>::value) {
             static_assert(HideError, "A Mapping must define the inv_jacobian_matrix function");
             return false;
         }
-        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_component>::has_attribute) {
+        if constexpr (!CheckClassAttributeExistence<Type, inv_jacobian_component>::value) {
             static_assert(HideError, "A Mapping must define the inv_jacobian_component function");
             return false;
         }
@@ -182,22 +160,16 @@ class DefinesInvJacobian
             using ResultBasisCov
                     = get_covariant_dims_t<ddc::to_type_seq_t<typename Type::CoordResult>>;
             using ArgBasis = get_contravariant_dims_t<ddc::to_type_seq_t<typename Type::CoordArg>>;
-            if constexpr (!std::is_invocable_r_v<
+            if constexpr (!std::is_same_v<
                                   DTensor<ArgBasis, ResultBasisCov>,
-                                  decltype(&Type::inv_jacobian_matrix),
-                                  Type,
-                                  CoordinateType>) {
+                                  inv_jacobian_matrix<Type>>) {
                 static_assert(
                         HideError,
                         "The inv_jacobian_matrix method of a Mapping must take a Coordinate as an "
                         "argument and return a Tensor.");
                 return false;
             }
-            if constexpr (!std::is_invocable_r_v<
-                                  double,
-                                  inv_jacobian_component<Type>,
-                                  Type,
-                                  CoordinateType>) {
+            if constexpr (!std::is_same_v<double, inv_jacobian_component<Type>>) {
                 static_assert(
                         HideError,
                         "The inv_jacobian_component method of a Mapping must take a Coordinate as "
@@ -228,7 +200,7 @@ private:
 
     static bool constexpr is_analytical_mapping()
     {
-        constexpr bool success = CheckClassAttributeExistence<Type, inverse_mapping>::has_attribute;
+        constexpr bool success = CheckClassAttributeExistence<Type, inverse_mapping>::value;
         if constexpr (success) {
             return std::is_invocable_v<inverse_mapping<Type>, Type>;
         }


### PR DESCRIPTION
Allow overloaded functions in classes in `mapping/`. These classes are often tested with `is_mapping_v`, `has_jacobian_v` etc. These static checkers are designed to check if a specified method exists, but before this PR they did not handle overloaded methods correctly. No method was identified even if the required method existed. This PR fixes this by changing the implementation of `CheckClassAttributeExistence` to use the result type of the method (selected using the arguments) instead of the address of the method. Fixes #285.