### PR TITLE
Fix bad copies in r,theta simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix uninitialised values being used as an initial guess for the result of the matrix equation in `PolarSplineFEMPoissonLikeSolver`.
 - Fix missing grids when calling `collect_grids_on_dim_t`.
 - Fix `is_borrowed_deriv_field_v<>` in `derivative_field_common.hpp` file.
+- Fix `phi_eq` in diocotron and vortex-merger simulations.
 
 ### Changed
 

--- a/simulations/geometryRTheta/diocotron/diocotron.cpp
+++ b/simulations/geometryRTheta/diocotron/diocotron.cpp
@@ -296,7 +296,7 @@ int main(int argc, char** argv)
     builder_host(get_field(rho_coef_eq), get_const_field(rho_eq));
     PoissonLikeRHSFunction poisson_rhs_eq(get_const_field(rho_coef_eq), spline_evaluator_host);
     poisson_solver(poisson_rhs_eq, get_field(phi_eq));
-    ddc::parallel_deepcopy(phi_eq, phi_eq_host);
+    ddc::parallel_deepcopy(phi_eq_host, phi_eq);
 
     // --- Save initial data --------------------------------------------------------------------------
     ddc::PdiEvent("initialisation")

--- a/simulations/geometryRTheta/vortex_merger/vortex_merger.cpp
+++ b/simulations/geometryRTheta/vortex_merger/vortex_merger.cpp
@@ -274,7 +274,7 @@ int main(int argc, char** argv)
     builder_host(get_field(rho_coef_eq), get_const_field(rho_eq));
     PoissonLikeRHSFunction poisson_rhs_eq(get_const_field(rho_coef_eq), spline_evaluator_host);
     poisson_solver(poisson_rhs_eq, get_field(phi_eq));
-    ddc::parallel_deepcopy(phi_eq, phi_eq_host);
+    ddc::parallel_deepcopy(phi_eq_host, phi_eq);
 
 
     // --- Save initial data --------------------------------------------------------------------------


### PR DESCRIPTION
Copies of `phi_eq` in r,theta simulations (diocotron and vortex_merger) are coded incorrectly. They copy CPU to GPU instead of the inverse.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
