### PR TITLE
Add a tensor product function

### DIFF
--- a/src/data_types/static_tensors.hpp
+++ b/src/data_types/static_tensors.hpp
@@ -88,14 +88,15 @@ public:
 
 /**
  * A class containing only static constexpr methods which describes
- * the Levi-Civita tensor.
+ * the Levi-Civita tensor in Cartesian coordinates.
  * @tparam ElementType The type of the elements of the tensor (usually double/complex).
  * @tparam ValidIndexSet The indices that can be used along any of the dimensions of the tensor.
  */
 template <class ElementType, class ValidIndexSet>
-class LeviCivitaTensor
+class CartesianLeviCivitaTensor
 {
     static_assert(is_vector_index_set_v<ValidIndexSet>);
+    static_assert(std::is_same_v<ValidIndexSet, vector_index_set_dual_t<ValidIndexSet>>);
 
 public:
     /// The type of the elements of the tensor.
@@ -130,7 +131,7 @@ public:
     /**
      * @brief Construct an uninitialised tensor object.
      */
-    KOKKOS_DEFAULTED_FUNCTION LeviCivitaTensor() = default;
+    KOKKOS_DEFAULTED_FUNCTION CartesianLeviCivitaTensor() = default;
 
     /**
      * @brief Get an element of the tensor.
@@ -141,14 +142,9 @@ public:
     static constexpr KOKKOS_FUNCTION ElementType get()
     {
         static_assert(tensor_tools::is_tensor_index_element_v<QueryTensorIndexElement>);
-        if constexpr (type_seq_has_unique_elements_v<
-                              typename QueryTensorIndexElement::IdxTypeSeq>) {
-            return type_seq_permutation_parity_v<
-                    typename QueryTensorIndexElement::IdxTypeSeq,
-                    ValidIndexSet>;
-        } else {
-            return 0;
-        }
+        return type_seq_permutation_parity_v<
+                typename QueryTensorIndexElement::IdxTypeSeq,
+                ValidIndexSet>;
     }
 
     /**
@@ -159,7 +155,6 @@ public:
     template <std::size_t dim>
     using vector_index_set_t = ValidIndexSet;
 };
-
 
 namespace ddcHelper {
 /**
@@ -185,10 +180,10 @@ KOKKOS_INLINE_FUNCTION constexpr double get(
  */
 template <class... QueryIndexTag, class ElementType, class ValidIndexSet>
 KOKKOS_INLINE_FUNCTION constexpr double get(
-        LeviCivitaTensor<ElementType, ValidIndexSet> const& tensor)
+        CartesianLeviCivitaTensor<ElementType, ValidIndexSet> const& tensor)
 {
     return tensor.template get<tensor_tools::TensorIndexElement<
-            typename LeviCivitaTensor<ElementType, ValidIndexSet>::index_set,
+            typename CartesianLeviCivitaTensor<ElementType, ValidIndexSet>::index_set,
             QueryIndexTag...>>();
 }
 } // namespace ddcHelper

--- a/src/data_types/static_tensors.hpp
+++ b/src/data_types/static_tensors.hpp
@@ -156,6 +156,88 @@ public:
     using vector_index_set_t = ValidIndexSet;
 };
 
+/**
+ * A class containing methods which describe the Levi-Civita tensor in general coordinates.
+ * @tparam ElementType The type of the elements of the tensor (usually double/complex).
+ * @tparam ValidIndexSet The indices that can be used along any of the dimensions of the tensor.
+ */
+template <class ElementType, class ValidIndexSet>
+class LeviCivitaTensor
+{
+    static_assert(is_vector_index_set_v<ValidIndexSet>);
+    static_assert(
+            (is_covariant_vector_index_set_v<ValidIndexSet>)
+            || (is_contravariant_vector_index_set_v<ValidIndexSet>));
+
+private:
+    double m_coeff;
+
+public:
+    /// The type of the elements of the tensor.
+    using element_type = ElementType;
+
+    /**
+     * @brief The rank of the tensor.
+     * This is equivalent to the number of indices required to
+     * access an element of the tensor.
+     *
+     * @return The rank of the tensor.
+     */
+    KOKKOS_FUNCTION static constexpr std::size_t rank()
+    {
+        return ddc::type_seq_size_v<ValidIndexSet>;
+    }
+
+    /**
+     * @brief The size of the tensor.
+     * This is the number of elements in the tensor.
+     *
+     * @return The number of elements in the tensor.
+     */
+    KOKKOS_FUNCTION static constexpr std::size_t size()
+    {
+        return rank() * rank();
+    }
+
+    /// The TensorIndexSet describing the possible indices.
+    using index_set = type_seq_duplicate_t<ValidIndexSet, rank()>;
+
+    /**
+     * @brief Construct an uninitialised tensor object.
+     */
+    KOKKOS_FUNCTION LeviCivitaTensor(double jacobian)
+    {
+        if constexpr (is_covariant_vector_index_set_v<ValidIndexSet>) {
+            m_coeff = jacobian;
+        } else {
+            m_coeff = 1.0 / jacobian;
+        }
+    }
+
+    /**
+     * @brief Get an element of the tensor.
+     * @tparam QueryIndexTag A type describing the relevant index.
+     * @return The relevant element of the tensor.
+     */
+    template <class QueryTensorIndexElement>
+    KOKKOS_INLINE_FUNCTION ElementType get() const
+    {
+        double constexpr eps = type_seq_permutation_parity_v<
+                typename QueryTensorIndexElement::IdxTypeSeq,
+                ValidIndexSet>;
+        return eps * m_coeff;
+    }
+
+    /**
+     * @brief A helper type alias to get all possible indices along a
+     * specified dimension.
+     * @tparam Dim The dimension of interest (0 <= dim < rank()).
+     */
+    template <std::size_t dim>
+    using vector_index_set_t = ValidIndexSet;
+};
+
+
 namespace ddcHelper {
 /**
  * @brief A helper function to get a modifiable reference to an element of the tensor.
@@ -184,6 +266,21 @@ KOKKOS_INLINE_FUNCTION constexpr double get(
 {
     return tensor.template get<tensor_tools::TensorIndexElement<
             typename CartesianLeviCivitaTensor<ElementType, ValidIndexSet>::index_set,
+            QueryIndexTag...>>();
+}
+
+/**
+ * @brief A helper function to get a modifiable reference to an element of the tensor.
+ * @tparam QueryIndexTag A type describing the relevant index.
+ * @param tensor The tensor whose elements are examined.
+ * @return The relevant element of the tensor.
+ */
+template <class... QueryIndexTag, class ElementType, class ValidIndexSet>
+KOKKOS_INLINE_FUNCTION constexpr double get(
+        LeviCivitaTensor<ElementType, ValidIndexSet> const& tensor)
+{
+    return tensor.template get<tensor_tools::TensorIndexElement<
+            typename LeviCivitaTensor<ElementType, ValidIndexSet>::index_set,
             QueryIndexTag...>>();
 }
 } // namespace ddcHelper

--- a/src/data_types/tensor.hpp
+++ b/src/data_types/tensor.hpp
@@ -9,22 +9,6 @@
 #include "tensor_index_tools.hpp"
 #include "vector_index_tools.hpp"
 
-namespace detail {
-
-template <class ValidIndexSet>
-struct ToCoord;
-
-template <class... Dims>
-struct ToCoord<VectorIndexSet<Dims...>>
-{
-    using type = Coord<Dims...>;
-};
-
-template <class ValidIndexSet>
-using to_coord_t = typename ToCoord<ValidIndexSet>::type;
-
-} // namespace detail
-
 /**
  * @brief A class representing a Tensor.
  * @tparam ElementType The type of the elements of the tensor (usually double/complex).

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -155,7 +155,7 @@ public:
 private:
     template <class... RowDims, class... ColDims>
     void fill_diagonal_elements(
-            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
+            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix) const
     {
         ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);
     }

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -3,6 +3,18 @@
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
 
+/**
+ * @brief A class describing an identity transformation.
+ *
+ * It is not expected that this class appear in a final simulation,
+ * but it may be useful when debugging vector calculations on
+ * general coordinates.
+ *
+ * @tparam ArgBasis A VectorIndexSet containing the continuous
+ *      dimensions on which the argument is described.
+ * @tparam ResultBasis A VectorIndexSet containing the continuous
+ *      dimensions on which the result is described.
+ */
 template <class ArgBasis, class ResultBasis>
 class IdentityCoordinateChange
 {

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+#include "ddc_aliases.hpp"
+#include "ddc_helper.hpp"
 
 template <class ArgBasis, class ResultBasis>
 class IdentityCoordinateChange
 {
 public:
     /// The type of the argument of the function described by this mapping
-    using CoordArg = to_coord_t<ArgBasis>;
+    using CoordArg = ddcHelper::to_coord_t<ArgBasis>;
     /// The type of the result of the function described by this mapping
-    using CoordResult = to_coord<ResultBasis>;
+    using CoordResult = ddcHelper::to_coord_t<ResultBasis>;
 
 private:
     using ArgBasisCov = vector_index_set_dual_t<ArgBasis>;
@@ -36,7 +38,7 @@ public:
      *
      * @return A double with the value of the determinant of the Jacobian matrix.
      */
-    static constexpr double jacobian(CoordArg const& coord) const
+    KOKKOS_INLINE_FUNCTION double jacobian(CoordArg const& coord) const
     {
         return 1;
     }
@@ -64,7 +66,7 @@ public:
      * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
      */
     template <class IndexTag1, class IndexTag2>
-    static constexpr double jacobian_component(Coord<R, Theta> const& coord) const
+    KOKKOS_INLINE_FUNCTION double jacobian_component(CoordArg const& coord) const
     {
         static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
         static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
@@ -85,7 +87,7 @@ public:
      *
      * @return A double with the value of the determinant of the Jacobian matrix.
      */
-    static constexpr double inv_jacobian(CoordArg const& coord) const
+    KOKKOS_INLINE_FUNCTION double inv_jacobian(CoordArg const& coord) const
     {
         return 1;
     }
@@ -114,7 +116,7 @@ public:
      * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
      */
     template <class IndexTag1, class IndexTag2>
-    static constexpr double inv_jacobian_component(Coord<R, Theta> const& coord) const
+    KOKKOS_INLINE_FUNCTION double inv_jacobian_component(CoordArg const& coord) const
     {
         static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
         static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -154,7 +154,7 @@ public:
 
 private:
     template <class... RowDims, class... ColDims>
-    void fill_diagonal_elems(
+    void fill_diagonal_elements(
             DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
     {
         ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);

--- a/src/mapping/identity_coordinate_change.hpp
+++ b/src/mapping/identity_coordinate_change.hpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+
+template <class ArgBasis, class ResultBasis>
+class IdentityCoordinateChange
+{
+public:
+    /// The type of the argument of the function described by this mapping
+    using CoordArg = to_coord_t<ArgBasis>;
+    /// The type of the result of the function described by this mapping
+    using CoordResult = to_coord<ResultBasis>;
+
+private:
+    using ArgBasisCov = vector_index_set_dual_t<ArgBasis>;
+
+public:
+    /**
+     * @brief Convert the coordinate in the argument basis to the equivalent coordinate in the result basis.
+     *
+     * @param[in] coord The coordinate to be converted.
+     *
+     * @return The equivalent coordinate.
+     */
+    template <class... ArgDims>
+    KOKKOS_FUNCTION CoordResult operator()(Coord<ArgDims...> const& coord) const
+    {
+        static_assert(std::is_same_v<CoordArg, Coord<ArgDims...>>);
+        return CoordResult((ddc::get<ArgDims>(coord))...);
+    }
+
+    /**
+     * @brief Compute the Jacobian, the determinant of the Jacobian matrix of the mapping.
+     *
+     * @param[in] coord
+     *          The coordinate where we evaluate the Jacobian.
+     *
+     * @return A double with the value of the determinant of the Jacobian matrix.
+     */
+    static constexpr double jacobian(CoordArg const& coord) const
+    {
+        return 1;
+    }
+
+    /**
+     * @brief Compute full Jacobian matrix.
+     *
+     * @param[in] coord
+     * 				The coordinate where we evaluate the Jacobian matrix.
+     * @return The Jacobian matrix.
+     */
+    KOKKOS_FUNCTION DTensor<ResultBasis, ArgBasisCov> jacobian_matrix(CoordArg const& coord) const
+    {
+        DTensor<ResultBasis, ArgBasisCov> jacobian_matrix(0.0);
+        fill_diagonal_elements(jacobian_matrix);
+        return jacobian_matrix;
+    }
+
+    /**
+     * @brief Compute the (i,j) coefficient of the Jacobian matrix.
+     * 
+     * @param[in] coord
+     *              The coordinate where we evaluate the Jacobian matrix.
+     *
+     * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
+     */
+    template <class IndexTag1, class IndexTag2>
+    static constexpr double jacobian_component(Coord<R, Theta> const& coord) const
+    {
+        static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
+        static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
+        if constexpr (
+                (ddc::type_seq_rank_v<IndexTag1, ResultBasis>)
+                == (ddc::type_seq_rank_v<IndexTag2, ArgBasisCov>)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @brief Compute the Jacobian, the determinant of the Jacobian matrix of the mapping.
+     *
+     * @param[in] coord
+     *          The coordinate where we evaluate the Jacobian.
+     *
+     * @return A double with the value of the determinant of the Jacobian matrix.
+     */
+    static constexpr double inv_jacobian(CoordArg const& coord) const
+    {
+        return 1;
+    }
+
+    /**
+     * @brief Compute full Jacobian matrix.
+     *
+     * @param[in] coord
+     * 				The coordinate where we evaluate the Jacobian matrix.
+     * @return The Jacobian matrix.
+     */
+    KOKKOS_FUNCTION DTensor<ResultBasis, ArgBasisCov> inv_jacobian_matrix(
+            CoordArg const& coord) const
+    {
+        DTensor<ResultBasis, ArgBasisCov> inv_jacobian_matrix(0.0);
+        fill_diagonal_elements(inv_jacobian_matrix);
+        return inv_jacobian_matrix;
+    }
+
+    /**
+     * @brief Compute the (i,j) coefficient of the Jacobian matrix.
+     * 
+     * @param[in] coord
+     *              The coordinate where we evaluate the Jacobian matrix.
+     *
+     * @return A double with the value of the (i,j) coefficient of the Jacobian matrix.
+     */
+    template <class IndexTag1, class IndexTag2>
+    static constexpr double inv_jacobian_component(Coord<R, Theta> const& coord) const
+    {
+        static_assert(ddc::in_tags_v<IndexTag1, ResultBasis>);
+        static_assert(ddc::in_tags_v<IndexTag2, ArgBasisCov>);
+        if constexpr (
+                (ddc::type_seq_rank_v<IndexTag1, ResultBasis>)
+                == (ddc::type_seq_rank_v<IndexTag2, ArgBasisCov>)) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @brief Get the inverse mapping.
+     *
+     * @return The inverse mapping.
+     */
+    KOKKOS_INLINE_FUNCTION IdentityCoordinateChange<ResultBasis, ArgBasis> get_inverse_mapping()
+            const
+    {
+        return IdentityCoordinateChange<ResultBasis, ArgBasis>();
+    }
+
+private:
+    template <class... RowDims, class... ColDims>
+    void fill_diagonal_elems(
+            DTensor<VectorIndexSet<RowDims...>, VectorIndexSet<ColDims...>>& matrix)
+    {
+        ((ddcHelper::get<RowDims, ColDims>(matrix) = 1.0), ...);
+    }
+};
+
+namespace mapping_detail {
+template <class ArgBasis, class ResultBasis, class ExecSpace>
+struct MappingAccessibility<ExecSpace, IdentityCoordinateChange<ArgBasis, ResultBasis>>
+    : std::true_type
+{
+};
+} // namespace mapping_detail

--- a/src/math_tools/CMakeLists.txt
+++ b/src/math_tools/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries("math_tools"
     INTERFACE
         DDC::core
         gslx::data_types
+        gslx::mapping
         gslx::quadrature
 )
 

--- a/src/utils/ddc_helper.hpp
+++ b/src/utils/ddc_helper.hpp
@@ -291,6 +291,16 @@ struct TypeSeqIntersection<
 };
 
 
+template <class ValidIndexSet>
+struct ToCoord;
+
+template <class... Dims>
+struct ToCoord<VectorIndexSet<Dims...>>
+{
+    using type = Coord<Dims...>;
+};
+
+
 } // namespace detail
 
 /**
@@ -325,4 +335,8 @@ using apply_template_to_type_seq_t = typename detail::ApplyTemplateToTypeSeq<Tem
 template <class TypeSeq1, class TypeSeq2>
 using type_seq_intersection_t =
         typename detail::TypeSeqIntersection<TypeSeq1, TypeSeq2, ddc::detail::TypeSeq<>>::type;
+
+/// Get a coordinate from a TypeSeq
+template <class ValidIndexSet>
+using to_coord_t = typename ToCoord<ValidIndexSet>::type;
 } // namespace ddcHelper

--- a/src/utils/ddc_helper.hpp
+++ b/src/utils/ddc_helper.hpp
@@ -295,7 +295,7 @@ template <class ValidIndexSet>
 struct ToCoord;
 
 template <class... Dims>
-struct ToCoord<VectorIndexSet<Dims...>>
+struct ToCoord<ddc::detail::TypeSeq<Dims...>>
 {
     using type = Coord<Dims...>;
 };
@@ -338,5 +338,5 @@ using type_seq_intersection_t =
 
 /// Get a coordinate from a TypeSeq
 template <class ValidIndexSet>
-using to_coord_t = typename ToCoord<ValidIndexSet>::type;
+using to_coord_t = typename detail::ToCoord<ValidIndexSet>::type;
 } // namespace ddcHelper

--- a/src/utils/type_seq_tools.hpp
+++ b/src/utils/type_seq_tools.hpp
@@ -90,21 +90,23 @@ struct GetPermutationParity<
         ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
         ddc::detail::TypeSeq<HeadType, TailOrderedTypeSeq...>>
 {
-    static_assert(
-            std::is_same_v<
-                    ddc::detail::TypeSeq<HeadType, TailOrderedTypeSeq...>,
-                    typename detail::GetUnique<
-                            ddc::detail::TypeSeq<HeadType, TailOrderedTypeSeq...>>::type>,
-            "Cannot calculate the permutation parity of a type seq with duplicate elements.");
-    static_assert(
-            std::is_same_v<
-                    ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
-                    typename detail::GetUnique<
-                            ddc::detail::TypeSeq<HeadType, TailTypeSeq...>>::type>,
-            "Cannot calculate the permutation parity of a type seq with duplicate elements.");
-    static constexpr int value = GetPermutationParity<
-            ddc::detail::TypeSeq<TailTypeSeq...>,
-            ddc::detail::TypeSeq<TailOrderedTypeSeq...>>::value;
+private:
+    static constexpr bool contains_duplicate
+            = (!std::is_same_v<
+                      ddc::detail::TypeSeq<HeadType, TailOrderedTypeSeq...>,
+                      typename detail::GetUnique<
+                              ddc::detail::TypeSeq<HeadType, TailOrderedTypeSeq...>>::type>)
+              || (!std::is_same_v<
+                      ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
+                      typename detail::GetUnique<
+                              ddc::detail::TypeSeq<HeadType, TailTypeSeq...>>::type>);
+
+public:
+    static constexpr int value
+            = contains_duplicate ? 0
+                                 : GetPermutationParity<
+                                         ddc::detail::TypeSeq<TailTypeSeq...>,
+                                         ddc::detail::TypeSeq<TailOrderedTypeSeq...>>::value;
 };
 
 template <class HeadType, class... TailTypeSeq, class OrderedHeadType, class... TailOrderedTypeSeq>
@@ -112,24 +114,26 @@ struct GetPermutationParity<
         ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
         ddc::detail::TypeSeq<OrderedHeadType, TailOrderedTypeSeq...>>
 {
-    static_assert(
-            std::is_same_v<
-                    ddc::detail::TypeSeq<OrderedHeadType, TailOrderedTypeSeq...>,
-                    typename detail::GetUnique<
-                            ddc::detail::TypeSeq<OrderedHeadType, TailOrderedTypeSeq...>>::type>,
-            "Cannot calculate the permutation parity of a type seq with duplicate elements.");
-    static_assert(
-            std::is_same_v<
-                    ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
-                    typename detail::GetUnique<
-                            ddc::detail::TypeSeq<HeadType, TailTypeSeq...>>::type>,
-            "Cannot calculate the permutation parity of a type seq with duplicate elements.");
-    static constexpr int value = -GetPermutationParity<
-            ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<TailTypeSeq...>,
-                    ddc::detail::TypeSeq<OrderedHeadType>,
-                    ddc::detail::TypeSeq<HeadType>>,
-            ddc::detail::TypeSeq<TailOrderedTypeSeq...>>::value;
+private:
+    static constexpr bool contains_duplicate
+            = (!std::is_same_v<
+                      ddc::detail::TypeSeq<OrderedHeadType, TailOrderedTypeSeq...>,
+                      typename detail::GetUnique<
+                              ddc::detail::TypeSeq<OrderedHeadType, TailOrderedTypeSeq...>>::type>)
+              || (!std::is_same_v<
+                      ddc::detail::TypeSeq<HeadType, TailTypeSeq...>,
+                      typename detail::GetUnique<
+                              ddc::detail::TypeSeq<HeadType, TailTypeSeq...>>::type>);
+
+public:
+    static constexpr int value
+            = contains_duplicate ? 0
+                                 : -GetPermutationParity<
+                                         ddc::type_seq_replace_t<
+                                                 ddc::detail::TypeSeq<TailTypeSeq...>,
+                                                 ddc::detail::TypeSeq<OrderedHeadType>,
+                                                 ddc::detail::TypeSeq<HeadType>>,
+                                         ddc::detail::TypeSeq<TailOrderedTypeSeq...>>::value;
 };
 
 template <>

--- a/tests/data_types/tensor.cpp
+++ b/tests/data_types/tensor.cpp
@@ -398,7 +398,7 @@ TEST(TensorTest, MulOrthonormal)
 
 TEST(TensorTest, LeviCivita2D)
 {
-    LeviCivitaTensor<int, VectorIndexSet<X, Y>> levi_civita;
+    CartesianLeviCivitaTensor<int, VectorIndexSet<X, Y>> levi_civita;
     static_assert(ddcHelper::get<X, X>(levi_civita) == 0);
     static_assert(ddcHelper::get<X, Y>(levi_civita) == 1);
     static_assert(ddcHelper::get<Y, X>(levi_civita) == -1);
@@ -407,7 +407,7 @@ TEST(TensorTest, LeviCivita2D)
 
 TEST(TensorTest, LeviCivita3D)
 {
-    LeviCivitaTensor<int, VectorIndexSet<X, Y, Z>> levi_civita;
+    CartesianLeviCivitaTensor<int, VectorIndexSet<X, Y, Z>> levi_civita;
     static_assert(ddcHelper::get<X, X, X>(levi_civita) == 0);
     static_assert(ddcHelper::get<X, X, Y>(levi_civita) == 0);
     static_assert(ddcHelper::get<X, X, Z>(levi_civita) == 0);
@@ -441,7 +441,7 @@ TEST(TensorTest, LeviCivita3D)
 
 TEST(TensorTest, LeviCivitaMul)
 {
-    LeviCivitaTensor<int, VectorIndexSet<X, Y>> levi_civita;
+    CartesianLeviCivitaTensor<int, VectorIndexSet<X, Y>> levi_civita;
     using Tensor2D = Tensor<int, VectorIndexSet<X, Y>, VectorIndexSet<X, Y>>;
     Tensor2D A;
     ddcHelper::get<X, X>(A) = 1;

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -102,3 +102,12 @@ TEST(MappingStaticAsserts, CartToBarycentric)
     static_assert(is_mapping_v<Mapping>);
     static_assert(is_analytical_mapping_v<Mapping>);
 }
+
+TEST(MappingStaticAsserts, Identity)
+{
+    using Mapping = IdentityCoordinateChange<VectorIndexSet<X, Y, Z>, VectorIndexSet<X, Y, Z>>;
+    static_assert(is_mapping_v<Mapping>);
+    static_assert(has_jacobian_v<Mapping, Coord<X, Y, Z>>);
+    static_assert(has_inv_jacobian_v<Mapping, Coord<X, Y, Z>>);
+    static_assert(is_analytical_mapping_v<Mapping>);
+}

--- a/tests/mapping/mapping_static_properties.cpp
+++ b/tests/mapping/mapping_static_properties.cpp
@@ -11,6 +11,7 @@
 #include "czarny_to_cartesian.hpp"
 #include "discrete_to_cartesian.hpp"
 #include "geometry_mapping_tests.hpp"
+#include "identity_coordinate_change.hpp"
 #include "mapping_tools.hpp"
 
 

--- a/tests/math_tools/test_math_tools.cpp
+++ b/tests/math_tools/test_math_tools.cpp
@@ -6,8 +6,10 @@
 #include "../mapping/geometry_mapping_tests.hpp"
 
 #include "circular_to_cartesian.hpp"
+#include "cylindrical_to_cartesian.hpp"
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
+#include "identity_coordinate_change.hpp"
 #include "math_tools.hpp"
 #include "mesh_builder.hpp"
 #include "metric_tensor_evaluator.hpp"
@@ -127,4 +129,71 @@ TEST(MathTools, Inverse)
     ASSERT_NEAR(test_val, 4, 1e-12);
     test_val = ddcHelper::get<Z, Z>(inv_matrix);
     ASSERT_NEAR(test_val, 1, 1e-12);
+}
+
+TEST(MathTools, ScalarProdCart)
+{
+    using IndexSet = VectorIndexSet<X, Y, Z>;
+    Tensor<double, IndexSet> A, B;
+    ddcHelper::get<X>(A) = 3;
+    ddcHelper::get<Y>(A) = 6;
+    ddcHelper::get<Z>(A) = -3;
+    ddcHelper::get<X>(B) = 1;
+    ddcHelper::get<Y>(B) = -4;
+    ddcHelper::get<Z>(B) = 2;
+    EXPECT_EQ(scalar_product(A, B), -27);
+    Coord<X, Y, Z> test_coord(0.0, 0.0, 0.0);
+    IdentityCoordinateChange<IndexSet, IndexSet> mapping;
+    MetricTensorEvaluator get_metric(mapping);
+    EXPECT_DOUBLE_EQ(scalar_product(get_metric(test_coord), A, B), -27);
+}
+
+TEST(MathTools, ScalarProdCyl)
+{
+    using IndexSet = VectorIndexSet<R, Z, Zeta>;
+    Tensor<double, IndexSet> A, B;
+    ddcHelper::get<R>(A) = 3;
+    ddcHelper::get<Z>(A) = 6;
+    ddcHelper::get<Zeta>(A) = 6;
+    ddcHelper::get<R>(B) = 1;
+    ddcHelper::get<Z>(B) = 2;
+    ddcHelper::get<Zeta>(B) = -4;
+    Coord<R, Z, Zeta> test_coord(2.5, -4.0, 0.3);
+    CylindricalToCartesian<R, Z, Zeta, X, Y> mapping;
+    MetricTensorEvaluator get_metric(mapping);
+    EXPECT_DOUBLE_EQ(scalar_product(get_metric(test_coord), A, B), -135);
+}
+
+TEST(MathTools, TensorProdCart)
+{
+    using IndexSet = VectorIndexSet<X, Y, Z>;
+    Tensor<double, IndexSet> A, B, C;
+    ddcHelper::get<X>(A) = 3;
+    ddcHelper::get<Y>(A) = 6;
+    ddcHelper::get<Z>(A) = -3;
+    ddcHelper::get<X>(B) = 1;
+    ddcHelper::get<Y>(B) = -4;
+    ddcHelper::get<Z>(B) = 2;
+    Coord<X, Y, Z> test_coord(0.0, 0.0, 0.0);
+    IdentityCoordinateChange<IndexSet, IndexSet> mapping;
+    C = tensor_product(mapping, test_coord, A, B);
+    EXPECT_NEAR(ddcHelper::get<X>(C), 0, 1e-14);
+    EXPECT_NEAR(ddcHelper::get<Y>(C), -9, 1e-14);
+    EXPECT_NEAR(ddcHelper::get<Z>(C), -18, 1e-14);
+}
+
+TEST(MathTools, TensorProdCyl)
+{
+    using IndexSet = VectorIndexSet<R, Z, Zeta>;
+    Tensor<double, IndexSet> A, B, C;
+    ddcHelper::get<R>(A) = 3;
+    ddcHelper::get<Z>(A) = 6;
+    ddcHelper::get<Zeta>(A) = -3;
+    ddcHelper::get<R>(B) = 1;
+    ddcHelper::get<Z>(B) = -4;
+    ddcHelper::get<Zeta>(B) = 2;
+    Coord<R, Z, Zeta> test_coord(2.5, -4.0, 0.3);
+    CylindricalToCartesian<R, Z, Zeta, X, Y> mapping;
+    C = tensor_product(mapping, test_coord, A, B);
+    // TODO: Complete test
 }


### PR DESCRIPTION
Add functions to calculate the scalar product and the tensor product of vectors. Fixes #301 .

This PR should be merged after #302 and probably after #305 is fixed (to finish the tests simply).