### PR TITLE
Stop naming 'break points' as 'knots'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix uninitialized warning in the `Tensor` class.
 - Fix unused `m_magnetic_field` variable in `MaxwellianEquilibrium` class.
+- Fix break points incorrectly labelled as knots.
 
 ### Changed
 

--- a/tests/coord_transformations/jacobian.cpp
+++ b/tests/coord_transformations/jacobian.cpp
@@ -85,12 +85,12 @@ TEST_P(InvJacobianMatrix, InverseMatrixDiscCzarMap)
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_size(Nt);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_size);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_size);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_size);
 
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(InterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(InterpPointsTheta::get_sampling<GridTheta>());
@@ -148,12 +148,12 @@ TEST_P(InvJacobianMatrix3D, InverseMatrixToroidalDiscCzarMap)
     CoordPhi const phi_max(2.0 * M_PI);
     IdxStepPhi const phi_size(Nt);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_size);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_size);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_size);
 
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(InterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(InterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/coord_transformations/jacobian_matrix_coef.cpp
+++ b/tests/coord_transformations/jacobian_matrix_coef.cpp
@@ -168,12 +168,12 @@ TEST_P(JacobianMatrixAndJacobianCoefficients, MatrixDiscCzarMap)
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_size(Nt);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_size);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_size);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_size);
 
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(InterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(InterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/coord_transformations/pseudo_cartesian_jacobian_matrix.cpp
+++ b/tests/coord_transformations/pseudo_cartesian_jacobian_matrix.cpp
@@ -177,22 +177,22 @@ public:
         double const dtheta((theta_max - theta_min) / theta_size);
 
 
-        std::vector<CoordR> r_knots(r_size + 1);
-        std::vector<CoordTheta> theta_knots(theta_size + 1);
+        std::vector<CoordR> r_break_points(r_size + 1);
+        std::vector<CoordTheta> theta_break_points(theta_size + 1);
 
 
-        r_knots[0] = r_min;
+        r_break_points[0] = r_min;
         for (int i(1); i < r_size; ++i) {
-            r_knots[i] = CoordR(r_min + i * dr);
+            r_break_points[i] = CoordR(r_min + i * dr);
         }
-        r_knots[r_size] = r_max;
+        r_break_points[r_size] = r_max;
         for (int i(0); i < theta_size + 1; ++i) {
-            theta_knots[i] = CoordTheta(theta_min + i * dtheta);
+            theta_break_points[i] = CoordTheta(theta_min + i * dtheta);
         }
 
         // Creating mesh & supports
-        ddc::init_discrete_space<BSplinesR>(r_knots);
-        ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+        ddc::init_discrete_space<BSplinesR>(r_break_points);
+        ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
         ddc::init_discrete_space<GridR>(InterpPointsR::template get_sampling<GridR>());
         ddc::init_discrete_space<GridTheta>(InterpPointsTheta::template get_sampling<GridTheta>());

--- a/tests/coord_transformations/refined_discrete_mapping.cpp
+++ b/tests/coord_transformations/refined_discrete_mapping.cpp
@@ -410,22 +410,22 @@ TEST(RefinedDiscreteMapping, TestRefinedDiscreteMapping)
     double const dr((r_max - r_min) / r_size);
     double const dp((theta_max - theta_min) / theta_size);
 
-    std::vector<CoordR> r_knots(r_size + 1);
-    std::vector<CoordTheta> theta_knots(theta_size + 1);
+    std::vector<CoordR> r_break_points(r_size + 1);
+    std::vector<CoordTheta> theta_break_points(theta_size + 1);
 
     for (int i(1); i < r_size + 1; ++i) {
-        r_knots[i] = CoordR(r_min + i * dr);
+        r_break_points[i] = CoordR(r_min + i * dr);
     }
-    r_knots[0] = CoordR(r_min);
-    r_knots[r_size] = CoordR(r_max);
+    r_break_points[0] = CoordR(r_min);
+    r_break_points[r_size] = CoordR(r_max);
     for (int i(1); i < theta_size; ++i) {
-        theta_knots[i] = CoordTheta(theta_min + i * dp);
+        theta_break_points[i] = CoordTheta(theta_min + i * dp);
     }
-    theta_knots[0] = CoordTheta(theta_min);
-    theta_knots[theta_size] = CoordTheta(theta_max);
+    theta_break_points[0] = CoordTheta(theta_min);
+    theta_break_points[theta_size] = CoordTheta(theta_max);
 
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(InterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(InterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/coord_transformations/vector_basis_change.cpp
+++ b/tests/coord_transformations/vector_basis_change.cpp
@@ -23,12 +23,12 @@ void setup_coordinates()
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_ncells(N_cells_theta);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_ncells);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_ncells);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
 
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(InterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(InterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
+++ b/tests/geometryRTheta/advection_field_rtheta/advection_field_gtest.cpp
@@ -77,13 +77,13 @@ TEST(AdvectionFieldRThetaComputation, TestAdvectionFieldFinder)
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_ncells(Nt);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_ncells);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_ncells);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
 
     // Creating mesh & supports:
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(SplineInterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -272,9 +272,9 @@ int main(int argc, char** argv)
             SplineInterpPointsR>(conf_gyselalibxx, "r");
     PC_tree_destroy(&conf_gyselalibxx);
 
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());
 
     IdxRangeTheta const interpolation_idx_range_theta(

--- a/tests/geometryRTheta/advection_rtheta/advection_selected_test.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_selected_test.cpp
@@ -107,9 +107,9 @@ int main(int argc, char** argv)
             SplineInterpPointsR>(conf_gyselalibxx, "r");
     PC_tree_destroy(&conf_gyselalibxx);
 
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());
     IdxRangeTheta const interpolation_idx_range_theta(
             SplineInterpPointsTheta::get_domain<GridTheta>());
@@ -124,7 +124,7 @@ int main(int argc, char** argv)
               << "WITH NrxNt = " << interpolation_idx_range_r.size() << "x"
               << interpolation_idx_range_theta.size() << " AND dt = " << dt << ": " << std::endl;
 
-    std::ofstream file("r_knots.txt");
+    std::ofstream file("r_interpolation_points.txt");
     for_each(interpolation_idx_range_r, [&](IdxR ir) {
         file << (ir - interpolation_idx_range_r.front()).value() << " "
              << double(ddc::coordinate(ir)) << std::endl;

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -85,14 +85,14 @@ int main(int argc, char** argv)
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_ncells(PCpp_int(conf_gyselalibxx, ".SplineMesh.theta_ncells"));
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_ncells);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_ncells);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
 
     // Creating mesh & supports
-    ddc::init_discrete_space<BSplinesR>(r_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
 
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(SplineInterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/geometryRTheta/quadrature/tests_L1_and_L2_norms.cpp
+++ b/tests/geometryRTheta/quadrature/tests_L1_and_L2_norms.cpp
@@ -203,13 +203,13 @@ TEST_P(SplineQuadrature, TestFunctions)
     CoordTheta const theta_max(2.0 * M_PI);
     IdxStepTheta const theta_ncells(Nt);
 
-    std::vector<CoordR> r_knots = build_uniform_break_points(r_min, r_max, r_ncells);
-    std::vector<CoordTheta> theta_knots
+    std::vector<CoordR> r_break_points = build_uniform_break_points(r_min, r_max, r_ncells);
+    std::vector<CoordTheta> theta_break_points
             = build_uniform_break_points(theta_min, theta_max, theta_ncells);
 
     // Creating mesh & supports
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(SplineInterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());

--- a/tests/geometryRTheta/spline_interpolator_rtheta/spline_interpolator_rtheta.cpp
+++ b/tests/geometryRTheta/spline_interpolator_rtheta/spline_interpolator_rtheta.cpp
@@ -295,20 +295,20 @@ int main(int argc, char** argv)
     double const dr((r_max - r_min) / r_size);
     double const dp((theta_max - theta_min) / theta_size);
 
-    std::vector<CoordR> r_knots(r_size + 1);
-    std::vector<CoordTheta> theta_knots(theta_size + 1);
+    std::vector<CoordR> r_break_points(r_size + 1);
+    std::vector<CoordTheta> theta_break_points(theta_size + 1);
 
     for (int i(0); i < r_size + 1; ++i) {
-        r_knots[i] = CoordR(r_min + i * dr);
+        r_break_points[i] = CoordR(r_min + i * dr);
     }
     for (int i(0); i < theta_size + 1; ++i) {
-        theta_knots[i] = CoordTheta(theta_min + i * dp);
+        theta_break_points[i] = CoordTheta(theta_min + i * dp);
     }
 
 
     // Creating mesh & supports
-    ddc::init_discrete_space<BSplinesR>(r_knots);
-    ddc::init_discrete_space<BSplinesTheta>(theta_knots);
+    ddc::init_discrete_space<BSplinesR>(r_break_points);
+    ddc::init_discrete_space<BSplinesTheta>(theta_break_points);
 
     ddc::init_discrete_space<GridR>(SplineInterpPointsR::get_sampling<GridR>());
     ddc::init_discrete_space<GridTheta>(SplineInterpPointsTheta::get_sampling<GridTheta>());


### PR DESCRIPTION
Fix break points incorrectly labelled as knots. Fixes #69 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [x] Have you checked that existing tests cover all code after the changes ?
- [x] Have you checked that existing tests are still passing ?
- [x] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
