### PR TITLE
Improve time integrators

### DIFF
--- a/simulations/geometryXY/guiding_centre/guiding_centre.cpp
+++ b/simulations/geometryXY/guiding_centre/guiding_centre.cpp
@@ -101,25 +101,24 @@ int main(int argc, char** argv)
     FFTPoissonSolver<IdxRangeXY> const poisson_solver(meshXY);
 
     // Create advection operators ---
-    Euler<FieldMemXY<CoordX>, DFieldMemXY> euler_x(meshXY);
+    EulerBuilder euler;
     BslAdvection1D<
             GridX,
             IdxRangeXY,
             IdxRangeXY,
             SplineXBuilder_XY,
             SplineXEvaluator_XY,
-            Euler<FieldMemXY<CoordX>, DFieldMemXY>>
-            advection_x(spline_x_interpolator, builder_x, spline_x_evaluator, euler_x);
+            EulerBuilder>
+            advection_x(spline_x_interpolator, builder_x, spline_x_evaluator, euler);
 
-    Euler<FieldMemXY<CoordY>, DFieldMemXY> euler_y(meshXY);
     BslAdvection1D<
             GridY,
             IdxRangeXY,
             IdxRangeXY,
             SplineYBuilder_XY,
             SplineYEvaluator_XY,
-            Euler<FieldMemXY<CoordY>, DFieldMemXY>>
-            advection_y(spline_y_interpolator, builder_y, spline_y_evaluator, euler_y);
+            EulerBuilder>
+            advection_y(spline_y_interpolator, builder_y, spline_y_evaluator, euler);
 
 
     // Create an initialiser ---

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -9,6 +9,7 @@
 #include "ddc_helper.hpp"
 #include "euler.hpp"
 #include "iinterpolator.hpp"
+#include "itimestepper.hpp"
 
 
 /**
@@ -55,13 +56,11 @@ template <
         class IdxRangeFunction,
         class AdvectionFieldBuilder,
         class AdvectionFieldEvaluator,
-        class TimeStepper
-        = Euler<FieldMem<
-                        Coord<typename GridInterest::continuous_dimension_type>,
-                        IdxRangeAdvection>,
-                DFieldMem<IdxRangeAdvection>>>
+        class TimeStepperBuilder = EulerBuilder>
 class BslAdvection1D
 {
+    static_assert(is_timestepper_builder_v<TimeStepperBuilder>);
+
 private:
     // Advection index range element:
     using IdxAdvection = typename IdxRangeAdvection::discrete_element_type;
@@ -110,12 +109,16 @@ private:
     using IdxRangeFunctionDeriv = typename FunctionInterpolatorType::batched_derivs_idx_range_type;
     using FunctionDerivFieldMem = DFieldMem<IdxRangeFunctionDeriv>;
 
+    using TimeStepper = typename TimeStepperBuilder::time_stepper_t<
+            FieldMem<Coord<typename GridInterest::continuous_dimension_type>, IdxRangeAdvection>,
+            DFieldMem<IdxRangeAdvection>>;
+
     FunctionPreallocatableInterpolatorType const& m_function_interpolator;
 
     AdvectionFieldBuilder const& m_adv_field_builder;
     AdvectionFieldEvaluator const& m_adv_field_evaluator;
 
-    TimeStepper const& m_time_stepper;
+    TimeStepperBuilder const& m_time_stepper_builder;
 
 public:
     /**
@@ -139,11 +142,11 @@ public:
             FunctionPreallocatableInterpolatorType const& function_interpolator,
             AdvectionFieldBuilder const& adv_field_builder,
             AdvectionFieldEvaluator const& adv_field_evaluator,
-            TimeStepper const& time_stepper)
+            TimeStepperBuilder const& time_stepper_builder)
         : m_function_interpolator(function_interpolator)
         , m_adv_field_builder(adv_field_builder)
         , m_adv_field_evaluator(adv_field_evaluator)
-        , m_time_stepper(time_stepper)
+        , m_time_stepper_builder(time_stepper_builder)
     {
     }
 
@@ -233,9 +236,11 @@ public:
                               get_const_field(advection_field_coefs));
                   };
 
+        TimeStepper time_stepper
+                = m_time_stepper_builder.template preallocate<TimeStepper>(idx_range_advection);
 
         // Solve the characteristic equation with a time integration method
-        m_time_stepper
+        time_stepper
                 .update(Kokkos::DefaultExecutionSpace(),
                         get_field(slice_feet),
                         -dt,

--- a/src/timestepper/crank_nicolson.hpp
+++ b/src/timestepper/crank_nicolson.hpp
@@ -187,3 +187,42 @@ public:
         return (max_diff / norm_old) < m_epsilon;
     }
 };
+
+class CrankNicolsonBuilder
+{
+private:
+    int const m_max_counter;
+    double const m_epsilon;
+
+public:
+    CrankNicolsonBuilder(int const counter = int(20), double const epsilon = 1e-12)
+        : m_max_counter(counter)
+        , m_epsilon(epsilon)
+    {
+    }
+
+    template <
+            class FieldMem,
+            class DerivFieldMem = FieldMem,
+            class ExecSpace = Kokkos::DefaultExecutionSpace>
+    using time_stepper_t = CrankNicolson<FieldMem, DerivFieldMem, ExecSpace>;
+
+    template <class TimeStepper>
+    auto preallocate(typename TimeStepper::IdxRange const m_idx_range)
+    {
+        static_assert(std::is_same_v<
+                      TimeStepper,
+                      time_stepper_t<
+                              typename TimeStepper::ValFieldMem,
+                              typename TimeStepper::DerivFieldMem,
+                              typename TimeStepper::exec_space>>);
+        return TimeStepper(m_idx_range, m_max_counter, m_epsilon);
+    }
+};
+
+namespace detail {
+
+template <>
+inline constexpr bool enable_is_timestepper_builder<CrankNicolsonBuilder> = true;
+
+}

--- a/src/timestepper/crank_nicolson.hpp
+++ b/src/timestepper/crank_nicolson.hpp
@@ -208,7 +208,7 @@ public:
     using time_stepper_t = CrankNicolson<FieldMem, DerivFieldMem, ExecSpace>;
 
     template <class TimeStepper>
-    auto preallocate(typename TimeStepper::IdxRange const m_idx_range)
+    auto preallocate(typename TimeStepper::IdxRange const m_idx_range) const
     {
         static_assert(std::is_same_v<
                       TimeStepper,

--- a/src/timestepper/euler.hpp
+++ b/src/timestepper/euler.hpp
@@ -89,3 +89,5 @@ public:
         y_update(y, get_const_field(k1), dt);
     }
 };
+
+using EulerBuilder = ExplicitTimeStepperBuilder<Euler>;

--- a/src/timestepper/itimestepper.hpp
+++ b/src/timestepper/itimestepper.hpp
@@ -345,7 +345,7 @@ public:
     using time_stepper_t = TimeStepper<FieldMem, DerivFieldMem, ExecSpace>;
 
     template <class ChosenTimeStepper>
-    auto preallocate(typename ChosenTimeStepper::IdxRange const m_idx_range)
+    auto preallocate(typename ChosenTimeStepper::IdxRange const m_idx_range) const
     {
         static_assert(std::is_same_v<
                       ChosenTimeStepper,

--- a/src/timestepper/itimestepper.hpp
+++ b/src/timestepper/itimestepper.hpp
@@ -370,4 +370,3 @@ inline constexpr bool enable_is_timestepper_builder<ExplicitTimeStepperBuilder<T
 template <typename Type>
 inline constexpr bool is_timestepper_builder_v
         = detail::enable_is_timestepper_builder<std::remove_const_t<std::remove_reference_t<Type>>>;
-

--- a/src/timestepper/rk2.hpp
+++ b/src/timestepper/rk2.hpp
@@ -108,3 +108,5 @@ public:
         y_update(y, get_const_field(k2), dt);
     }
 };
+
+using RK2Builder = ExplicitTimeStepperBuilder<RK2>;

--- a/src/timestepper/rk3.hpp
+++ b/src/timestepper/rk3.hpp
@@ -150,3 +150,5 @@ public:
         y_update(y, get_const_field(k_total), dt / 6.);
     }
 };
+
+using RK3Builder = ExplicitTimeStepperBuilder<RK3>;

--- a/src/timestepper/rk4.hpp
+++ b/src/timestepper/rk4.hpp
@@ -156,3 +156,5 @@ public:
         y_update(y, get_const_field(k_total), dt / 6.);
     }
 };
+
+using RK4Builder = ExplicitTimeStepperBuilder<RK4>;

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -173,14 +173,8 @@ TEST_F(XAdvection1DTest, AdvectionX)
             spline_interpolator(builder, spline_evaluator, interpolation_idx_range);
 
 
-    RK2<FieldMemX<CoordX>, DFieldMemX> time_stepper(interpolation_idx_range);
-    BslAdvection1D<
-            GridX,
-            IdxRangeX,
-            IdxRangeX,
-            SplineXBuilder,
-            SplineXEvaluator,
-            RK2<FieldMemX<CoordX>, DFieldMemX>> const
+    RK2Builder time_stepper;
+    BslAdvection1D<GridX, IdxRangeX, IdxRangeX, SplineXBuilder, SplineXEvaluator, RK2Builder> const
             advection(spline_interpolator, builder, spline_evaluator, time_stepper);
 
     double const max_relative_error = AdvectionX(advection);

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -230,14 +230,14 @@ TEST_F(XVxAdvection1DTest, AdvectionXVx)
     PreallocatableSplineInterpolator const
             spline_interpolator_x(builder_x, spline_evaluator_x, idx_range_xvx);
 
-    RK2<FieldMemXVx<CoordX>, DFieldMemXVx> time_stepper(idx_range_xvx);
+    RK2Builder time_stepper;
     BslAdvection1D<
             GridX,
             IdxRangeXVx,
             IdxRangeXVx,
             SplineXBuilder,
             SplineXEvaluator,
-            RK2<FieldMemXVx<CoordX>, DFieldMemXVx>> const
+            RK2Builder> const
             advection(spline_interpolator_x, builder_x, spline_evaluator_x, time_stepper);
 
     double const max_relative_error = AdvectionXVx(advection);

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -340,8 +340,7 @@ TEST_F(XYVxVyAdvection1DTest, AdvectionXY)
             function_spline_y_interpolator(builder_y, spline_evaluator_y, xyvxvy_grid);
 
 
-    RK2<FieldMemXY<CoordX>, DFieldMemXY> time_stepper_x(xy_grid);
-    RK2<FieldMemXY<CoordY>, DFieldMemXY> time_stepper_y(xy_grid);
+    RK2Builder time_stepper;
 
     BslAdvection1D<
             GridX,
@@ -349,24 +348,24 @@ TEST_F(XYVxVyAdvection1DTest, AdvectionXY)
             IdxRangeXYVxVy,
             SplineXBuilder,
             SplineXEvaluator,
-            RK2<FieldMemXY<CoordX>, DFieldMemXY>> const
+            RK2Builder> const
             advection_x(
                     function_spline_x_interpolator,
                     builder_x,
                     spline_evaluator_x,
-                    time_stepper_x);
+                    time_stepper);
     BslAdvection1D<
             GridY,
             IdxRangeXY,
             IdxRangeXYVxVy,
             SplineYBuilder,
             SplineYEvaluator,
-            RK2<FieldMemXY<CoordY>, DFieldMemXY>> const
+            RK2Builder> const
             advection_y(
                     function_spline_y_interpolator,
                     builder_y,
                     spline_evaluator_y,
-                    time_stepper_y);
+                    time_stepper);
 
 
     double const max_relative_error = AdvectionXY(advection_x, advection_y);

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -231,14 +231,14 @@ TEST_F(Spatial1DAdvectionTest, SpatialAdvection)
     PreallocatableSplineInterpolator const
             spline_x_interpolator(builder_x, spline_x_evaluator, meshSpXVx);
 
-    Euler<FieldMemSpXVx<CoordX>, DFieldMemSpXVx> euler(meshSpXVx);
+    EulerBuilder euler;
     BslAdvection1D<
             GridX,
             IdxRangeSpXVx,
             IdxRangeSpXVx,
             SplineXBuilder,
             SplineXEvaluator,
-            Euler<FieldMemSpXVx<CoordX>, DFieldMemSpXVx>> const
+            EulerBuilder> const
             spline_advection_x(spline_x_interpolator, builder_x, spline_x_evaluator, euler);
 
     double const err = SpatialAdvection(spline_advection_x);

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -289,14 +289,14 @@ TEST_F(Velocity1DAdvectionTest, BatchedLagrange)
     SplineVxEvaluator const spline_vx_evaluator(bv_v_min, bv_v_max);
 
 
-    Euler<FieldMemSpXVx<CoordVx>, DFieldMemSpXVx> euler(meshSpXVx);
+    EulerBuilder euler;
     BslAdvection1D<
             GridVx,
             IdxRangeSpXVx,
             IdxRangeSpXVx,
             SplineVxBuilder,
             SplineVxEvaluator,
-            Euler<FieldMemSpXVx<CoordVx>, DFieldMemSpXVx>> const
+            EulerBuilder> const
             lagrange_advection_vx(lagrange_vx_interpolator, builder_vx, spline_vx_evaluator, euler);
 
 
@@ -322,14 +322,14 @@ TEST_F(Velocity1DAdvectionTest, SplineBatched)
     PreallocatableSplineInterpolator const
             spline_vx_interpolator(builder_vx, spline_vx_evaluator, meshSpXVx);
 
-    Euler<FieldMemSpXVx<CoordVx>, DFieldMemSpXVx> euler(meshSpXVx);
+    EulerBuilder euler;
     BslAdvection1D<
             GridVx,
             IdxRangeSpXVx,
             IdxRangeSpXVx,
             SplineVxBuilder,
             SplineVxEvaluator,
-            Euler<FieldMemSpXVx<CoordVx>, DFieldMemSpXVx>> const
+            EulerBuilder> const
             spline_advection_vx(spline_vx_interpolator, builder_vx, spline_vx_evaluator, euler);
 
 

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -131,18 +131,11 @@ private:
     NumericalParams params;
 
 public:
-    using ValFieldMem = FieldMemRTheta<CoordRTheta>;
-    using DerivFieldMem = DVectorFieldMemRTheta<X_adv, Y_adv>;
-
     using NumericalTuple = std::tuple<
-            NumericalMethodParameters<
-                    Euler<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>>,
-            NumericalMethodParameters<
-                    CrankNicolson<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>>,
-            NumericalMethodParameters<
-                    RK3<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>>,
-            NumericalMethodParameters<
-                    RK4<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>>>;
+            NumericalMethodParameters<EulerBuilder>,
+            NumericalMethodParameters<CrankNicolsonBuilder>,
+            NumericalMethodParameters<RK3Builder>,
+            NumericalMethodParameters<RK4Builder>>;
 
     static constexpr int size_tuple = std::tuple_size<NumericalTuple> {};
 
@@ -151,28 +144,13 @@ public:
     explicit Numerics(NumericalParams m_params)
         : params(m_params)
         , numerics(std::make_tuple(
+                  NumericalMethodParameters(EulerBuilder(), params.dt * 0.1, "EULER"),
                   NumericalMethodParameters(
-                          Euler<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>(
-                                  params.grid),
-                          params.dt * 0.1,
-                          "EULER"),
-                  NumericalMethodParameters(
-                          CrankNicolson<
-                                  ValFieldMem,
-                                  DerivFieldMem,
-                                  Kokkos::DefaultExecutionSpace>(params.grid, 20, 1e-12),
+                          CrankNicolsonBuilder(20, 1e-12),
                           params.dt,
                           "CRANK NICOLSON"),
-                  NumericalMethodParameters(
-                          RK3<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>(
-                                  params.grid),
-                          params.dt,
-                          "RK3"),
-                  NumericalMethodParameters(
-                          RK4<ValFieldMem, DerivFieldMem, Kokkos::DefaultExecutionSpace>(
-                                  params.grid),
-                          params.dt,
-                          "RK4")))
+                  NumericalMethodParameters(RK3Builder(), params.dt, "RK3"),
+                  NumericalMethodParameters(RK4Builder(), params.dt, "RK4")))
     {
     }
 };
@@ -218,6 +196,7 @@ void run_simulations_with_methods(
     std::string output_stem = output_stream.str();
 
     SplinePolarFootFinder const foot_finder(
+            params.grid,
             num.time_stepper,
             sim.to_physical_mapping,
             sim.analytical_to_pseudo_physical_mapping,

--- a/tests/geometryRTheta/advection_rtheta/advection_selected_test.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_selected_test.cpp
@@ -232,36 +232,23 @@ int main(int argc, char** argv)
 
     // SELECTION OF THE TIME INTEGRATION METHOD.
 #if defined(EULER_METHOD)
-    Euler<FieldMemRTheta<CoordRTheta>,
-          DVectorFieldMemRTheta<X_adv, Y_adv>,
-          Kokkos::DefaultExecutionSpace>
-            time_stepper(grid);
+    EulerBuilder time_stepper;
     std::string const method_name = "EULER";
     key += "euler";
 
 #elif defined(CRANK_NICOLSON_METHOD)
     double const epsilon_CN = 1e-8;
-    CrankNicolson<
-            FieldMemRTheta<CoordRTheta>,
-            DVectorFieldMemRTheta<X_adv, Y_adv>,
-            Kokkos::DefaultExecutionSpace>
-            time_stepper(grid, 20, epsilon_CN);
+    CrankNicolsonBuilder time_stepper(20, epsilon_CN);
     std::string const method_name = "CRANK NICOLSON";
     key += "crank_nicolson";
 
 #elif defined(RK3_METHOD)
-    RK3<FieldMemRTheta<CoordRTheta>,
-        DVectorFieldMemRTheta<X_adv, Y_adv>,
-        Kokkos::DefaultExecutionSpace>
-            time_stepper(grid);
+    RK3Builder time_stepper;
     std::string const method_name = "RK3";
     key += "rk3";
 
 #elif defined(RK4_METHOD)
-    RK4<FieldMemRTheta<CoordRTheta>,
-        DVectorFieldMemRTheta<X_adv, Y_adv>,
-        Kokkos::DefaultExecutionSpace>
-            time_stepper(grid);
+    RK4Builder time_stepper;
     std::string const method_name = "RK4";
     key += "rk4";
 #endif
@@ -292,6 +279,7 @@ int main(int argc, char** argv)
     }
 
     SplinePolarFootFinder const foot_finder(
+            grid,
             time_stepper,
             to_physical_mapping,
             logical_to_pseudo_cart_mapping,


### PR DESCRIPTION
Improve time integrator interface to simplify simulation code. Each time integrator now has an associated Builder class. The introduction of this class makes the caller responsible for defining the appropriate types and allows memory to be allocated where it is needed instead of existing for the lifetime of the simulation.