### PR TITLE
Change interface of `EdgeTransformation::search_for_match` to fix uninitialised warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change interface of `EdgeTransformation::search_for_match` to return an `out_of_bounds_idx` instead of a boolean.
+
 ### Deprecated
 
 ## [v0.2.0] - 2025-07-03

--- a/src/multipatch/connectivity/edge_transformation.hpp
+++ b/src/multipatch/connectivity/edge_transformation.hpp
@@ -227,18 +227,17 @@ public:
      * can use a dichotomy method. 
      * 
      * @warning target_idx is always replaced by the suspected index. 
-     * If there is not equivalent index, the returned index is wrong but the 
-     * closest that the algorithm found. 
+     * If there is not equivalent index, the returned index is out_of_bounds_idx.
      * 
-     * @tparam CurrentGrid The grid where the input index is defined. 
      * @tparam TargetGrid The grid where the output index is defined.
-
-     * @param[out] target_idx
-     *      A index on the edge of the target patch.
+     * @tparam CurrentGrid The grid where the input index is defined.
+     *                     This template parameter can be deduced from the function call.
+     *
      * @param[in] current_idx
      *      A index on the edge of the current patch.
-     * @tparam CurrentIdx 
-     *      The current index type of the given coordinate index. 
+     *
+     * @returns target_idx
+     *      A index on the edge of the target patch.
      * 
      * @return Boolean stating if there is an equivalent index. 
      * 

--- a/src/multipatch/connectivity/edge_transformation.hpp
+++ b/src/multipatch/connectivity/edge_transformation.hpp
@@ -11,6 +11,8 @@
 #include "edge.hpp"
 #include "interface.hpp"
 
+template <class TargetGrid>
+static constexpr Idx<TargetGrid> out_of_bounds_idx = Idx<TargetGrid>(std::string::npos);
 
 /**
  * @brief Transform a coordinate or an index from one edge to the one on the other edge.
@@ -179,7 +181,7 @@ public:
         using TargetGrid = std::
                 conditional_t<std::is_same_v<CurrentIdx, Idx<EdgeGrid1>>, EdgeGrid2, EdgeGrid1>;
         Idx<TargetGrid> target_idx = search_for_match<TargetGrid>(current_idx);
-        assert(target_idx != Idx<TargetGrid>(std::string::npos));
+        assert(target_idx != out_of_bounds_idx<TargetGrid>);
         return target_idx;
     }
 
@@ -209,7 +211,7 @@ public:
         using TargetGrid = std::
                 conditional_t<std::is_same_v<CurrentIdx, Idx<EdgeGrid1>>, EdgeGrid2, EdgeGrid1>;
         Idx<TargetGrid> target_idx = search_for_match<TargetGrid>(current_idx);
-        return search_for_match<TargetGrid>(current_idx) != Idx<TargetGrid>(std::string::npos);
+        return search_for_match<TargetGrid>(current_idx) != out_of_bounds_idx<TargetGrid>;
     }
 
 
@@ -354,7 +356,7 @@ public:
             }
         }
 
-        return Idx<TargetGrid>(std::string::npos);
+        return out_of_bounds_idx<TargetGrid>;
     }
 
 

--- a/src/multipatch/connectivity/matching_idx_slice.hpp
+++ b/src/multipatch/connectivity/matching_idx_slice.hpp
@@ -172,9 +172,9 @@ private:
             std::vector<Idx<EdgeGrid2>>& conforming_idx_vec_2)
     {
         EdgeTransformation<Interface> edge_transformation(m_idx_range_edge_1, m_idx_range_edge_2);
-        Idx<EdgeGrid2> idx_2;
         ddc::for_each(m_idx_range_edge_1, [&](Idx<EdgeGrid1> const& idx_1) {
-            if (edge_transformation.search_for_match(idx_2, idx_1)) {
+            Idx<EdgeGrid2> idx_2 = edge_transformation.template search_for_match<EdgeGrid2>(idx_1);
+            if (idx_2 != out_of_bounds_idx<EdgeGrid2>) {
                 conforming_idx_vec_1.push_back(idx_1);
                 conforming_idx_vec_2.push_back(idx_2);
             }


### PR DESCRIPTION
Change interface of `EdgeTransformation::search_for_match` to return an `out_of_bounds_idx` instead of a boolean. This fixes the warnings about uninitialised values.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
