### PR TITLE
Update .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -14,7 +14,9 @@ extend-ignore-re = ["capitalize()",
                     "unrecognized_links",
                     "Gif-sur-Yvette",
                     "GYSELALIBXX_HOME",
-                    "compute-sanitizer"
+                    "compute-sanitizer",
+                    "MINIMIZE",
+                    "minimize_tol"
                     ]
 extend-ignore-identifiers-re = [
     "Comput. Phys. Commun.",

--- a/.typos.toml
+++ b/.typos.toml
@@ -15,7 +15,6 @@ extend-ignore-re = ["capitalize()",
                     "Gif-sur-Yvette",
                     "GYSELALIBXX_HOME",
                     "compute-sanitizer",
-                    "MINIMIZE",
                     "minimize_tol"
                     ]
 extend-ignore-identifiers-re = [


### PR DESCRIPTION
These changes are necessary to pass the CI tests in GYSELAX++.

Note currently .typos.toml in GYSELAX++ uses a copy of GYSELAlib++. For the future, copying might not be the best choice?
