### PR TITLE
Use full rocm 6.3.3 stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change constructor argument of `PoissonLikeRHSFunction` from the (r, theta) geometry to pass spline coefficients on GPU.
 - Use Spack to install the Kokkos ecosystem in the MI250 Adastra toolchain.
 - Use Spack to install the Kokkos ecosystem in the GENOA Adastra toolchain.
+- Use a single rocm stack on Adastra.
 
 ### Deprecated
 

--- a/toolchains/mi250.hipcc.adastra.spack/environment.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/environment.sh
@@ -61,25 +61,8 @@ eval -- "$(
         py-pyyaml
 )"
 
-# Due to https://github.com/gyselax/gyselalibxx/pull/198#issuecomment-2943081411
-# we use a different HIP compiler to build dependencies and to build gyselalib. 
-# It is fine except we must unset some environment variables defined by spack's 
-# HIP packages so they do not interfere with HIPCC/clang in the 6.3.3 version.
-# Notably:
-unset ROCM_PATH                  # /opt/rocm-6.1.2
-unset HIP_CLANG_PATH             # /opt/rocm-6.1.2/llvm/bin
-unset HSA_PATH                   # /opt/rocm-6.1.2
-unset ROCMINFO_PATH              # /opt/rocm-6.1.2
-unset DEVICE_LIB_PATH            # /opt/rocm-6.1.2/amdgcn/bitcode
-unset HIP_DEVICE_LIB_PATH        # /opt/rocm-6.1.2/amdgcn/bitcode
-unset LLVM_PATH                  # /opt/rocm-6.1.2/llvm
-unset COMGR_PATH                 # /opt/rocm-6.1.2
-unset HIPCC_COMPILE_FLAGS_APPEND # --rocm-path=/opt/rocm-6.1.2 --gcc-toolchain=/opt/rh/gcc-toolset-13/root/usr --rocm-path=/opt/rocm-6.1.2 --gcc-toolchain=/opt/rh/gcc-toolset-13/root/usr
-unset HIPFLAGS                   # --gcc-toolchain=/opt/rh/gcc-toolset-13/root/usr --gcc-toolchain=/opt/rh/gcc-toolset-13/root/usr
-
 module load cpe/24.07
 module load craype-x86-trento craype-accel-amd-gfx90a
-# NOTE: Force 6.3.3 due to startup failures (https://github.com/gyselax/gyselalibxx/pull/198#issuecomment-2943081411)
 module load PrgEnv-gnu-amd amd-mixed/6.3.3
 
 module list

--- a/toolchains/mi250.hipcc.adastra.spack/packages.yaml
+++ b/toolchains/mi250.hipcc.adastra.spack/packages.yaml
@@ -1,0 +1,255 @@
+---
+packages:
+  all:
+    compiler: [gcc@13.2.1.mi250]
+    target: [zen3]
+    permissions:
+      write: group
+    providers:
+      mpi: [cray-mpich]
+      blas: [cray-libsci, openblas]
+      lapack: [cray-libsci, openblas]
+      blacs: [cray-libsci]
+      scalapack: [cray-libsci]
+      netlib-scalapack: [cray-libsci]
+      mkl: [cray-libsci]
+      fftw: [cray-fftw]
+      opencl: [rocm-opencl@6.3.3]
+      opencl-runtime: [rocm-opencl-runtime@6.3.3]
+    require:
+      - one_of: [amdgpu_target=gfx90a, amdgpu_target=gfx942]
+        when: +rocm
+      - spec: +rocm amdgpu_target=gfx90a ^cray-mpich+rocm amdgpu_target=gfx90a
+        when: +rocm amdgpu_target=gfx90a ^cray-mpich
+      - spec: +rocm amdgpu_target=gfx942 ^cray-mpich+rocm amdgpu_target=gfx942
+        when: +rocm amdgpu_target=gfx942 ^cray-mpich
+  cray-mpich:
+    buildable: false
+    version: [8.1.30]
+    externals:
+      - spec: cray-mpich@8.1.30
+        modules:
+          - cray-mpich/8.1.30
+  cray-libsci:
+    buildable: false
+    version: [23.12.5, 24.07.0]
+    externals:
+      - spec: cray-libsci@23.12.5
+        modules:
+          - cray-libsci/23.12.5
+      - spec: cray-libsci@24.07.0
+        modules:
+          - cray-libsci/24.07.0
+  hip:
+    buildable: false
+    externals:
+      - extra_attributes:
+          compilers:
+            c: /opt/rocm-6.3.3/llvm/bin/clang++
+            c++: /opt/rocm-6.3.3/llvm/bin/clang++
+            hip: /opt/rocm-6.3.3/bin/hipcc
+        prefix: /opt/rocm-6.3.3
+        spec: hip@6.3.3
+    version: [6.3.3]
+  hipblas:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipblas@6.3.3
+    version: [6.3.3]
+  hipcub:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipcub@6.3.3
+    version: [6.3.3]
+  hipfft:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipfft@6.3.3
+    version: [6.3.3]
+  hipfort:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipfort@6.3.3
+    version: [6.3.3]
+  hipify-clang:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipify-clang@6.3.3
+    version: [6.3.3]
+  hiprand:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hiprand@6.3.3
+    version: [6.3.3]
+  hip-rocclr:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/rocclr
+        spec: hip-rocclr@6.3.3
+    version: [6.3.3]
+  hipsolver:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipsolver@6.3.3
+    version: [6.3.3]
+  hipsparse:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hipsparse@6.3.3
+    version: [6.3.3]
+  hsa-rocr-dev:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hsa-rocr-dev@6.3.3
+        extra_attributes:
+          compilers:
+            c: /opt/rocm-6.3.3/llvm/bin/clang++
+            cxx: /opt/rocm-6.3.3/llvm/bin/clang++
+    version: [6.3.3]
+  hsakmt-roct:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: hsakmt-roct@6.3.3
+    version: [6.3.3]
+  libfabric:
+    buildable: false
+    externals:
+      - prefix: /opt/software/libfabric/1.23.1
+        spec: libfabric@1.23.1
+    version: [1.23.1]
+  llvm-amdgpu:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/llvm
+        spec: llvm-amdgpu@6.3.3
+        extra_attributes:
+          compilers:
+            c: /opt/rocm-6.3.3/llvm/bin/clang++
+            cxx: /opt/rocm-6.3.3/llvm/bin/clang++
+    version: [6.3.3]
+  miopen-hip:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: miopen-hip@6.3.3
+    version: [6.3.3]
+  python:
+    buildable: true
+    version: [3.9.13.1, 3.11.5, 3.11.7]
+    externals:
+      - spec: python@3.11.7
+        modules:
+          - cray-python/3.11.7
+      - spec: python@3.11.5
+        modules:
+          - cray-python/3.11.5
+      - spec: python@3.9.13.1
+        modules:
+          - cray-python/3.9.13.1
+  rccl:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rccl@6.3.3
+    version: [6.3.3]
+  rocalution:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocalution@6.3.3
+    version: [6.3.3]
+  rocblas:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocblas@6.3.3
+    version: [6.3.3]
+  rocfft:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocfft@6.3.3
+    variants: amdgpu_target=gfx90a amdgpu_target_sram_ecc=gfx90a
+    version: [6.3.3]
+  rocm-opencl:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/opencl
+        spec: rocm-opencl@6.3.3
+    version: [6.3.3]
+  rocm-opencl-runtime:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/opencl
+        spec: rocm-opencl-runtime@6.3.3
+    version: [6.3.3]
+  rocm-smi:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/rocm_smi
+        spec: rocm-smi@6.3.3
+    version: [6.3.3]
+  rocminfo:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocminfo@6.3.3
+    version: [6.3.3]
+  rocprim:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocprim@6.3.3
+    version: [6.3.3]
+  rocprofiler-dev:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/rocprofiler
+        spec: rocprofiler-dev@6.3.3
+    version: [6.3.3]
+  rocrand:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocrand@6.3.3
+    version: [6.3.3]
+  rocsolver:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocsolver@6.3.3
+    version: [6.3.3]
+  rocsparse:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocsparse@6.3.3
+    version: [6.3.3]
+  rocthrust:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3
+        spec: rocthrust@6.3.3
+    version: [6.3.3]
+  roctracer-dev:
+    buildable: false
+    externals:
+      - prefix: /opt/rocm-6.3.3/roctracer
+        spec: roctracer-dev@6.3.3
+    version: [6.3.3]
+  julia:
+    buildable: false
+    version: [1.10.0]
+    externals:
+      - spec: julia@1.10.0
+        prefix: /opt/software/gaia-external/CPU/julia-1-10-0/julia-1.10.0

--- a/toolchains/mi250.hipcc.adastra.spack/prepare.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/prepare.sh
@@ -24,6 +24,8 @@ module list
 which spack
 spack debug report
 
+cp "${TOOLCHAIN_ROOT_DIRECTORY}/packages.yaml" "${SPACK_USER_CONFIG_PATH}"
+
 mkdir -p -- "${SPACK_USER_CONFIG_PATH}/external-repositories"
 
 # Inject recent PDI recipes into our repository.


### PR DESCRIPTION
This PR removes the mix of rocm 6.1.2 and rocm 6.3.3 on Adastra by declaring rocm 6.3.3 packages in packages.yaml. This file has been generated from the file provided by the CINES configuration in rocm 6.1.2, some packages have been removed.

As a consequence this provides a uniform environment and simplifies the file `environment.sh`.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
