### PR TITLE
Clean mapping interface

### DIFF
--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -242,7 +242,7 @@ private:
                 get_const_field(coords),
                 get_const_field(electrostatic_potential_coef));
 
-        InverseJacobianMatrix<Mapping, CoordRTheta> inv_jacobian_matrix(m_mapping);
+        InverseJacobianMatrix inv_jacobian_matrix(m_mapping);
 
         // > computation of the electric field
         ddc::for_each(grid, [&](IdxRTheta const irtheta) {

--- a/src/mapping/cartesian_to_circular.hpp
+++ b/src/mapping/cartesian_to_circular.hpp
@@ -53,6 +53,8 @@ public:
     using CoordArg = Coord<X, Y>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<R, Theta>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first physical coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/cartesian_to_cylindrical.hpp
+++ b/src/mapping/cartesian_to_cylindrical.hpp
@@ -72,6 +72,8 @@ public:
     using CoordArg = Coord<X, Y, Z>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<R, Z, Zeta>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first Cartesian coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/circular_to_cartesian.hpp
+++ b/src/mapping/circular_to_cartesian.hpp
@@ -56,6 +56,8 @@ public:
     using CoordArg = Coord<R, Theta>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<X, Y>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first physical coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/combined_mapping.hpp
+++ b/src/mapping/combined_mapping.hpp
@@ -125,8 +125,7 @@ public:
             static_assert(std::is_same_v<CoordJacobian, typename Mapping1::CoordJacobian>);
             static_assert(std::is_same_v<CoordJacobian, typename InverseMapping2::CoordJacobian>);
             // The Jacobian defined on CoordJacobian is the inverse of the inverse mapping
-            InverseJacobianMatrix<InverseMapping2, CoordJacobian> jacobian_mapping_2(
-                    m_mapping_2.get_inverse_mapping());
+            InverseJacobianMatrix jacobian_mapping_2(m_mapping_2.get_inverse_mapping());
             return tensor_mul(
                     index<'i', 'j'>(m_mapping_1.jacobian_matrix(coord)),
                     index<'j', 'k'>(jacobian_mapping_2(coord)));

--- a/src/mapping/combined_mapping.hpp
+++ b/src/mapping/combined_mapping.hpp
@@ -120,8 +120,10 @@ public:
         if constexpr (std::is_same_v<CoordJacobian, typename Mapping2::CoordResult>) {
             static_assert(is_analytical_mapping_v<Mapping2>);
             using InverseMapping2 = inverse_mapping_t<Mapping2>;
-            static_assert(has_jacobian_v<Mapping1, CoordJacobian>);
-            static_assert(has_jacobian_v<InverseMapping2, CoordJacobian>);
+            static_assert(has_jacobian_v<Mapping1>);
+            static_assert(has_jacobian_v<InverseMapping2>);
+            static_assert(std::is_same_v<CoordJacobian, typename Mapping1::CoordJacobian>);
+            static_assert(std::is_same_v<CoordJacobian, typename InverseMapping2::CoordJacobian>);
             // The Jacobian defined on CoordJacobian is the inverse of the inverse mapping
             InverseJacobianMatrix<InverseMapping2, CoordJacobian> jacobian_mapping_2(
                     m_mapping_2.get_inverse_mapping());

--- a/src/mapping/combined_mapping.hpp
+++ b/src/mapping/combined_mapping.hpp
@@ -269,14 +269,13 @@ private:
             static_assert(is_analytical_mapping_v<Mapping2>);
             using InverseMapping2 = inverse_mapping_t<Mapping2>;
             InverseMapping2 inv_mapping_2 = m_mapping_2.get_inverse_mapping();
-            InverseJacobianMatrix<Mapping1, CoordJacobian> inv_jacobian_matrix_1(m_mapping_1);
+            InverseJacobianMatrix inv_jacobian_matrix_1(m_mapping_1);
             return tensor_mul(
                     index<'i', 'j'>(inv_mapping_2.jacobian_matrix(coord)),
                     index<'j', 'k'>(inv_jacobian_matrix_1(coord)));
         } else {
-            InverseJacobianMatrix<Mapping1, typename Mapping1::CoordArg> inv_jacobian_matrix_1(
-                    m_mapping_1);
-            InverseJacobianMatrix<Mapping2, CoordJacobian> inv_jacobian_matrix_2(m_mapping_2);
+            InverseJacobianMatrix inv_jacobian_matrix_1(m_mapping_1);
+            InverseJacobianMatrix inv_jacobian_matrix_2(m_mapping_2);
             typename Mapping1::CoordArg coord_map1 = m_mapping_2(coord);
             return tensor_mul(
                     index<'i', 'j'>(inv_jacobian_matrix_2(coord)),

--- a/src/mapping/combined_mapping.hpp
+++ b/src/mapping/combined_mapping.hpp
@@ -20,21 +20,23 @@
  * The functions in this mapping are defined on the coordinate system associated
  * with the domain @f$ \Omega_{mid} @f$.
  */
-template <class Mapping1, class Mapping2, class CoordJacobian = typename Mapping2::CoordResult>
+template <class Mapping1, class Mapping2, class CoordJacobianType = typename Mapping2::CoordResult>
 class CombinedMapping
 {
     static_assert(is_mapping_v<Mapping1>);
     static_assert(is_mapping_v<Mapping2>);
     static_assert(std::is_same_v<typename Mapping2::CoordResult, typename Mapping1::CoordArg>);
     static_assert(
-            (std::is_same_v<CoordJacobian, typename Mapping2::CoordArg>)
-            || (std::is_same_v<CoordJacobian, typename Mapping2::CoordResult>));
+            (std::is_same_v<CoordJacobianType, typename Mapping2::CoordArg>)
+            || (std::is_same_v<CoordJacobianType, typename Mapping2::CoordResult>));
 
 public:
     /// The type of the argument of the function described by this mapping.
     using CoordArg = typename Mapping2::CoordArg;
     /// The type of the result of the function described by this mapping.
     using CoordResult = typename Mapping1::CoordResult;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordJacobianType;
     /// The type of the Jacobian matrix.
     using JacobianMatrixType = DTensor<
             ddc::to_type_seq_t<CoordResult>,

--- a/src/mapping/cylindrical_to_cartesian.hpp
+++ b/src/mapping/cylindrical_to_cartesian.hpp
@@ -72,6 +72,8 @@ public:
     using CoordArg = Coord<R, Z, Zeta>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<X, Y, Z>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first Cartesian coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/czarny_to_cartesian.hpp
+++ b/src/mapping/czarny_to_cartesian.hpp
@@ -63,6 +63,8 @@ public:
     using CoordArg = Coord<R, Theta>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<X, Y>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first physical coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/discrete_to_cartesian.hpp
+++ b/src/mapping/discrete_to_cartesian.hpp
@@ -57,6 +57,8 @@ public:
     using CoordArg = Coord<R, Theta>;
     /// The type of the result of the function described by this mapping
     using CoordResult = Coord<X, Y>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
     /// @brief The covariant form of the first physical coordinate.
     using X_cov = typename X::Dual;

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -23,6 +23,8 @@ public:
     using CoordArg = ddcHelper::to_coord_t<ArgBasis>;
     /// The type of the result of the function described by this mapping
     using CoordResult = ddcHelper::to_coord_t<ResultBasis>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = ddcHelper::to_coord_t<ArgBasis>;
 
 private:
     using ArgBasisCov = vector_index_set_dual_t<ArgBasis>;

--- a/src/mapping/inverse_jacobian_matrix.hpp
+++ b/src/mapping/inverse_jacobian_matrix.hpp
@@ -12,16 +12,14 @@
  * Otherwise the inverse is calculated from the Jacobian matrix.
  *
  * @tparam Mapping The mapping whose inverse we are interested in.
- * @tparam PositionCoordinate The coordinate system in which the inverse should be calculated.
  */
-template <class Mapping, class PositionCoordinate = typename Mapping::CoordArg>
+template <class Mapping>
 class InverseJacobianMatrix
 {
 private:
     using ValidArgIndices = ddc::to_type_seq_t<typename Mapping::CoordArg>;
     using ValidResultIndices = ddc::to_type_seq_t<typename Mapping::CoordResult>;
-
-    static_assert(std::is_same_v<PositionCoordinate, typename Mapping::CoordJacobian>);
+    using CoordJacobian = typename Mapping::CoordJacobian;
 
 public:
     /// The type of the tensor representing the inverse Jacobian.
@@ -48,7 +46,7 @@ public:
      * @param[in] coord The coordinate where we evaluate the Jacobian matrix.
      * @returns The inverse Jacobian matrix returned.
      */
-    KOKKOS_INLINE_FUNCTION InverseJacobianTensor operator()(PositionCoordinate const& coord) const
+    KOKKOS_INLINE_FUNCTION InverseJacobianTensor operator()(CoordJacobian const& coord) const
     {
         if constexpr (has_inv_jacobian_v<Mapping, false>) {
             return m_mapping.inv_jacobian_matrix(coord);
@@ -73,7 +71,7 @@ public:
      * @return A double with the value of the (i,j) coefficient of the inverse Jacobian matrix.
      */
     template <class IndexTag1, class IndexTag2>
-    KOKKOS_INLINE_FUNCTION double inv_jacobian_component(PositionCoordinate const& coord) const
+    KOKKOS_INLINE_FUNCTION double inv_jacobian_component(CoordJacobian const& coord) const
     {
         static_assert(ddc::in_tags_v<IndexTag1, ValidArgIndices>);
         static_assert(ddc::in_tags_v<IndexTag2, get_covariant_dims_t<ValidResultIndices>>);

--- a/src/mapping/inverse_jacobian_matrix.hpp
+++ b/src/mapping/inverse_jacobian_matrix.hpp
@@ -21,6 +21,8 @@ private:
     using ValidArgIndices = ddc::to_type_seq_t<typename Mapping::CoordArg>;
     using ValidResultIndices = ddc::to_type_seq_t<typename Mapping::CoordResult>;
 
+    static_assert(std::is_same_v<PositionCoordinate, typename Mapping::CoordJacobian>);
+
 public:
     /// The type of the tensor representing the inverse Jacobian.
     using InverseJacobianTensor
@@ -48,10 +50,10 @@ public:
      */
     KOKKOS_INLINE_FUNCTION InverseJacobianTensor operator()(PositionCoordinate const& coord) const
     {
-        if constexpr (has_inv_jacobian_v<Mapping, PositionCoordinate, false>) {
+        if constexpr (has_inv_jacobian_v<Mapping, false>) {
             return m_mapping.inv_jacobian_matrix(coord);
         } else {
-            static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
+            static_assert(has_jacobian_v<Mapping>);
             DTensor<ValidResultIndices, vector_index_set_dual_t<ValidArgIndices>> jacobian
                     = m_mapping.jacobian_matrix(coord);
             assert(fabs(determinant(jacobian)) > 1e-15);
@@ -76,10 +78,10 @@ public:
         static_assert(ddc::in_tags_v<IndexTag1, ValidArgIndices>);
         static_assert(ddc::in_tags_v<IndexTag2, get_covariant_dims_t<ValidResultIndices>>);
 
-        if constexpr (has_inv_jacobian_v<Mapping, PositionCoordinate, false>) {
+        if constexpr (has_inv_jacobian_v<Mapping, false>) {
             return m_mapping.template inv_jacobian_component<IndexTag1, IndexTag2>(coord);
         } else {
-            static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
+            static_assert(has_jacobian_v<Mapping>);
             static_assert(Mapping::CoordArg::size() == 2);
 
             using DimArg0 = ddc::type_seq_element_t<0, ValidArgIndices>;

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -15,7 +15,7 @@
  * @tparam Mapping The mapping providing the Jacobian operator.
  * @tparam PositionCoordinate The coordinate type where the metric tensor can be evaluated.
  */
-template <class Mapping, class PositionCoordinate = typename Mapping::CoordArg>
+template <class Mapping, class PositionCoordinate = typename Mapping::CoordJacobian>
 class MetricTensorEvaluator
 {
     static_assert(is_mapping_v<Mapping>);

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -84,7 +84,7 @@ public:
      */
     KOKKOS_FUNCTION DTensor<Dims, Dims> inverse(CoordArg const& coord) const
     {
-        InverseJacobianMatrix<Mapping, PositionCoordinate> get_inverse_jacobian(m_mapping);
+        InverseJacobianMatrix get_inverse_jacobian(m_mapping);
         Tensor inv_J = get_inverse_jacobian(coord);
         return tensor_mul(index<'i', 'j'>(inv_J), index<'k', 'j'>(inv_J));
     }

--- a/src/mapping/metric_tensor_evaluator.hpp
+++ b/src/mapping/metric_tensor_evaluator.hpp
@@ -19,7 +19,12 @@ template <class Mapping, class PositionCoordinate = typename Mapping::CoordArg>
 class MetricTensorEvaluator
 {
     static_assert(is_mapping_v<Mapping>);
-    static_assert(has_jacobian_v<Mapping, PositionCoordinate>);
+    static_assert(has_jacobian_v<Mapping>);
+    static_assert(
+            std::is_same_v<PositionCoordinate, typename Mapping::CoordJacobian>,
+            "The metric tensor is calculated from the Jacobian matrix. In order to evaluate the "
+            "metric tensor on a coordinate different to the one given as argument to the mapping, "
+            "please define a specialisation of this class.");
     static_assert(
             (is_covariant_vector_index_set_v<ddc::to_type_seq_t<typename Mapping::CoordResult>>)&&(
                     is_contravariant_vector_index_set_v<

--- a/src/mapping/toroidal_to_cylindrical.hpp
+++ b/src/mapping/toroidal_to_cylindrical.hpp
@@ -55,6 +55,8 @@ public:
     using CoordArg = Coord<Rho, Theta, Phi>;
     /// The type of the result of the function described by this mapping.
     using CoordResult = Coord<R, Z, Zeta>;
+    /// The type of the coordinate that can be used to evaluate the Jacobian of this mapping
+    using CoordJacobian = CoordArg;
 
 private:
     Curvilinear2DToCartesian m_mapping_2d;

--- a/src/mapping/toroidal_to_cylindrical.hpp
+++ b/src/mapping/toroidal_to_cylindrical.hpp
@@ -171,8 +171,7 @@ public:
     KOKKOS_FUNCTION DTensor<VectorIndexSet<Rho, Theta, Phi>, VectorIndexSet<R_cov, Z_cov, Zeta_cov>>
     inv_jacobian_matrix(CoordArg const& coord) const
     {
-        InverseJacobianMatrix<Curvilinear2DToCartesian, CoordArg2D> inv_jacobian_matrix_2d(
-                m_mapping_2d);
+        InverseJacobianMatrix inv_jacobian_matrix_2d(m_mapping_2d);
         DTensor<VectorIndexSet<Rho, Theta, Phi>, VectorIndexSet<R_cov, Z_cov, Zeta_cov>> inv_J_3d;
         DTensor<VectorIndexSet<Rho, Theta>, VectorIndexSet<R_cov, Z_cov>> inv_J_2d
                 = inv_jacobian_matrix_2d(CoordArg2D(coord));

--- a/src/mapping/toroidal_to_cylindrical.hpp
+++ b/src/mapping/toroidal_to_cylindrical.hpp
@@ -201,7 +201,7 @@ public:
     template <class IndexTag1, class IndexTag2>
     KOKKOS_INLINE_FUNCTION double inv_jacobian_component(CoordArg const& coord) const
     {
-        static_assert(has_inv_jacobian_v<Curvilinear2DToCartesian, CoordArg>);
+        static_assert(has_inv_jacobian_v<Curvilinear2DToCartesian>);
         static_assert(ddc::in_tags_v<IndexTag1, ddc::detail::TypeSeq<Rho, Theta, Phi>>);
         static_assert(ddc::in_tags_v<IndexTag2, ddc::detail::TypeSeq<R_cov, Z_cov, Zeta_cov>>);
 

--- a/src/mapping/toroidal_to_cylindrical.hpp
+++ b/src/mapping/toroidal_to_cylindrical.hpp
@@ -234,4 +234,10 @@ struct MappingAccessibility<ExecSpace, ToroidalToCylindrical<Curvilinear2DToCart
 {
 };
 
+template <class Curvilinear2DToCartesian, class Zeta, class Phi>
+struct SingularOPointInvJacobian<ToroidalToCylindrical<Curvilinear2DToCartesian, Zeta, Phi>>
+    : std::true_type
+{
+};
+
 } // namespace mapping_detail

--- a/src/mapping/vector_mapper.hpp
+++ b/src/mapping/vector_mapper.hpp
@@ -89,7 +89,7 @@ public:
                                 = ddcHelper::get<YOut>(vector_field_out);
                     });
         } else {
-            InverseJacobianMatrix<Mapping, ddc::coordinate_of_t<IdxType>> inv_mapping(m_mapping);
+            InverseJacobianMatrix<Mapping> inv_mapping(m_mapping);
             ddc::parallel_for_each(
                     exec_space,
                     get_idx_range(vector_field_input),

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -330,7 +330,7 @@ public:
                   ddc::discrete_space<PolarBSplinesRTheta>().nbasis()
                           - ddc::discrete_space<BSplinesTheta>().nbasis())
     {
-        static_assert(has_jacobian_v<Mapping, CoordRTheta>);
+        static_assert(has_jacobian_v<Mapping>);
         //initialise x_init
         Kokkos::deep_copy(m_x_init, 0);
         // Get break points

--- a/src/quadrature/volume_quadrature_nd.hpp
+++ b/src/quadrature/volume_quadrature_nd.hpp
@@ -52,7 +52,7 @@ DFieldMem<IdxRangeCoeffs, typename ExecSpace::memory_space> compute_coeffs_on_ma
     using R = typename Mapping::curvilinear_tag_r;
     using Theta = typename Mapping::curvilinear_tag_theta;
 
-    static_assert(has_jacobian_v<Mapping, Coord<R, Theta>>);
+    static_assert(has_jacobian_v<Mapping>);
 
     using IdxCoeffs = typename IdxRangeCoeffs::discrete_element_type;
     IdxRangeCoeffs grid = get_idx_range(coefficients_alloc);

--- a/tests/geometryRTheta/polar_poisson/test_cases.hpp
+++ b/tests/geometryRTheta/polar_poisson/test_cases.hpp
@@ -121,7 +121,7 @@ template <class CurvilinearToCartesian>
 class CartesianSolution : public PoissonSolution<CurvilinearToCartesian>
 {
 private:
-    InverseJacobianMatrix<CurvilinearToCartesian, Coord<R, Theta>> m_inverse_jacobian;
+    InverseJacobianMatrix<CurvilinearToCartesian> m_inverse_jacobian;
     double m_x0;
     double m_y0;
 

--- a/tests/mapping/mapping_jacobian.cpp
+++ b/tests/mapping/mapping_jacobian.cpp
@@ -38,7 +38,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixCircMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix
@@ -59,8 +59,8 @@ TEST_P(InvJacobianMatrix, InverseMatrixCzarMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
-    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix
     ddc::for_each(grid, [&](IdxRTheta const irtheta) {
@@ -115,7 +115,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixDiscCzarMap)
                     evaluator);
     DiscreteToCartesian mapping = mapping_builder();
 
-    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping)>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix
@@ -194,7 +194,7 @@ TEST_P(InvJacobianMatrix3D, InverseMatrixToroidalDiscCzarMap)
 
     ToroidalToCylindrical<Mapping2D, Zeta, Phi> mapping(mapping_2d);
 
-    static_assert(has_jacobian_v<decltype(mapping), CoordRThetaPhi>);
+    static_assert(has_jacobian_v<decltype(mapping)>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the inv_Jacobian_matrix is the inverse of the Jacobian_matrix

--- a/tests/mapping/mapping_jacobian_matrix_coef.cpp
+++ b/tests/mapping/mapping_jacobian_matrix_coef.cpp
@@ -36,8 +36,8 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixCircMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
-    static_assert(has_inv_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping)>);
+    static_assert(has_inv_jacobian_v<decltype(mapping)>);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions
     //are the same as the coefficients in the matrix function.
@@ -87,7 +87,7 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixCzarMap)
     FieldMemRTheta_host<CoordRTheta> coords = get_example_coords(IdxStepR(Nr), IdxStepTheta(Nt));
     IdxRangeRTheta grid = get_idx_range(coords);
 
-    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping)>);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions
     //are the same as the coefficients in the matrix function.
@@ -176,7 +176,7 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixDiscCzarMap)
                     evaluator);
     DiscreteToCartesian mapping = mapping_builder();
 
-    static_assert(has_jacobian_v<decltype(mapping), CoordRTheta>);
+    static_assert(has_jacobian_v<decltype(mapping)>);
     InverseJacobianMatrix inv_jacobian(mapping);
 
     // Test for each coordinates if the coefficients defined by the coefficients functions

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -109,8 +109,8 @@ TEST(MappingStaticAsserts, Identity)
 {
     using Mapping = IdentityCoordinateChange<VectorIndexSet<X, Y, Z>, VectorIndexSet<X, Y, Z>>;
     static_assert(is_mapping_v<Mapping>);
-    static_assert(has_jacobian_v<Mapping, Coord<X, Y, Z>>);
-    static_assert(has_inv_jacobian_v<Mapping, Coord<X, Y, Z>>);
+    static_assert(has_jacobian_v<Mapping>);
+    static_assert(has_inv_jacobian_v<Mapping>);
     static_assert(is_analytical_mapping_v<Mapping>);
 }
 

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -12,6 +12,7 @@
 #include "discrete_to_cartesian.hpp"
 #include "geometry_mapping_tests.hpp"
 #include "mapping_tools.hpp"
+#include "toroidal_to_cylindrical.hpp"
 
 
 TEST(MappingStaticAsserts, CirctoCart)
@@ -101,4 +102,14 @@ TEST(MappingStaticAsserts, CartToBarycentric)
     using Mapping = CartesianToBarycentric<X, Y, Corner1, Corner2, Corner3>;
     static_assert(is_mapping_v<Mapping>);
     static_assert(is_analytical_mapping_v<Mapping>);
+}
+
+TEST(MappingStaticAsserts, TorToCyl)
+{
+    using Mapping2D = CircularToCartesian<R, Theta, X, Y>;
+    using Mapping = ToroidalToCylindrical<Mapping2D, Zeta, Phi>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(has_jacobian_v<Mapping>);
+    static_assert(has_inv_jacobian_v<Mapping>);
+    static_assert(has_singular_o_point_inv_jacobian_v<Mapping>);
 }

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -17,8 +17,8 @@
 TEST(MappingStaticAsserts, CirctoCart)
 {
     static_assert(is_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
-    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
-    static_assert(has_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
+    static_assert(has_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(is_curvilinear_2d_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(is_analytical_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(has_singular_o_point_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
@@ -27,7 +27,7 @@ TEST(MappingStaticAsserts, CirctoCart)
 TEST(MappingStaticAsserts, CartToCirc)
 {
     static_assert(is_mapping_v<CartesianToCircular<X, Y, R, Theta>>);
-    static_assert(has_jacobian_v<CartesianToCircular<X, Y, R, Theta>, CoordXY>);
+    static_assert(has_jacobian_v<CartesianToCircular<X, Y, R, Theta>>);
     static_assert(is_analytical_mapping_v<CartesianToCircular<X, Y, R, Theta>>);
 }
 
@@ -35,8 +35,8 @@ TEST(MappingStaticAsserts, CartToCirc)
 TEST(MappingStaticAsserts, CzarnytoCart)
 {
     static_assert(is_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
-    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
-    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>, CoordRTheta>);
+    static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(is_curvilinear_2d_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(is_analytical_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(has_singular_o_point_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
@@ -52,7 +52,7 @@ TEST(MappingStaticAsserts, DiscToCart)
 {
     using Mapping = DiscreteToCartesian<X, Y, SplineRThetaEvaluator_host>;
     static_assert(is_mapping_v<Mapping>);
-    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(has_jacobian_v<Mapping>);
     static_assert(is_curvilinear_2d_mapping_v<Mapping>);
     static_assert(!is_analytical_mapping_v<Mapping>);
     static_assert(has_singular_o_point_inv_jacobian_v<Mapping>);
@@ -64,22 +64,22 @@ TEST(MappingStaticAsserts, CombinedMapping)
             CircularToCartesian<R, Theta, X, Y>,
             CartesianToCzarny<X, Y, R, Theta>>;
     static_assert(is_mapping_v<Mapping>);
-    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
-    static_assert(has_inv_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(has_jacobian_v<Mapping>);
+    static_assert(has_inv_jacobian_v<Mapping>);
 }
 
 TEST(MappingStaticAsserts, CylToCart)
 {
     static_assert(is_mapping_v<CylindricalToCartesian<R, Z, Zeta, X, Y>>);
-    static_assert(has_jacobian_v<CylindricalToCartesian<R, Z, Zeta, X, Y>, Coord<R, Z, Zeta>>);
-    static_assert(has_inv_jacobian_v<CylindricalToCartesian<R, Z, Zeta, X, Y>, Coord<R, Z, Zeta>>);
+    static_assert(has_jacobian_v<CylindricalToCartesian<R, Z, Zeta, X, Y>>);
+    static_assert(has_inv_jacobian_v<CylindricalToCartesian<R, Z, Zeta, X, Y>>);
     static_assert(is_analytical_mapping_v<CylindricalToCartesian<R, Z, Zeta, X, Y>>);
 }
 
 TEST(MappingStaticAsserts, CartToCyl)
 {
     static_assert(is_mapping_v<CartesianToCylindrical<X, Y, Z, R, Zeta>>);
-    static_assert(has_jacobian_v<CartesianToCylindrical<X, Y, Z, R, Zeta>, Coord<X, Y, Z>>);
+    static_assert(has_jacobian_v<CartesianToCylindrical<X, Y, Z, R, Zeta>>);
     static_assert(is_analytical_mapping_v<CartesianToCylindrical<X, Y, Z, R, Zeta>>);
 }
 

--- a/tests/mapping/refined_discrete_mapping.cpp
+++ b/tests/mapping/refined_discrete_mapping.cpp
@@ -185,7 +185,7 @@ double check_Jacobian_on_grid(
         Mapping const& analytical_mapping,
         IdxRangeRTheta const& idx_range)
 {
-    static_assert(has_jacobian_v<Mapping, CoordRTheta>);
+    static_assert(has_jacobian_v<Mapping>);
     double max_err = 0.;
     ddc::for_each(idx_range, [&](IdxRTheta const irtheta) {
         const CoordRTheta coord(ddc::coordinate(irtheta));


### PR DESCRIPTION
In order to achieve #305 it is important to be able to deduce the coordinate system on which the Jacobian is calculated. To do this a `CoordJacobian` attribute is added to mappings which have a Jacobian.

**Commit Summary**
- Add `CoordJacobian` attribute to existing mappings
- Make `CoordJacobian` attribute compulsory for mappings which define a Jacobian.
- Remove `CoordinateType` template parameter from `has_jacobian_v` and `has_inv_jacobian_v`
- Update calls to `has_jacobian_v` and `has_inv_jacobian_v`
- `InverseJacobianMatrix` does not need a `PositionCoordinate` parameter
- Add missing static tests for `ToroidalToCylindrical`
- Ensure `ToroidalToCylindrical` is marked as having a singular inverse Jacobian
- Update default template parameter for `MetricTensorEvaluator`