### PR TITLE
Clean up `bsl_predcorr_second_order_explicit.hpp` in geometryRTheta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow batch CSR convergence parameters to be specified in the constructor of `PolarSplineFEMPoissonLikeSolver`.
 - Change the internals of `PolarSplineFEMPoissonLikeSolver` to precalculate fewer values.
 - Change the internals of `PolarSplineFEMPoissonLikeSolver` to avoid calls to DDC's internals.
+- Clean up code in `BslExplicitPredCorrRTheta::operator()`.
 
 ### Deprecated
 

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -189,6 +189,8 @@ public:
 
         AdvectionFieldFinder advection_field_computer(m_logical_to_physical);
 
+        PoissonLikeRHSFunction const
+                charge_density_coord(get_const_field(density_coef), m_evaluator);
 
 
         // --- Parameter for linearisation of advection field: --------------------------------------------
@@ -198,9 +200,7 @@ public:
             // STEP 1: From rho^n, we compute phi^n: Poisson equation
             host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
             m_builder(get_field(density_coef), get_const_field(density_host));
-            PoissonLikeRHSFunction const
-                    charge_density_coord_1(get_const_field(density_coef), m_evaluator);
-            m_poisson_solver(charge_density_coord_1, get_field(electrostatic_potential_coef));
+            m_poisson_solver(charge_density_coord, get_field(electrostatic_potential_coef));
 
             polar_spline_evaluator(
                     get_field(electrical_potential_host),
@@ -236,9 +236,7 @@ public:
                     = ddc::create_mirror_view_and_copy(get_field(density_predicted));
             // STEP 4: From rho^P, we compute phi^P: Poisson equation
             m_builder(get_field(density_coef), get_const_field(density_predicted_host));
-            PoissonLikeRHSFunction const
-                    charge_density_coord_4(get_const_field(density_coef), m_evaluator);
-            m_poisson_solver(charge_density_coord_4, get_field(electrostatic_potential_coef));
+            m_poisson_solver(charge_density_coord, get_field(electrostatic_potential_coef));
 
             // STEP 5: From phi^P, we compute A^P:
             advection_field_computer(
@@ -295,8 +293,6 @@ public:
         // STEP 1: From rho^n, we compute phi^n: Poisson equation
         host_t<Spline2DMem> density_coef(get_spline_idx_range(m_builder));
         m_builder(get_field(density_coef), get_const_field(density_host));
-        PoissonLikeRHSFunction const
-                charge_density_coord(get_const_field(density_coef), m_evaluator);
         m_poisson_solver(charge_density_coord, get_field(electrical_potential));
         ddc::parallel_deepcopy(electrical_potential_host, electrical_potential);
         ddc::PdiEvent("last_iteration")

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -186,8 +186,9 @@ public:
         // --- For the computation of advection field from the electrostatic potential (phi): -------------
         host_t<DVectorFieldMemRTheta<X, Y>> advection_field_alloc_host(grid);
         host_t<DVectorFieldMemRTheta<X, Y>> advection_field_predicted_alloc_host(grid);
-        auto advection_field_alloc = ddcHelper::
-                create_mirror_view(Kokkos::DefaultExecutionSpace(), advection_field_host);
+        auto advection_field_alloc = ddcHelper::create_mirror_view_and_copy(
+                Kokkos::DefaultExecutionSpace(),
+                get_field(advection_field_alloc_host));
 
         // Create fields
         host_t<DVectorFieldRTheta<X, Y>> advection_field_host(advection_field_alloc_host);
@@ -240,7 +241,7 @@ public:
             // STEP 3: From rho^n and A^n, we compute rho^P: Vlasov equation
             // --- Copy rho^n because it will be modified:
             ddc::parallel_deepcopy(get_field(density_predicted_alloc), density_host);
-            ddc::parallel_deepcopy(advection_field, advection_field_host);
+            ddcHelper::deepcopy(advection_field, advection_field_host);
             m_advection_solver(get_field(density_predicted_alloc), advection_field, dt);
 
             // --- advect also the feet because it is needed for the next step

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -181,13 +181,9 @@ public:
                 polar_spline_evaluator(extrapolation_rule);
 
         // --- For the computation of advection field from the electrostatic potential (phi): -------------
-        host_t<DVectorFieldMemRTheta<X, Y>> electric_field_alloc(grid);
-        host_t<DVectorFieldMemRTheta<X, Y>> electric_field_predicted_alloc(grid);
         host_t<DVectorFieldMemRTheta<X, Y>> advection_field_alloc(grid);
         host_t<DVectorFieldMemRTheta<X, Y>> advection_field_predicted_alloc(grid);
 
-        host_t<DVectorFieldRTheta<X, Y>> electric_field(electric_field_alloc);
-        host_t<DVectorFieldRTheta<X, Y>> electric_field_predicted(electric_field_predicted_alloc);
         host_t<DVectorFieldRTheta<X, Y>> advection_field_host(advection_field_alloc);
         host_t<DVectorFieldRTheta<X, Y>> advection_field_predicted(advection_field_predicted_alloc);
 

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -210,7 +210,7 @@ public:
         AdvectionFieldFinder advection_field_computer(m_logical_to_physical);
 
         PoissonLikeRHSFunction const
-                charge_density_coord(get_const_field(density_coef_alloc_host), m_evaluator);
+                charge_density(get_const_field(density_coef_alloc_host), m_evaluator);
 
 
         // --- Parameter for linearisation of advection field: --------------------------------------------
@@ -219,9 +219,7 @@ public:
             double const time = iter * dt;
             // STEP 1: From rho^n, we compute phi^n: Poisson equation
             m_builder(get_field(density_coef_alloc_host), get_const_field(density_host));
-            m_poisson_solver(
-                    charge_density_coord,
-                    get_field(electrostatic_potential_coef_alloc_host));
+            m_poisson_solver(charge_density, get_field(electrostatic_potential_coef_alloc_host));
 
             polar_spline_evaluator(
                     get_field(electrical_potential_host),
@@ -253,9 +251,7 @@ public:
             ddc::parallel_deepcopy(density_predicted_host, get_field(density_predicted_alloc));
             // STEP 4: From rho^P, we compute phi^P: Poisson equation
             m_builder(get_field(density_coef_alloc_host), get_const_field(density_predicted_host));
-            m_poisson_solver(
-                    charge_density_coord,
-                    get_field(electrostatic_potential_coef_alloc_host));
+            m_poisson_solver(charge_density, get_field(electrostatic_potential_coef_alloc_host));
 
             // STEP 5: From phi^P, we compute A^P:
             advection_field_computer(
@@ -299,7 +295,7 @@ public:
 
         // STEP 1: From rho^n, we compute phi^n: Poisson equation
         m_builder(get_field(density_coef_alloc_host), get_const_field(density_host));
-        m_poisson_solver(charge_density_coord, get_field(electrical_potential));
+        m_poisson_solver(charge_density, get_field(electrical_potential));
         ddc::parallel_deepcopy(electrical_potential_host, electrical_potential);
         ddc::PdiEvent("last_iteration")
                 .with("iter", steps)

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -271,22 +271,15 @@ public:
 
             // STEP 6: From rho^n and (A^n(X^P) + A^P(X^n))/2, we compute rho^{n+1}: Vlasov equation
             ddc::for_each(grid, [&](IdxRTheta const irtheta) {
-                ddcHelper::get<X>(advection_field_host)(irtheta)
-                        = (ddcHelper::get<X>(advection_field_evaluated_alloc_host)(irtheta)
-                           + ddcHelper::get<X>(advection_field_predicted_host)(irtheta))
-                          / 2.;
-                ddcHelper::get<Y>(advection_field_host)(irtheta)
-                        = (ddcHelper::get<Y>(advection_field_evaluated_alloc_host)(irtheta)
-                           + ddcHelper::get<Y>(advection_field_predicted_host)(irtheta))
-                          / 2.;
+                ddcHelper::assign_vector_field_element(
+                        advection_field_host,
+                        irtheta,
+                        (advection_field_evaluated_alloc_host(irtheta)
+                         + advection_field_predicted_host(irtheta))
+                                / 2.);
             });
 
-            ddc::parallel_deepcopy(
-                    ddcHelper::get<X>(advection_field),
-                    ddcHelper::get<X>(advection_field_host));
-            ddc::parallel_deepcopy(
-                    ddcHelper::get<Y>(advection_field),
-                    ddcHelper::get<Y>(advection_field_host));
+            ddcHelper::deepcopy(advection_field, advection_field_host);
             auto density = ddc::
                     create_mirror_view_and_copy(Kokkos::DefaultExecutionSpace(), density_host);
             m_advection_solver(get_field(density), get_const_field(advection_field), dt);


### PR DESCRIPTION
Clean up bsl_predcorr.hpp in geometryRTheta ready for https://github.com/gyselax/gyselalibxx/pull/392 .
Improvements:
- Data allocations are now grouped to avoid reallocating data unnecessarily
- Data allocations have the suffix documented in the Coding standards (_alloc)
- Host variables have the suffix _host
- assign_vector_field_element is used to ensure equations will be simplified after https://github.com/gyselax/gyselalibxx/issues/322
- Unused variables are removed

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
