### PR TITLE
Inject Kokkos Tools lib directory to LD_LIBRARY_PATH on Adastra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use patched recipes for the CPU Spack toolchain.
+- Inject Kokkos Tools lib directory to `LD_LIBRARY_PATH` in the Adastra toolchains.
 
 ### Deprecated
 

--- a/toolchains/genoa.gcc.adastra.spack/environment.sh
+++ b/toolchains/genoa.gcc.adastra.spack/environment.sh
@@ -66,3 +66,6 @@ module load craype-x86-genoa
 module load PrgEnv-gnu
 
 module list
+
+# Add Kokkos Tools to the `LD_LIBRARY_PATH`
+export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"

--- a/toolchains/mi250.hipcc.adastra.spack/environment.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/environment.sh
@@ -84,4 +84,6 @@ module load PrgEnv-gnu-amd amd-mixed/6.3.3
 
 module list
 
+# Add Kokkos Tools to the `LD_LIBRARY_PATH`
+export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
The Spack Kokkos Tools package does not expose the `lib` directory in the `LD_LIBRARY_PATH` making it non-trivial to use Kokkos Tools. The PR fixes this, further investigation should be made on the Kokkos team side.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
