### PR TITLE
Expose O-point from curvilinear mappings

### DIFF
--- a/src/coord_transformations/cartesian_to_circular.hpp
+++ b/src/coord_transformations/cartesian_to_circular.hpp
@@ -74,7 +74,7 @@ public:
      *
      * @param[in] o_point The (x,y)-coordinate of the centre of the circle ((0,0) by default).
      */
-    explicit KOKKOS_FUNCTION CartesianToCircular(Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+    explicit KOKKOS_FUNCTION CartesianToCircular(Coord<X, Y> o_point = Coord<X, Y>(0.0, 0.0))
         : m_o_point(o_point)
     {
     }

--- a/src/coord_transformations/cartesian_to_circular.hpp
+++ b/src/coord_transformations/cartesian_to_circular.hpp
@@ -66,19 +66,16 @@ public:
     using Theta_cov = typename Theta::Dual;
 
 private:
-    double m_x0;
-    double m_y0;
+    Coord<X, Y> m_o_point;
 
 public:
     /**
      * @brief Instantiate a CartesianToCircular from parameters.
      *
-     * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
-     * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
+     * @param[in] o_point The (x,y)-coordinate of the centre of the circle ((0,0) by default).
      */
-    explicit KOKKOS_FUNCTION CartesianToCircular(double x0 = 0.0, double y0 = 0.0)
-        : m_x0(x0)
-        , m_y0(y0)
+    explicit KOKKOS_FUNCTION CartesianToCircular(Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+        : m_o_point(o_point)
     {
     }
 
@@ -129,8 +126,8 @@ public:
      */
     KOKKOS_FUNCTION Coord<R, Theta> operator()(Coord<X, Y> const& coord) const
     {
-        const double x = ddc::get<X>(coord) - m_x0;
-        const double y = ddc::get<Y>(coord) - m_y0;
+        const double x = ddc::get<X>(coord) - ddc::get<X>(m_o_point);
+        const double y = ddc::get<Y>(coord) - ddc::get<Y>(m_o_point);
         const double r = Kokkos::sqrt(x * x + y * y);
         const double theta_pi_to_pi(Kokkos::atan2(y, x));
         const double theta = theta_pi_to_pi * (theta_pi_to_pi >= 0)
@@ -148,8 +145,8 @@ public:
      */
     KOKKOS_FUNCTION double jacobian(Coord<X, Y> const& coord)
     {
-        const double x = ddc::get<X>(coord) - m_x0;
-        const double y = ddc::get<Y>(coord) - m_y0;
+        const double x = ddc::get<X>(coord) - ddc::get<X>(m_o_point);
+        const double y = ddc::get<Y>(coord) - ddc::get<Y>(m_o_point);
         return 1. / Kokkos::sqrt(x * x + y * y);
     }
 
@@ -168,8 +165,8 @@ public:
             Coord<X, Y> const& coord) const
 
     {
-        const double x = ddc::get<X>(coord) - m_x0;
-        const double y = ddc::get<Y>(coord) - m_y0;
+        const double x = ddc::get<X>(coord) - ddc::get<X>(m_o_point);
+        const double y = ddc::get<Y>(coord) - ddc::get<Y>(m_o_point);
         DTensor<VectorIndexSet<R, Theta>, VectorIndexSet<X_cov, Y_cov>> jacobian_matrix;
         const double r2 = x * x + y * y;
         const double r = Kokkos::sqrt(r2);
@@ -194,8 +191,8 @@ public:
         static_assert(ddc::in_tags_v<IndexTag1, VectorIndexSet<R, Theta>>);
         static_assert(ddc::in_tags_v<IndexTag2, VectorIndexSet<X_cov, Y_cov>>);
 
-        const double x = ddc::get<X>(coord) - m_x0;
-        const double y = ddc::get<Y>(coord) - m_y0;
+        const double x = ddc::get<X>(coord) - ddc::get<X>(m_o_point);
+        const double y = ddc::get<Y>(coord) - ddc::get<Y>(m_o_point);
         if constexpr (std::is_same_v<IndexTag1, R> && std::is_same_v<IndexTag2, X_cov>) {
             // Component (1,1), i.e dr/dx
             return x / Kokkos::pow(x * x + y * y, 0.5);
@@ -218,7 +215,7 @@ public:
      */
     KOKKOS_INLINE_FUNCTION CircularToCartesian<R, Theta, X, Y> get_inverse_mapping() const
     {
-        return CircularToCartesian<R, Theta, X, Y>(m_x0, m_y0);
+        return CircularToCartesian<R, Theta, X, Y>(m_o_point);
     }
 };
 

--- a/src/coord_transformations/cartesian_to_czarny.hpp
+++ b/src/coord_transformations/cartesian_to_czarny.hpp
@@ -46,8 +46,7 @@ public:
 private:
     double m_epsilon;
     double m_e;
-    double m_x0;
-    double m_y0;
+    Coord<X, Y> m_o_point;
 
 public:
     /**
@@ -65,12 +64,10 @@ public:
     explicit KOKKOS_FUNCTION CartesianToCzarny(
             double epsilon,
             double e,
-            double x0 = 0.0,
-            double y0 = 0.0)
+            Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
         : m_epsilon(epsilon)
         , m_e(e)
-        , m_x0(x0)
-        , m_y0(y0)
+        , m_o_point(o_point)
     {
     }
 
@@ -145,8 +142,8 @@ public:
      */
     KOKKOS_FUNCTION Coord<R, Theta> operator()(Coord<X, Y> const& coord) const
     {
-        const double x = ddc::get<X>(coord) - m_x0;
-        const double y = ddc::get<Y>(coord) - m_y0;
+        const double x = ddc::get<X>(coord) - ddc::get<X>(m_o_point);
+        const double y = ddc::get<Y>(coord) - ddc::get<Y>(m_o_point);
         const double ex = 1. + m_epsilon * x;
         const double ex2 = (m_epsilon * x * x - 2. * x - m_epsilon);
         const double xi2 = 1. / (1. - m_epsilon * m_epsilon * 0.25);
@@ -166,7 +163,7 @@ public:
      */
     KOKKOS_INLINE_FUNCTION CzarnyToCartesian<R, Theta, X, Y> get_inverse_mapping() const
     {
-        return CzarnyToCartesian<R, Theta, X, Y>(m_epsilon, m_e, m_x0, m_y0);
+        return CzarnyToCartesian<R, Theta, X, Y>(m_epsilon, m_e, m_o_point);
     }
 };
 

--- a/src/coord_transformations/cartesian_to_czarny.hpp
+++ b/src/coord_transformations/cartesian_to_czarny.hpp
@@ -64,7 +64,7 @@ public:
     explicit KOKKOS_FUNCTION CartesianToCzarny(
             double epsilon,
             double e,
-            Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+            Coord<X, Y> o_point = Coord<X, Y>(0.0, 0.0))
         : m_epsilon(epsilon)
         , m_e(e)
         , m_o_point(o_point)

--- a/src/coord_transformations/circular_to_cartesian.hpp
+++ b/src/coord_transformations/circular_to_cartesian.hpp
@@ -77,7 +77,7 @@ public:
      *
      * @param[in] o_point The (x,y)-coordinate of the centre of the circle ((0,0) by default).
      */
-    explicit KOKKOS_FUNCTION CircularToCartesian(Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+    explicit KOKKOS_FUNCTION CircularToCartesian(Coord<X, Y> o_point = Coord<X, Y>(0.0, 0.0))
         : m_o_point(o_point)
     {
     }

--- a/src/coord_transformations/circular_to_cartesian.hpp
+++ b/src/coord_transformations/circular_to_cartesian.hpp
@@ -69,8 +69,7 @@ public:
     using Theta_cov = typename Theta::Dual;
 
 private:
-    double m_x0;
-    double m_y0;
+    Coord<X, Y> m_o_point;
 
 public:
     /**
@@ -79,10 +78,22 @@ public:
      * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
      * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
      */
-    explicit KOKKOS_FUNCTION CircularToCartesian(double x0 = 0.0, double y0 = 0.0)
-        : m_x0(x0)
-        , m_y0(y0)
+    explicit KOKKOS_FUNCTION CircularToCartesian(Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+        : m_o_point(o_point)
     {
+    }
+
+    /**
+     * @brief Get the O-point in Cartesian coordinates.
+     *
+     * Get the O-point of this mapping in Cartesian coordinates. This is calculated in
+     * the constructor.
+     *
+     * @return The O-point.
+     */
+    KOKKOS_INLINE_FUNCTION Coord<X, Y> o_point() const
+    {
+        return m_o_point;
     }
 
     /**
@@ -134,8 +145,8 @@ public:
     {
         const double r = ddc::get<R>(coord);
         const double theta = ddc::get<Theta>(coord);
-        const double x = r * Kokkos::cos(theta) + m_x0;
-        const double y = r * Kokkos::sin(theta) + m_y0;
+        const double x = r * Kokkos::cos(theta) + ddc::get<X>(m_o_point);
+        const double y = r * Kokkos::sin(theta) + ddc::get<Y>(m_o_point);
         return Coord<X, Y>(x, y);
     }
 
@@ -297,7 +308,7 @@ public:
      */
     KOKKOS_INLINE_FUNCTION CartesianToCircular<X, Y, R, Theta> get_inverse_mapping() const
     {
-        return CartesianToCircular<X, Y, R, Theta>(m_x0, m_y0);
+        return CartesianToCircular<X, Y, R, Theta>(m_o_point);
     }
 };
 

--- a/src/coord_transformations/circular_to_cartesian.hpp
+++ b/src/coord_transformations/circular_to_cartesian.hpp
@@ -75,8 +75,7 @@ public:
     /**
      * @brief Instantiate a CircularToCartesian from parameters.
      *
-     * @param[in] x0 The x-coordinate of the centre of the circle (0 by default).
-     * @param[in] y0 The y-coordinate of the centre of the circle (0 by default).
+     * @param[in] o_point The (x,y)-coordinate of the centre of the circle ((0,0) by default).
      */
     explicit KOKKOS_FUNCTION CircularToCartesian(Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
         : m_o_point(o_point)

--- a/src/coord_transformations/cylindrical_to_cartesian.hpp
+++ b/src/coord_transformations/cylindrical_to_cartesian.hpp
@@ -128,6 +128,19 @@ public:
     CylindricalToCartesian& operator=(CylindricalToCartesian&& x) = default;
 
     /**
+     * @brief Get the O-point in Cartesian coordinates.
+     *
+     * Get the O-point of this mapping in Cartesian coordinates. This is calculated in
+     * the constructor.
+     *
+     * @return The O-point.
+     */
+    KOKKOS_INLINE_FUNCTION Coord<X, Y> o_point() const
+    {
+        return Coord<X, Y>(0.0, 0.0);
+    }
+
+    /**
      * @brief Convert the @f$ (r, \zeta) @f$ coordinate to the equivalent (x,y) coordinate.
      *
      * @param[in] coord The coordinate to be converted.

--- a/src/coord_transformations/czarny_to_cartesian.hpp
+++ b/src/coord_transformations/czarny_to_cartesian.hpp
@@ -82,8 +82,7 @@ public:
 private:
     double m_epsilon;
     double m_e;
-    double m_x0;
-    double m_y0;
+    Coord<X, Y> m_o_point;
 
 public:
     /**
@@ -101,12 +100,10 @@ public:
     explicit KOKKOS_FUNCTION CzarnyToCartesian(
             double epsilon,
             double e,
-            double x0 = 0.0,
-            double y0 = 0.0)
+            Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
         : m_epsilon(epsilon)
         , m_e(e)
-        , m_x0(x0)
-        , m_y0(y0)
+        , m_o_point(o_point)
     {
     }
 
@@ -173,6 +170,19 @@ public:
     }
 
     /**
+     * @brief Get the O-point in Cartesian coordinates.
+     *
+     * Get the O-point of this mapping in Cartesian coordinates. This is calculated in
+     * the constructor.
+     *
+     * @return The O-point.
+     */
+    KOKKOS_INLINE_FUNCTION Coord<X, Y> o_point() const
+    {
+        return m_o_point;
+    }
+
+    /**
      * @brief Convert the @f$ (r, \theta) @f$ coordinate to the equivalent (x,y) coordinate.
      *
      * @param[in] coord The coordinate to be converted.
@@ -186,10 +196,10 @@ public:
         const double tmp1
                 = Kokkos::sqrt(m_epsilon * (m_epsilon + 2.0 * r * Kokkos::cos(theta)) + 1.0);
 
-        const double x = (1.0 - tmp1) / m_epsilon + m_x0;
+        const double x = (1.0 - tmp1) / m_epsilon + ddc::get<X>(m_o_point);
         const double y = m_e * r * Kokkos::sin(theta)
                                  / (Kokkos::sqrt(1.0 - 0.25 * m_epsilon * m_epsilon) * (2.0 - tmp1))
-                         + m_y0;
+                         + ddc::get<Y>(m_o_point);
 
         return Coord<X, Y>(x, y);
     }
@@ -403,7 +413,7 @@ public:
      */
     KOKKOS_INLINE_FUNCTION CartesianToCzarny<X, Y, R, Theta> get_inverse_mapping() const
     {
-        return CartesianToCzarny<X, Y, R, Theta>(m_epsilon, m_e, m_x0, m_y0);
+        return CartesianToCzarny<X, Y, R, Theta>(m_epsilon, m_e, m_o_point);
     }
 };
 

--- a/src/coord_transformations/czarny_to_cartesian.hpp
+++ b/src/coord_transformations/czarny_to_cartesian.hpp
@@ -100,7 +100,7 @@ public:
     explicit KOKKOS_FUNCTION CzarnyToCartesian(
             double epsilon,
             double e,
-            Coord<X, Y> o_point = Coord<X,Y>(0.0, 0.0))
+            Coord<X, Y> o_point = Coord<X, Y>(0.0, 0.0))
         : m_epsilon(epsilon)
         , m_e(e)
         , m_o_point(o_point)

--- a/src/coord_transformations/discrete_to_cartesian.hpp
+++ b/src/coord_transformations/discrete_to_cartesian.hpp
@@ -152,6 +152,19 @@ public:
     }
 
     /**
+     * @brief Get the O-point in Cartesian coordinates.
+     *
+     * Get the O-point of this mapping in Cartesian coordinates. This is calculated in
+     * the constructor.
+     *
+     * @return The O-point.
+     */
+    KOKKOS_INLINE_FUNCTION Coord<X, Y> o_point() const
+    {
+        return m_o_point;
+    }
+
+    /**
      * @brief Compute the physical coordinates from the logical coordinates.
      *
      * It evaluates the decomposed mapping on B-splines at the coordinate point

--- a/src/coord_transformations/discrete_to_cartesian.hpp
+++ b/src/coord_transformations/discrete_to_cartesian.hpp
@@ -139,15 +139,15 @@ public:
             FieldMem<Coord<X, Y>, IdxRangeRTheta> coord_centre_field_alloc(idx_range_o_point);
             Field<Coord<X, Y>, IdxRangeRTheta> coord_centre_field
                     = get_field(coord_centre_field_alloc);
-            using ExecSpace = SplineEvaluator::exec_space;
+            using ExecSpace = typename SplineEvaluator::exec_space;
             ddc::parallel_for_each(
                     ExecSpace(),
-                    idx_range_centre,
+                    idx_range_o_point,
                     KOKKOS_CLASS_LAMBDA(IdxRTheta idx) {
                         coord_centre_field(idx) = (*this)(ddc::coordinate(idx));
                     });
             auto coord_centre_field_host = ddc::create_mirror_view_and_copy(coord_centre_field);
-            m_o_point = coord_centre_field_host(idx_range_centre.front());
+            m_o_point = coord_centre_field_host(idx_range_o_point.front());
         }
     }
 

--- a/tests/advection/polar_foot_finder.cpp
+++ b/tests/advection/polar_foot_finder.cpp
@@ -161,16 +161,15 @@ LogicalToOtherMapping init_mapping()
     using OtherX = typename LogicalToOtherMapping::cartesian_tag_x;
     using OtherY = typename LogicalToOtherMapping::cartesian_tag_y;
     // At x0,y0 to match rotation centre
-    double x0 = 0.0;
-    double y0 = 0.0;
+    Coord<OtherX, OtherY> o_point(0.0, 0.0);
     if constexpr (std::is_same_v<
                           LogicalToOtherMapping,
                           CircularToCartesian<R, Theta, OtherX, OtherY>>) {
-        return LogicalToOtherMapping(x0, y0);
+        return LogicalToOtherMapping(o_point);
     } else if constexpr (std::is_same_v<
                                  LogicalToOtherMapping,
                                  CzarnyToCartesian<R, Theta, OtherX, OtherY>>) {
-        return LogicalToOtherMapping(0.3, 1.4, x0, y0);
+        return LogicalToOtherMapping(0.3, 1.4, o_point);
     }
 }
 

--- a/tests/coord_transformations/metric_tensor_evaluator.cpp
+++ b/tests/coord_transformations/metric_tensor_evaluator.cpp
@@ -88,8 +88,8 @@ TEST_P(InverseMetricTensor3D, InverseMatrixToroidalMap)
     using ToroidalMapping = ToroidalToCylindrical<Mapping2D, Zeta, Phi>;
     using CylindricalMapping = CylindricalToCartesian<R, Z, Zeta, X, Y>;
     using Mapping = CombinedMapping<CylindricalMapping, ToroidalMapping, Coord<Rho, Theta, Phi>>;
-    double major_radius = 6.2;
-    Mapping2D polar_to_RZ(major_radius);
+    Coord<R, Z> o_point(6.2, 0.0);
+    Mapping2D polar_to_RZ(o_point);
     ToroidalMapping toroidal_to_cylindrical(polar_to_RZ);
     CylindricalMapping cylindrical_to_cartesian;
     Mapping mapping(cylindrical_to_cartesian, toroidal_to_cylindrical);

--- a/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_all_tests.cpp
@@ -328,11 +328,13 @@ int main(int argc, char** argv)
 
     // SET THE DIFFERENT PARAMETERS OF THE TESTS ------------------------------------------------
     // Offset the centre of the circle to ensure that this is correctly handled
-    CircularToCartMapping const from_circ_map(6.2, 0.8);
-    CircularToPseudoCartMapping const to_pseudo_circ_map(6.2, 0.8);
-    CartesianToCircular<X, Y, R, Theta> to_circ_map(6.2, 0.8);
-    CzarnyToCartMapping const from_czarny_map(0.3, 1.4, 6.2, 0.8);
-    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4, 6.2, 0.8);
+    Coord<X, Y> o_point(6.2, 0.8);
+    CircularToCartMapping const from_circ_map(o_point);
+    Coord<X_pC, Y_pC> o_point_pc(6.2, 0.8);
+    CircularToPseudoCartMapping const to_pseudo_circ_map(o_point_pc);
+    CartesianToCircular<X, Y, R, Theta> to_circ_map(o_point);
+    CzarnyToCartMapping const from_czarny_map(0.3, 1.4, o_point);
+    CartesianToCzarny<X, Y, R, Theta> const to_czarny_map(0.3, 1.4, o_point);
     DiscreteMappingBuilderHost const discrete_czarny_map_builder_host(
             Kokkos::DefaultHostExecutionSpace(),
             from_czarny_map,

--- a/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
+++ b/tests/geometryRTheta/advection_rtheta/advection_simulation_utils.hpp
@@ -186,7 +186,7 @@ host_t<FieldMemRTheta<CoordRTheta>> compute_exact_feet_rtheta(
                   DiscreteToCartesian<X, Y, SplineRThetaEvaluatorConstBound_host>>);
 
     host_t<FieldMemRTheta<CoordRTheta>> feet_coords_rtheta(idx_range_rtheta);
-    CoordXY const coord_xy_centre = CoordXY(logical_to_physical_mapping(CoordRTheta(0, 0)));
+    CoordXY const coord_xy_centre = CoordXY(logical_to_physical_mapping.o_point());
     ddc::for_each(idx_range_rtheta, [&](IdxRTheta const irtheta) {
         CoordRTheta const coord_rtheta = ddc::coordinate(irtheta);
         CoordXY const coord_xy

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -106,10 +106,11 @@ int main(int argc, char** argv)
 
     double major_radius = 6.1;
     double vertical_offset = 0.3;
+    Coord<X, Y> o_point(major_radius, vertical_offset);
 #if defined(CIRCULAR_MAPPING)
-    const Mapping mapping(major_radius, vertical_offset);
+    const Mapping mapping(o_point);
 #elif defined(CZARNY_MAPPING)
-    const Mapping mapping(0.3, 1.4, major_radius, vertical_offset);
+    const Mapping mapping(0.3, 1.4, o_point);
 #endif
 
     ddc::NullExtrapolationRule bv_r_min;

--- a/tests/math_tools/test_poisson_bracket.cpp
+++ b/tests/math_tools/test_poisson_bracket.cpp
@@ -29,8 +29,8 @@ void compute_and_test_Lie_Poisson_Bracket()
     using Mapping2D = CircularToCartesian<Rho, Theta, R, Z>;
     using ToroidalMapping = ToroidalToCylindrical<Mapping2D, Zeta, Phi>;
     using CylindricalMapping = CylindricalToCartesian<R, Z, Zeta, X, Y>;
-    double major_radius(6.2);
-    Mapping2D polar_to_RZ(major_radius);
+    Coord<R, Z> o_point(6.2, 0.0);
+    Mapping2D polar_to_RZ(o_point);
     ToroidalMapping toroidal_to_cylindrical(polar_to_RZ);
     CylindricalMapping cylindrical_to_cartesian;
     CombinedMapping<CylindricalMapping, ToroidalMapping, Coord<Rho, Theta, Phi>>


### PR DESCRIPTION
Add a `o_point` method to curvilinear mappings to help locate the singularity regardless of the CPU/GPU accessibility of the class. The O-point is a coordinate and should therefore be statically typed. The constructor arguments are updated to reflect this.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
