### PR TITLE
Use a vector field for the electric field in the geometryXYVxVy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change the interface of `IVlasovSolver` and `IQNSolver` in `geometryXYVxVy` to store the electric field in a `VectorField`.
+
 ### Deprecated
 
 ## [v0.1.0] - 2025-05-28

--- a/src/geometryXYVxVy/geometry/CMakeLists.txt
+++ b/src/geometryXYVxVy/geometry/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories("geometry_xyvxvy"
 )
 target_link_libraries("geometry_xyvxvy" INTERFACE
     DDC::core
+    gslx::data_types
     gslx::mpi_parallelisation
     gslx::speciesinfo
     gslx::utils

--- a/src/geometryXYVxVy/geometry/geometry.hpp
+++ b/src/geometryXYVxVy/geometry/geometry.hpp
@@ -9,9 +9,9 @@
 #include "ddc_helper.hpp"
 #include "mpilayout.hpp"
 #include "species_info.hpp"
-#include "vector_index_tools.hpp"
 #include "vector_field.hpp"
 #include "vector_field_mem.hpp"
+#include "vector_index_tools.hpp"
 
 
 /**
@@ -349,6 +349,10 @@ using ConstFieldY = Field<ElementType const, IdxRangeY>;
 template <class ElementType>
 using ConstFieldXY = Field<ElementType const, IdxRangeXY>;
 using DConstFieldXY = ConstFieldXY<double>;
+
+template <class ElementType>
+using VectorConstFieldXY = VectorConstField<ElementType, IdxRangeXY, VectorIndexSet<X, Y>>;
+using DVectorConstFieldXY = VectorConstFieldXY<double>;
 
 template <class ElementType>
 using ConstFieldVx = Field<ElementType const, IdxRangeVx>;

--- a/src/geometryXYVxVy/geometry/geometry.hpp
+++ b/src/geometryXYVxVy/geometry/geometry.hpp
@@ -9,6 +9,10 @@
 #include "ddc_helper.hpp"
 #include "mpilayout.hpp"
 #include "species_info.hpp"
+#include "vector_index_tools.hpp"
+#include "vector_field.hpp"
+#include "vector_field_mem.hpp"
+
 
 /**
  * @brief A class which describes the real space in the first spatial direction X.
@@ -265,6 +269,10 @@ using FieldMemXY = FieldMem<ElementType, IdxRangeXY>;
 using DFieldMemXY = FieldMemXY<double>;
 
 template <class ElementType>
+using VectorFieldMemXY = VectorFieldMem<ElementType, IdxRangeXY, VectorIndexSet<X, Y>>;
+using DVectorFieldMemXY = VectorFieldMemXY<double>;
+
+template <class ElementType>
 using FieldMemVx = FieldMem<ElementType, IdxRangeVx>;
 
 template <class ElementType>
@@ -302,6 +310,10 @@ using DFieldY = FieldY<double>;
 template <class ElementType>
 using FieldXY = Field<ElementType, IdxRangeXY>;
 using DFieldXY = FieldXY<double>;
+
+template <class ElementType>
+using VectorFieldXY = VectorField<ElementType, IdxRangeXY, VectorIndexSet<X, Y>>;
+using DVectorFieldXY = VectorFieldXY<double>;
 
 template <class ElementType>
 using FieldVx = Field<ElementType, IdxRangeVx>;

--- a/src/geometryXYVxVy/poisson/README.md
+++ b/src/geometryXYVxVy/poisson/README.md
@@ -20,10 +20,6 @@ The charge density is calculated by integrating the distribution function.
 
 ## Quasi-Neutrality Solver
 
-The Quasi-Neutrality equation can be solved with a variety of different methods. Here we have implemented:
-
-- FftQNSolver
+The Quasi-Neutrality equation can be solved with a variety of different methods by combining Poisson solvers and charge density solvers.
 
 These classes return the electric potential $\phi$ and the electric field $\frac{d \phi}{dx}$.
-
-The FftQNSolver does not calculate the electric field using the Fourier modes. Rather it uses a spline interpolation to approximate this value. This interpolation is calculated by the operator ElectricField.

--- a/src/geometryXYVxVy/poisson/iqnsolver.hpp
+++ b/src/geometryXYVxVy/poisson/iqnsolver.hpp
@@ -24,13 +24,11 @@ public:
      * The operator which solves the equation using the method described by the class.
      *
      * @param[out] electrostatic_potential The electrostatic potential, the result of the poisson solver.
-     * @param[out] electric_field_x The x-component of the electric field, the gradient of the electrostatic potential.
-     * @param[out] electric_field_y The y-component of the electric field, the gradient of the electrostatic potential.
+     * @param[out] electric_field The electric field, the gradient of the electrostatic potential.
      * @param[in] allfdistribu The distribution function.
      */
     virtual void operator()(
             DFieldXY electrostatic_potential,
-            DFieldXY electric_field_x,
-            DFieldXY electric_field_y,
+            DVectorFieldXY electric_field,
             DConstFieldSpVxVyXY allfdistribu) const = 0;
 };

--- a/src/geometryXYVxVy/poisson/nullqnsolver.cpp
+++ b/src/geometryXYVxVy/poisson/nullqnsolver.cpp
@@ -2,10 +2,6 @@
 
 #include "nullqnsolver.hpp"
 
-void NullQNSolver::operator()(
-        DFieldXY const,
-        DFieldXY const,
-        DFieldXY const,
-        DConstFieldSpVxVyXY const) const
+void NullQNSolver::operator()(DFieldXY const, DVectorFieldXY const, DConstFieldSpVxVyXY const) const
 {
 }

--- a/src/geometryXYVxVy/poisson/nullqnsolver.hpp
+++ b/src/geometryXYVxVy/poisson/nullqnsolver.hpp
@@ -25,7 +25,6 @@ public:
      */
     void operator()(
             DFieldXY electrostatic_potential,
-            DFieldXY electric_field_x,
-            DFieldXY electric_field_y,
+            DVectorFieldXY electric_field,
             DConstFieldSpVxVyXY allfdistribu) const override;
 };

--- a/src/geometryXYVxVy/poisson/nullqnsolver.hpp
+++ b/src/geometryXYVxVy/poisson/nullqnsolver.hpp
@@ -19,8 +19,7 @@ public:
     /** @brief A QN Solver which does nothing
      *
      * @param[out] electrostatic_potential The electrostatic potential, the result of the poisson solver.
-     * @param[out] electric_field_x The x-component of the electric field, the gradient of the electrostatic potential.
-     * @param[out] electric_field_y The y-component of the electric field, the gradient of the electrostatic potential.
+     * @param[out] electric_field The electric field, the gradient of the electrostatic potential.
      * @param[in] allfdistribu The distribution function.
      */
     void operator()(

--- a/src/geometryXYVxVy/poisson/qnsolver.cpp
+++ b/src/geometryXYVxVy/poisson/qnsolver.cpp
@@ -20,8 +20,7 @@ QNSolver::QNSolver(PoissonSolver const& solve_poisson, IChargeDensityCalculator 
 
 void QNSolver::operator()(
         DFieldXY const electrostatic_potential,
-        DFieldXY const electric_field_x,
-        DFieldXY const electric_field_y,
+        DVectorFieldXY const electric_field,
         DConstFieldSpVxVyXY const allfdistribu) const
 {
     Kokkos::Profiling::pushRegion("QNSolver");
@@ -33,13 +32,6 @@ void QNSolver::operator()(
     DFieldMemVxVy contiguous_slice_vxvy(get_idx_range<GridVx, GridVy>(allfdistribu));
     m_compute_rho(get_field(rho), allfdistribu);
 
-    VectorField<
-            double,
-            IdxRangeXY,
-            VectorIndexSet<X, Y>,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            typename DFieldMemXY::layout_type>
-            electric_field(electric_field_x, electric_field_y);
     m_solve_poisson(electrostatic_potential, electric_field, get_field(rho));
 
     Kokkos::Profiling::popRegion();

--- a/src/geometryXYVxVy/poisson/qnsolver.hpp
+++ b/src/geometryXYVxVy/poisson/qnsolver.hpp
@@ -43,13 +43,11 @@ public:
      * The operator which solves the equation using the method described by the class.
      *
      * @param[out] electrostatic_potential The electrostatic potential, the result of the poisson solver.
-     * @param[out] electric_field_x The x-component of the electric field, the gradient of the electrostatic potential.
-     * @param[out] electric_field_y The y-component of the electric field, the gradient of the electrostatic potential.
+     * @param[out] electric_field The electric field, the gradient of the electrostatic potential.
      * @param[in] allfdistribu The distribution function.
      */
     void operator()(
             DFieldXY electrostatic_potential,
-            DFieldXY electric_field_x,
-            DFieldXY electric_field_y,
+            DVectorFieldXY electric_field,
             DConstFieldSpVxVyXY allfdistribu) const override;
 };

--- a/src/geometryXYVxVy/time_integration/predcorr.cpp
+++ b/src/geometryXYVxVy/time_integration/predcorr.cpp
@@ -69,10 +69,7 @@ DFieldSpVxVyXY PredCorr::operator()(
         ddc::parallel_deepcopy(allfdistribu_half_t, allfdistribu_v2D_split);
 
         // predictor
-        m_vlasov_solver(
-                get_field(allfdistribu_half_t),
-                get_const_field(electric_field),
-                dt / 2);
+        m_vlasov_solver(get_field(allfdistribu_half_t), get_const_field(electric_field), dt / 2);
 
         // computation of the electrostatic potential at time tn+1/2
         // and the associated electric field
@@ -82,10 +79,7 @@ DFieldSpVxVyXY PredCorr::operator()(
                 get_const_field(allfdistribu_half_t));
 
         // correction on a dt
-        m_vlasov_solver(
-                get_field(allfdistribu_v2D_split),
-                get_const_field(electric_field),
-                dt);
+        m_vlasov_solver(get_field(allfdistribu_v2D_split), get_const_field(electric_field), dt);
     }
 
     double const final_time = iter * dt;

--- a/src/geometryXYVxVy/time_integration/predcorr.cpp
+++ b/src/geometryXYVxVy/time_integration/predcorr.cpp
@@ -31,20 +31,13 @@ DFieldSpVxVyXY PredCorr::operator()(
 
     // electrostatic potential and electric field (depending only on x)
     DFieldMemXY electrostatic_potential(get_idx_range<GridX, GridY>(allfdistribu_v2D_split));
-    DFieldMemXY electric_field_x(get_idx_range<GridX, GridY>(allfdistribu_v2D_split));
-    DFieldMemXY electric_field_y(get_idx_range<GridX, GridY>(allfdistribu_v2D_split));
+    DVectorFieldMemXY electric_field(get_idx_range<GridX, GridY>(allfdistribu_v2D_split));
 
     host_t<DFieldMemXY> electrostatic_potential_host(
             get_idx_range<GridX, GridY>(allfdistribu_v2D_split));
 
     // a 2D memory block of the same size as fdistribu
     DFieldMemSpVxVyXY allfdistribu_half_t(get_idx_range(allfdistribu_v2D_split));
-
-    m_poisson_solver(
-            get_field(electrostatic_potential),
-            get_field(electric_field_x),
-            get_field(electric_field_y),
-            get_const_field(allfdistribu_v2D_split));
 
     int iter = 0;
     for (; iter < steps; ++iter) {
@@ -54,8 +47,7 @@ DFieldSpVxVyXY PredCorr::operator()(
         // the associated electric field
         m_poisson_solver(
                 get_field(electrostatic_potential),
-                get_field(electric_field_x),
-                get_field(electric_field_y),
+                get_field(electric_field),
                 get_const_field(allfdistribu_v2D_split));
 
         transpose_layout(
@@ -79,31 +71,29 @@ DFieldSpVxVyXY PredCorr::operator()(
         // predictor
         m_vlasov_solver(
                 get_field(allfdistribu_half_t),
-                get_const_field(electric_field_x),
-                get_const_field(electric_field_y),
+                get_const_field(ddcHelper::get<X>(electric_field)),
+                get_const_field(ddcHelper::get<Y>(electric_field)),
                 dt / 2);
 
         // computation of the electrostatic potential at time tn+1/2
         // and the associated electric field
         m_poisson_solver(
                 get_field(electrostatic_potential),
-                get_field(electric_field_x),
-                get_field(electric_field_y),
+                get_field(electric_field),
                 get_const_field(allfdistribu_half_t));
 
         // correction on a dt
         m_vlasov_solver(
                 get_field(allfdistribu_v2D_split),
-                get_const_field(electric_field_x),
-                get_const_field(electric_field_y),
+                get_const_field(ddcHelper::get<X>(electric_field)),
+                get_const_field(ddcHelper::get<Y>(electric_field)),
                 dt);
     }
 
     double const final_time = iter * dt;
     m_poisson_solver(
             get_field(electrostatic_potential),
-            get_field(electric_field_x),
-            get_field(electric_field_y),
+            get_field(electric_field),
             get_const_field(allfdistribu_v2D_split));
 
 

--- a/src/geometryXYVxVy/time_integration/predcorr.cpp
+++ b/src/geometryXYVxVy/time_integration/predcorr.cpp
@@ -71,8 +71,7 @@ DFieldSpVxVyXY PredCorr::operator()(
         // predictor
         m_vlasov_solver(
                 get_field(allfdistribu_half_t),
-                get_const_field(ddcHelper::get<X>(electric_field)),
-                get_const_field(ddcHelper::get<Y>(electric_field)),
+                get_const_field(electric_field),
                 dt / 2);
 
         // computation of the electrostatic potential at time tn+1/2
@@ -85,8 +84,7 @@ DFieldSpVxVyXY PredCorr::operator()(
         // correction on a dt
         m_vlasov_solver(
                 get_field(allfdistribu_v2D_split),
-                get_const_field(ddcHelper::get<X>(electric_field)),
-                get_const_field(ddcHelper::get<Y>(electric_field)),
+                get_const_field(electric_field),
                 dt);
     }
 

--- a/src/geometryXYVxVy/vlasov/ivlasovsolver.hpp
+++ b/src/geometryXYVxVy/vlasov/ivlasovsolver.hpp
@@ -18,15 +18,13 @@ public:
      * @param[in, out] allfdistribu On input : the initial value of the distribution function.
      *                              On output : the value of the distribution function after solving 
      *                              the Vlasov equation.
-     * @param[in] efield_x The electric field in the x direction computed at all spatial positions. 
-     * @param[in] efield_y The electric field in the y direction computed at all spatial positions. 
+     * @param[in] efield The electric field computed at all spatial positions.
      * @param[in] dt The timestep. 
      *
      * @return The distribution function after solving the Vlasov equation.
      */
     virtual DFieldSpVxVyXY operator()(
             DFieldSpVxVyXY allfdistribu,
-            DConstFieldXY efield_x,
-            DConstFieldXY efield_y,
+            DVectorConstFieldXY efield,
             double dt) const = 0;
 };

--- a/src/geometryXYVxVy/vlasov/mpisplitvlasovsolver.cpp
+++ b/src/geometryXYVxVy/vlasov/mpisplitvlasovsolver.cpp
@@ -18,8 +18,7 @@ MpiSplitVlasovSolver::MpiSplitVlasovSolver(
 
 DFieldSpVxVyXY MpiSplitVlasovSolver::operator()(
         DFieldSpVxVyXY const allfdistribu_v2Dsplit,
-        DConstFieldXY const electric_field_x,
-        DConstFieldXY const electric_field_y,
+        DVectorConstFieldXY const electric_field,
         double const dt) const
 {
     IdxRangeSpVxVyXY idxrange_v2Dsplit(m_transpose.get_local_idx_range<V2DSplit>());
@@ -33,10 +32,10 @@ DFieldSpVxVyXY MpiSplitVlasovSolver::operator()(
     DFieldMemXY local_electric_field_y(idx_range_xy_v2Dsplit);
     ddc::parallel_deepcopy(
             get_field(local_electric_field_x),
-            electric_field_x[idx_range_xy_v2Dsplit]);
+            ddcHelper::get<X>(electric_field)[idx_range_xy_v2Dsplit]);
     ddc::parallel_deepcopy(
             get_field(local_electric_field_y),
-            electric_field_y[idx_range_xy_v2Dsplit]);
+            ddcHelper::get<Y>(electric_field)[idx_range_xy_v2Dsplit]);
 
     // Advect in spatial dimensions
     m_advec_x(allfdistribu_v2Dsplit, dt / 2);

--- a/src/geometryXYVxVy/vlasov/mpisplitvlasovsolver.hpp
+++ b/src/geometryXYVxVy/vlasov/mpisplitvlasovsolver.hpp
@@ -57,15 +57,13 @@ public:
      * @param[in, out] allfdistribu On input : the initial value of the distribution function.
      *                              On output : the value of the distribution function after solving 
      *                              the Vlasov equation.
-     * @param[in] electric_field_x The electric field in the x direction computed at all spatial positions. 
-     * @param[in] electric_field_y The electric field in the y direction computed at all spatial positions. 
+     * @param[in] electric_field The electric field computed at all spatial positions.
      * @param[in] dt The timestep. 
      *
      * @return The distribution function after solving the Vlasov equation.
      */
     DFieldSpVxVyXY operator()(
             DFieldSpVxVyXY allfdistribu,
-            DConstFieldXY electric_field_x,
-            DConstFieldXY electric_field_y,
+            DVectorConstFieldXY electric_field,
             double dt) const override;
 };

--- a/src/geometryXYVxVy/vlasov/splitvlasovsolver.cpp
+++ b/src/geometryXYVxVy/vlasov/splitvlasovsolver.cpp
@@ -18,15 +18,14 @@ SplitVlasovSolver::SplitVlasovSolver(
 
 DFieldSpVxVyXY SplitVlasovSolver::operator()(
         DFieldSpVxVyXY const allfdistribu,
-        DConstFieldXY const electric_field_x,
-        DConstFieldXY const electric_field_y,
+        DVectorConstFieldXY const electric_field,
         double const dt) const
 {
     m_advec_x(allfdistribu, dt / 2);
     m_advec_y(allfdistribu, dt / 2);
-    m_advec_vx(allfdistribu, electric_field_x, dt / 2);
-    m_advec_vy(allfdistribu, electric_field_y, dt);
-    m_advec_vx(allfdistribu, electric_field_x, dt / 2);
+    m_advec_vx(allfdistribu, ddcHelper::get<X>(electric_field), dt / 2);
+    m_advec_vy(allfdistribu, ddcHelper::get<Y>(electric_field), dt);
+    m_advec_vx(allfdistribu, ddcHelper::get<X>(electric_field), dt / 2);
     m_advec_y(allfdistribu, dt / 2);
     m_advec_x(allfdistribu, dt / 2);
 

--- a/src/geometryXYVxVy/vlasov/splitvlasovsolver.hpp
+++ b/src/geometryXYVxVy/vlasov/splitvlasovsolver.hpp
@@ -53,15 +53,13 @@ public:
      * @param[in, out] allfdistribu On input : the initial value of the distribution function.
      *                              On output : the value of the distribution function after solving 
      *                              the Vlasov equation.
-     * @param[in] electric_field_x The electric field in the x direction computed at all spatial positions. 
-     * @param[in] electric_field_y The electric field in the y direction computed at all spatial positions. 
+     * @param[in] electric_field The electric field computed at all spatial positions.
      * @param[in] dt The timestep. 
      *
      * @return The distribution function after solving the Vlasov equation.
      */
     DFieldSpVxVyXY operator()(
             DFieldSpVxVyXY allfdistribu,
-            DConstFieldXY electric_field_x,
-            DConstFieldXY electric_field_y,
+            DVectorConstFieldXY electric_field,
             double dt) const override;
 };


### PR DESCRIPTION
Use a vector field for the electric field in the geometryXYVxVy. This removes the need for the constructor of `VectorField` which takes multiple `Field`s. This constructor is blocking for #322.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [x] Have you checked that existing tests cover all code after the changes ?
- [x] Have you checked that existing tests are still passing ?
- [x] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
