### PR TITLE
Fix module ordering in Adastra toolchains

### DIFF
--- a/toolchains/genoa.gcc.adastra.spack/environment.sh
+++ b/toolchains/genoa.gcc.adastra.spack/environment.sh
@@ -1,14 +1,8 @@
+#!/bin/bash
+
 ENVIRONMENT_ROOT_DIRECTORY="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
 
 module purge
-
-module load cpe/24.07
-module load craype-x86-genoa
-module load PrgEnv-gnu
-
-module load cray-fftw
-module load cray-hdf5-parallel
-module load cray-python
 
 SPACK_USER_VERSION="spack-user-4.0.0"
 
@@ -30,5 +24,13 @@ module load \
     gcc/13.2.1.genoa/zen4/py-matplotlib \
     gcc/13.2.1.genoa/zen4/py-xarray \
     gcc/13.2.1.genoa/zen4/py-h5py
+
+module load cpe/24.07
+module load craype-x86-genoa
+module load PrgEnv-gnu
+
+module load cray-fftw
+module load cray-hdf5-parallel
+module load cray-python
 
 module list

--- a/toolchains/mi250.hipcc.adastra.spack/environment.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/environment.sh
@@ -1,18 +1,8 @@
+#!/bin/bash
+
 ENVIRONMENT_ROOT_DIRECTORY="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
 
 module purge
-
-module load cpe/24.07
-# FIXME:
-# craype-accel-amd-gfx90a Error with the cray wrappers clang: error: unsupported option '-fopenmp-targets=' for language mode 'HIP'
-module load craype-x86-trento
-# NOTE: Force 6.3.3 due to startup failures (https://github.com/gyselax/gyselalibxx/pull/198#issuecomment-2943081411)
-module load PrgEnv-cray-amd amd-mixed/6.3.3
-
-module load rocm/6.3.3
-module load cray-fftw
-module load cray-hdf5-parallel
-module load cray-python
 
 SPACK_USER_VERSION="spack-user-4.0.0"
 
@@ -34,5 +24,18 @@ module load \
     gcc/13.2.1.mi250/zen3/py-matplotlib \
     gcc/13.2.1.mi250/zen3/py-xarray \
     gcc/13.2.1.mi250/zen3/py-h5py
+
+unset HIPCC_COMPILE_FLAGS_APPEND
+
+module load cpe/24.07
+# FIXME:
+# craype-accel-amd-gfx90a Error with the cray wrappers clang: error: unsupported option '-fopenmp-targets=' for language mode 'HIP'
+module load craype-x86-trento
+# NOTE: Force 6.3.3 due to startup failures (https://github.com/gyselax/gyselalibxx/pull/198#issuecomment-2943081411)
+module load PrgEnv-cray-amd amd-mixed/6.3.3
+module load rocm/6.3.3
+module load cray-fftw
+module load cray-hdf5-parallel
+module load cray-python
 
 module list


### PR DESCRIPTION
Turns out that the spack products' modules define ROCM environment variable. This ends up overriding the variables define by other fundamental modules, such as the system's ROCM.

The Spack configuration provided by cines is based on ROCM 6.1.2. It is with this version that we build all the deps.

But GYSELA is known to trigger a GPU global variable bug in HIP. Using ROCM 6.3.3 fixes that issue. So we build the deps using ROCm 6.1.2 and build gyselalib using 6.3.3.

This PR swaps the module ordering to prevent any overriding done by spack modules. It also unsets a problematic environment variable also defined by spack modules.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?
