### PR TITLE
Fix Ruche modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
+  
 ### Changed
 
 ### Deprecated
-
-## [v0.2.0] - 2025-07-16
-
-### Fixed
-
-- Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
 
 ## [v0.2.0] - 2025-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
+- Modify `ruche.v100/environment.sh` file to fix tokamaxi simulation segfault issues.
   
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [v0.2.0] - 2025-07-16
+
+### Fixed
+
+-Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
+
 ## [v0.2.0] - 2025-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
+- Modify ruche.v100/environment.sh file to fix tokamaxi simulation segfault issues.
 
 ## [v0.2.0] - 2025-07-03
 

--- a/toolchains/v100.ruche/environment.sh
+++ b/toolchains/v100.ruche/environment.sh
@@ -9,8 +9,7 @@ module load \
     paraconf/1.0.0/gcc-11.2.0 \
     fftw/3.3.10/gcc-11.2.0-openmpi \
     ginkgo/1.8.0/gcc-11.2.0 \
-    openblas/0.3.8/gcc-9.2.0 \
-    spack/0.21.1/gcc-11.2.0
+    openblas/0.3.8/gcc-9.2.0
 
 # additional module for tests and simulations
 module load \
@@ -18,3 +17,6 @@ module load \
     pdiplugin-set-value/1.6.0/gcc-11.2.0 \
     pdiplugin-trace/1.6.0/gcc-11.2.0 \
     python/3.9.10/gcc-11.2.0
+
+module swap openmpi/4.1.1/gcc-11.2.0 openmpi/4.1.1/gcc-11.2.0-cuda
+module swap cuda/11.5.0/gcc-11.2.0 cuda/12.2.1/gcc-11.2.0


### PR DESCRIPTION
The aim of this PR is to fix an environment issue encountered during Gysela-X tokamaxi simulations on Ruche. Indeed, running with more than one mpi process was leading to a segmentation fault because the version of MPI that was used was not GPU aware.
The swap command is used to ensure that the correct version of cuda and openmpi-cuda are used, and to avoid relying on automatically loaded versions of these modules.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

