### PR TITLE
Use command -v to avoid spack warning

### DIFF
--- a/toolchains/v100.persee/environment.sh
+++ b/toolchains/v100.persee/environment.sh
@@ -7,11 +7,11 @@ then
     exit 1
 fi
 
-if [ -f "$(which spack)" ]
+if command -v spack >/dev/null 2>&1
 then
-  spack env deactivate
+    spack env deactivate
 else
-  . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
+    . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
 fi
 
 spack load gcc@12

--- a/toolchains/xeon.persee/environment.sh
+++ b/toolchains/xeon.persee/environment.sh
@@ -7,11 +7,11 @@ then
     exit 1
 fi
 
-if [ -f "$(which spack)" ]
+if command -v spack >/dev/null 2>&1
 then
-  spack env deactivate
+    spack env deactivate
 else
-  . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
+    . /data/gyselarunner/spack-0.23.0/share/spack/setup-env.sh
 fi
 
 spack load gcc@12


### PR DESCRIPTION
Use command -v to avoid spack warning on persee. The warning is printed because `which` prints an error message on persee if no executable is found.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
