### PR TITLE
Simplify polar bspline usage

### DIFF
--- a/src/interpolation/polar_splines/polar_bsplines.hpp
+++ b/src/interpolation/polar_splines/polar_bsplines.hpp
@@ -696,7 +696,6 @@ KOKKOS_FUNCTION Idx<BSplinesR, BSplinesTheta> PolarBSplines<BSplinesR, BSplinesT
     Idx<BSplinesR> first_tensor_product_radial_spline(C + 1);
 
     if (jmin_r < first_tensor_product_radial_spline) {
-        jmin_r = first_tensor_product_radial_spline;
         nr_done = first_tensor_product_radial_spline - jmin_r;
         for (discrete_element_type k : singular_idx_range<DDim>()) {
             singular_values(k - discrete_element_type(0)) = 0.0;
@@ -708,6 +707,7 @@ KOKKOS_FUNCTION Idx<BSplinesR, BSplinesTheta> PolarBSplines<BSplinesR, BSplinesT
                 }
             }
         }
+        jmin_r = first_tensor_product_radial_spline;
     } else {
         for (std::size_t k(0); k < n_singular_basis(); ++k) {
             singular_values(k) = 0.0;

--- a/src/interpolation/polar_splines/polar_bsplines.hpp
+++ b/src/interpolation/polar_splines/polar_bsplines.hpp
@@ -696,6 +696,7 @@ KOKKOS_FUNCTION Idx<BSplinesR, BSplinesTheta> PolarBSplines<BSplinesR, BSplinesT
     Idx<BSplinesR> first_tensor_product_radial_spline(C + 1);
 
     if (jmin_r < first_tensor_product_radial_spline) {
+        jmin_r = first_tensor_product_radial_spline;
         nr_done = first_tensor_product_radial_spline - jmin_r;
         for (discrete_element_type k : singular_idx_range<DDim>()) {
             singular_values(k - discrete_element_type(0)) = 0.0;

--- a/src/interpolation/polar_splines/polar_spline_evaluator.hpp
+++ b/src/interpolation/polar_splines/polar_spline_evaluator.hpp
@@ -465,13 +465,8 @@ private:
         for (std::size_t i = 0; i < PolarBSplinesType::n_singular_basis(); ++i) {
             y += spline_coef(Idx<PolarBSplinesType>(i)) * singular_vals(i);
         }
-        Idx<BSplinesR> jmin_r = ddc::select<BSplinesR>(jmin);
-        Idx<BSplinesTheta> jmin_theta = ddc::select<BSplinesTheta>(jmin);
-        int nr = BSplinesR::degree() + 1;
-        if (jmin_r < Idx<BSplinesR>(continuity + 1)) {
-            nr = nr - (Idx<BSplinesR>(continuity + 1) - jmin_r);
-            jmin_r = Idx<BSplinesR>(continuity + 1);
-        }
+        Idx<BSplinesR> jmin_r(jmin);
+        Idx<BSplinesTheta> jmin_theta(jmin);
 
         DConstField<IdxRange<BSplinesR, BSplinesTheta>, MemorySpace> spline_coef_2d
                 = PolarBSplinesType::get_tensor_product_subset(spline_coef);
@@ -479,7 +474,7 @@ private:
         IdxRange<BSplinesTheta> tensor_prod_idx_range_theta(tensor_prod_idx_range);
         Idx<BSplinesTheta> idx_theta_max = tensor_prod_idx_range_theta.back();
         IdxStep<BSplinesTheta> n_idx_theta = tensor_prod_idx_range_theta.extents();
-        for (int i = 0; i < nr; ++i) {
+        for (int i = 0; i < BSplinesR::degree() + 1; ++i) {
             for (std::size_t j = 0; j < BSplinesTheta::degree() + 1; ++j) {
                 Idx<BSplinesTheta> idx_theta = jmin_theta + j;
                 if (idx_theta > idx_theta_max) {


### PR DESCRIPTION
Evaluating polar bsplines involves 2 arrays to handle the singular bsplines and the tensor product bsplines. The method `eval_basis` returns an `Idx<BSplinesR, BSplinesTheta>` which identifies the smallest non-zero bsplines. However on devel this element can be a tensor bspline which doesn't exist in the polar bspline basis. As a result when calling `eval_basis` a small adjustment was required to ensure that fileds were not evaluated outside their domain. This PR fixes this logic issue. This simplifies the work on the polar Poisson solver.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
