### PR TITLE
Improve matrix handling for polar poisson solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove non-parallelisable loop in `PolarSplineFEMPoissonLikeSolver::init_nnz_per_line`.
 - Remove use of `std::cyl_bessel_j` which is not available in libc++.
 - Fix `mi250.hipcc.adastra.spack` toolchain.
+- Fix uninitialised values being used as an initial guess for the result of the matrix equation in `PolarSplineFEMPoissonLikeSolver`.
 
 ### Changed
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change template parameters of `PolarSplineEvaluator` to add execution and memory space information.
 - Allow `get_idx_range` to be called from a GPU execution space.
 - Uniformise toolchains.
+- Allow batch CSR convergence parameters to be specified in the constructor of `PolarSplineFEMPoissonLikeSolver`.
 
 ### Deprecated
 

--- a/src/matrix_tools/matrix_batch_csr.hpp
+++ b/src/matrix_tools/matrix_batch_csr.hpp
@@ -62,7 +62,7 @@ private:
     int m_max_iter;
     double m_tol;
     bool m_with_logger;
-    unsigned int m_preconditionner_max_block_size; // Maximum size of Jacobi-block preconditionner
+    unsigned int m_preconditioner_max_block_size; // Maximum size of Jacobi-block preconditioner
 
 public:
     /**
@@ -75,7 +75,7 @@ public:
      * @param[in] res_tol residual tolerance parameter, to ensure convergence. Be careful! the relative residual 
      * provided here, will be used as "implicit residual" in ginkgo solver.
      * @param[in] logger boolean parameter for saving log information such residual and interactions count.
-     * @param[in] preconditionner_max_block_size An optional parameter used to define the maximum size of a block
+     * @param[in] preconditioner_max_block_size An optional parameter used to define the maximum size of a block
      */
     explicit MatrixBatchCsr(
             const int batch_size,
@@ -84,13 +84,13 @@ public:
             std::optional<int> max_iter = std::nullopt,
             std::optional<double> res_tol = std::nullopt,
             std::optional<bool> logger = std::nullopt,
-            std::optional<int> preconditionner_max_block_size = 1u)
+            std::optional<int> preconditioner_max_block_size = std::nullopt)
         : MatrixBatch<ExecSpace>(batch_size, mat_size)
         , m_max_iter(max_iter.value_or(1000))
         , m_tol(res_tol.value_or(1e-15))
         , m_with_logger(logger.value_or(false))
-        , m_preconditionner_max_block_size(preconditionner_max_block_size.value_or(
-                  default_preconditionner_max_block_size<ExecSpace>()))
+        , m_preconditioner_max_block_size(preconditioner_max_block_size.value_or(
+                  default_preconditioner_max_block_size<ExecSpace>()))
     {
         std::shared_ptr const gko_exec = gko::ext::kokkos::create_executor(ExecSpace());
         m_batch_matrix_csr = gko::share(
@@ -115,7 +115,7 @@ public:
      * provided here, set as relative residual, will be used as "implicit residual" in ginkgo solver.
      * Default value is set to 1e-15.
      * @param[in] logger boolean parameter to save logger information. Default value false.
-     * @param[in] preconditionner_max_block_size An optional parameter used to define the maximum size of a block
+     * @param[in] preconditioner_max_block_size An optional parameter used to define the maximum size of a block
      */
     explicit MatrixBatchCsr(
             Kokkos::View<double**, Kokkos::LayoutRight, ExecSpace> batch_values,
@@ -124,13 +124,13 @@ public:
             std::optional<int> max_iter = std::nullopt,
             std::optional<double> res_tol = std::nullopt,
             std::optional<bool> logger = std::nullopt,
-            std::optional<int> preconditionner_max_block_size = 1u)
+            std::optional<int> preconditioner_max_block_size = 1u)
         : MatrixBatch<ExecSpace>(batch_values.extent(0), nnz_per_row.size() - 1)
         , m_max_iter(max_iter.value_or(1000))
         , m_tol(res_tol.value_or(1e-15))
         , m_with_logger(logger.value_or(false))
-        , m_preconditionner_max_block_size(preconditionner_max_block_size.value_or(
-                  default_preconditionner_max_block_size<ExecSpace>()))
+        , m_preconditioner_max_block_size(preconditioner_max_block_size.value_or(
+                  default_preconditioner_max_block_size<ExecSpace>()))
     {
         std::shared_ptr const gko_exec = gko::ext::kokkos::create_executor(ExecSpace());
         m_batch_matrix_csr = gko::share(
@@ -206,7 +206,7 @@ public:
 
             std::shared_ptr const preconditioner
                     = gko::preconditioner::Jacobi<double>::build()
-                              .with_max_block_size(m_preconditionner_max_block_size)
+                              .with_max_block_size(m_preconditioner_max_block_size)
                               .on(gko_exec);
 
             std::unique_ptr const solver_factory
@@ -224,7 +224,7 @@ public:
             // Create the solver factory
             std::shared_ptr const preconditioner
                     = gko::batch::preconditioner::Jacobi<double, int>::build()
-                              .with_max_block_size(m_preconditionner_max_block_size)
+                              .with_max_block_size(m_preconditioner_max_block_size)
                               .on(gko_exec);
 
             std::shared_ptr solver_factory = solver_type::build()

--- a/src/matrix_tools/matrix_batch_csr.hpp
+++ b/src/matrix_tools/matrix_batch_csr.hpp
@@ -124,7 +124,7 @@ public:
             std::optional<int> max_iter = std::nullopt,
             std::optional<double> res_tol = std::nullopt,
             std::optional<bool> logger = std::nullopt,
-            std::optional<int> preconditioner_max_block_size = 1u)
+            std::optional<int> preconditioner_max_block_size = std::nullopt)
         : MatrixBatch<ExecSpace>(batch_values.extent(0), nnz_per_row.size() - 1)
         , m_max_iter(max_iter.value_or(1000))
         , m_tol(res_tol.value_or(1e-15))

--- a/src/matrix_tools/matrix_utils.hpp
+++ b/src/matrix_tools/matrix_utils.hpp
@@ -228,7 +228,7 @@ void save_logger(
 }
 
 template <class ExecSpace>
-unsigned int default_preconditionner_max_block_size() noexcept
+unsigned int default_preconditioner_max_block_size() noexcept
 {
 #ifdef KOKKOS_ENABLE_SERIAL
     if (std::is_same_v<ExecSpace, Kokkos::Serial>) {

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -957,7 +957,6 @@ public:
         Kokkos::deep_copy(b, b_host);
         Kokkos::Profiling::popRegion();
 
-        Kokkos::deep_copy(m_x_init, x_init_host);
         // Solve the matrix equation
         Kokkos::Profiling::pushRegion("PolarPoissonSolve");
         m_gko_matrix->solve(m_x_init, b);


### PR DESCRIPTION
Add the batch CSR convergence parameters to the constructor of the polar poisson solver so they can be modified in different ways for different simulations. Remove the line `Kokkos::deep_copy(m_x_init, x_init_host);` which prevents the previous solution being used as an initial guess for the convergence.
Fix typo `preconditionner`->`preconditioner`.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [x] Have you checked that existing tests cover all code after the changes ?
- [x] Have you checked that existing tests are still passing ?
- [x] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
