### PR TITLE
Add an identity mapping for testing

### DIFF
--- a/src/data_types/tensor.hpp
+++ b/src/data_types/tensor.hpp
@@ -9,22 +9,6 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-namespace detail {
-
-template <class ValidIndexSet>
-struct ToCoord;
-
-template <class... Dims>
-struct ToCoord<VectorIndexSet<Dims...>>
-{
-    using type = Coord<Dims...>;
-};
-
-template <class ValidIndexSet>
-using to_coord_t = typename ToCoord<ValidIndexSet>::type;
-
-} // namespace detail
-
 /**
  * @brief A class representing a Tensor.
  * @tparam ElementType The type of the elements of the tensor (usually double/complex).

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -155,7 +155,7 @@ public:
 private:
     template <class... RowDims, class... ColDims>
     void fill_diagonal_elements(
-            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
+            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix) const
     {
         ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);
     }

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -3,6 +3,18 @@
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
 
+/**
+ * @brief A class describing an identity transformation.
+ *
+ * It is not expected that this class appear in a final simulation,
+ * but it may be useful when debugging vector calculations on
+ * general coordinates.
+ *
+ * @tparam ArgBasis A VectorIndexSet containing the continuous
+ *      dimensions on which the argument is described.
+ * @tparam ResultBasis A VectorIndexSet containing the continuous
+ *      dimensions on which the result is described.
+ */
 template <class ArgBasis, class ResultBasis>
 class IdentityCoordinateChange
 {

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+#include "ddc_aliases.hpp"
+#include "ddc_helper.hpp"
 
 template <class ArgBasis, class ResultBasis>
 class IdentityCoordinateChange
 {
 public:
     /// The type of the argument of the function described by this mapping
-    using CoordArg = to_coord_t<ArgBasis>;
+    using CoordArg = ddcHelper::to_coord_t<ArgBasis>;
     /// The type of the result of the function described by this mapping
-    using CoordResult = to_coord<ResultBasis>;
+    using CoordResult = ddcHelper::to_coord_t<ResultBasis>;
 
 private:
     using ArgBasisCov = vector_index_set_dual_t<ArgBasis>;
@@ -36,7 +38,7 @@ public:
      *
      * @return A double with the value of the determinant of the Jacobian matrix.
      */
-    static constexpr double jacobian(CoordArg const& coord) const
+    KOKKOS_INLINE_FUNCTION double jacobian(CoordArg const& coord) const
     {
         return 1;
     }
@@ -64,7 +66,7 @@ public:
      * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
      */
     template <class IndexTag1, class IndexTag2>
-    static constexpr double jacobian_component(Coord<R, Theta> const& coord) const
+    KOKKOS_INLINE_FUNCTION double jacobian_component(CoordArg const& coord) const
     {
         static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
         static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
@@ -85,7 +87,7 @@ public:
      *
      * @return A double with the value of the determinant of the Jacobian matrix.
      */
-    static constexpr double inv_jacobian(CoordArg const& coord) const
+    KOKKOS_INLINE_FUNCTION double inv_jacobian(CoordArg const& coord) const
     {
         return 1;
     }
@@ -114,7 +116,7 @@ public:
      * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
      */
     template <class IndexTag1, class IndexTag2>
-    static constexpr double inv_jacobian_component(Coord<R, Theta> const& coord) const
+    KOKKOS_INLINE_FUNCTION double inv_jacobian_component(CoordArg const& coord) const
     {
         static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
         static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -154,7 +154,7 @@ public:
 
 private:
     template <class... RowDims, class... ColDims>
-    void fill_diagonal_elems(
+    void fill_diagonal_elements(
             DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
     {
         ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+template <class ArgBasis, class ResultBasis>
+class IdentityCoordinateChange
+{
+public:
+    /// The type of the argument of the function described by this mapping
+    using CoordArg = to_coord_t<ArgBasis>;
+    /// The type of the result of the function described by this mapping
+    using CoordResult = to_coord<ResultBasis>;
+
+private:
+    using ArgBasisCov = vector_index_set_dual_t<ArgBasis>;
+
+public:
+    /**
+     * @brief Convert the coordinate in the argument basis to the equivalent coordinate in the result basis.
+     *
+     * @param[in] coord The coordinate to be converted.
+     *
+     * @return The equivalent coordinate.
+     */
+    template <class... ArgDims>
+    KOKKOS_FUNCTION CoordResult operator()(Coord<ArgDims...> const& coord) const
+    {
+        static_assert(std::is_same_v<CoordArg, Coord<ArgDims...>>);
+        return CoordResult((ddc::get<ArgDims>(coord))...);
+    }
+
+    /**
+     * @brief Compute the Jacobian, the determinant of the Jacobian matrix of the mapping.
+     *
+     * @param[in] coord
+     *          The coordinate where we evaluate the Jacobian.
+     *
+     * @return A double with the value of the determinant of the Jacobian matrix.
+     */
+    static constexpr double jacobian(CoordArg const& coord) const
+    {
+        return 1;
+    }
+
+    /**
+     * @brief Compute full Jacobian matrix.
+     *
+     * @param[in] coord
+     * 				The coordinate where we evaluate the Jacobian matrix.
+     * @return The Jacobian matrix.
+     */
+    KOKKOS_FUNCTION DTensor<ResultBasis, ArgBasisCov> jacobian_matrix(CoordArg const& coord) const
+    {
+        DTensor<ResultBasis, ArgBasisCov> jacobian_matrix(0.0);
+        fill_diagonal_elements(jacobian_matrix);
+        return jacobian_matrix;
+    }
+
+    /**
+     * @brief Compute the (i,j) coefficient of the Jacobian matrix.
+     * 
+     * @param[in] coord
+     *              The coordinate where we evaluate the Jacobian matrix.
+     *
+     * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
+     */
+    template <class IndexTag1, class IndexTag2>
+    static constexpr double jacobian_component(Coord<R, Theta> const& coord) const
+    {
+        static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
+        static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
+        if constexpr (
+                (ddc::type_seq_rank_v<IndexTag1, ResultBasis>)
+                == (ddc::type_seq_rank_v<IndexTag2, ArgBasisCov>)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @brief Compute the Jacobian, the determinant of the Jacobian matrix of the mapping.
+     *
+     * @param[in] coord
+     *          The coordinate where we evaluate the Jacobian.
+     *
+     * @return A double with the value of the determinant of the Jacobian matrix.
+     */
+    static constexpr double inv_jacobian(CoordArg const& coord) const
+    {
+        return 1;
+    }
+
+    /**
+     * @brief Compute full Jacobian matrix.
+     *
+     * @param[in] coord
+     * 				The coordinate where we evaluate the Jacobian matrix.
+     * @return The Jacobian matrix.
+     */
+    KOKKOS_FUNCTION DTensor<ResultBasis, ArgBasisCov> inv_jacobian_matrix(
+            CoordArg const& coord) const
+    {
+        DTensor<ResultBasis, ArgBasisCov> inv_jacobian_matrix(0.0);
+        fill_diagonal_elements(inv_jacobian_matrix);
+        return inv_jacobian_matrix;
+    }
+
+    /**
+     * @brief Compute the (i,j) coefficient of the Jacobian matrix.
+     * 
+     * @param[in] coord
+     *              The coordinate where we evaluate the Jacobian matrix.
+     *
+     * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
+     */
+    template <class IndexTag1, class IndexTag2>
+    static constexpr double inv_jacobian_component(Coord<R, Theta> const& coord) const
+    {
+        static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
+        static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
+        if constexpr (
+                (ddc::type_seq_rank_v<IndexTag1, ResultBasis>)
+                == (ddc::type_seq_rank_v<IndexTag2, ArgBasisCov>)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @brief Get the inverse mapping.
+     *
+     * @return The inverse mapping.
+     */
+    KOKKOS_INLINE_FUNCTION IdentityCoordinateChange<ResultBasis, ArgBasis> get_inverse_mapping()
+            const
+    {
+        return IdentityCoordinateChange<ResultBasis, ArgBasis>();
+    }
+
+private:
+    template <class... RowDims, class... ColDims>
+    void fill_diagonal_elems(
+            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
+    {
+        ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);
+    }
+};
+
+namespace mapping_detail {
+template <class ArgBasis, class ResultBasis, class ExecSpace>
+struct MappingAccessibility<ExecSpace, IdentityCoordinateChange<ArgBasis, ResultBasis>>
+    : std::true_type
+{
+};
+} // namespace mapping_detail

--- a/src/utils/ddc_helper.hpp
+++ b/src/utils/ddc_helper.hpp
@@ -291,6 +291,16 @@ struct TypeSeqIntersection<
 };
 
 
+template <class ValidIndexSet>
+struct ToCoord;
+
+template <class... Dims>
+struct ToCoord<VectorIndexSet<Dims...>>
+{
+    using type = Coord<Dims...>;
+};
+
+
 } // namespace detail
 
 /**
@@ -325,4 +335,8 @@ using apply_template_to_type_seq_t = typename detail::ApplyTemplateToTypeSeq<Tem
 template <class TypeSeq1, class TypeSeq2>
 using type_seq_intersection_t =
         typename detail::TypeSeqIntersection<TypeSeq1, TypeSeq2, ddc::detail::TypeSeq<>>::type;
+
+/// Get a coordinate from a TypeSeq
+template <class ValidIndexSet>
+using to_coord_t = typename ToCoord<ValidIndexSet>::type;
 } // namespace ddcHelper

--- a/src/utils/ddc_helper.hpp
+++ b/src/utils/ddc_helper.hpp
@@ -295,7 +295,7 @@ template <class ValidIndexSet>
 struct ToCoord;
 
 template <class... Dims>
-struct ToCoord<VectorIndexSet<Dims...>>
+struct ToCoord<ddc::detail::TypeSeq<Dims...>>
 {
     using type = Coord<Dims...>;
 };
@@ -338,5 +338,5 @@ using type_seq_intersection_t =
 
 /// Get a coordinate from a TypeSeq
 template <class ValidIndexSet>
-using to_coord_t = typename ToCoord<ValidIndexSet>::type;
+using to_coord_t = typename detail::ToCoord<ValidIndexSet>::type;
 } // namespace ddcHelper

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -102,3 +102,12 @@ TEST(MappingStaticAsserts, CartToBarycentric)
     static_assert(is_mapping_v<Mapping>);
     static_assert(is_analytical_mapping_v<Mapping>);
 }
+
+TEST(MappingStaticAsserts, Identity)
+{
+    using Mapping = IdentityCoordinateChange<VectorIndexSet<X, Y, Z>, VectorIndexSet<X, Y, Z>>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(has_jacobian_v<Mapping, Coord<X, Y, Z>>);
+    static_assert(has_inv_jacobian_v<Mapping, Coord<X, Y, Z>>);
+    static_assert(is_analytical_mapping_v<Mapping>);
+}

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -11,6 +11,7 @@
 #include "czarny_to_cartesian.hpp"
 #include "discrete_to_cartesian.hpp"
 #include "geometry_mapping_tests.hpp"
+#include "identity_coordinate_change.hpp"
 #include "mapping_tools.hpp"
 
 


### PR DESCRIPTION
Add an identity mapping. This is useful for testing vector expressions (which depend on a mapping) in a Cartesian geometry. Fixes #300 