### PR TITLE
Rename static variable `is_curvilinear_2d_mapping_v` -> `has_o_point_v`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use patched recipes for the CPU Spack toolchain.
 - Inject Kokkos Tools lib directory to `LD_LIBRARY_PATH` in the Adastra toolchains.
+- Rename static variable `is_curvilinear_2d_mapping_v` to the more accurate: `has_o_point_v`.
 
 ### Deprecated
 

--- a/src/coord_transformations/circular_to_cartesian.hpp
+++ b/src/coord_transformations/circular_to_cartesian.hpp
@@ -318,7 +318,7 @@ struct MappingAccessibility<ExecSpace, CircularToCartesian<R, Theta, X, Y>> : st
 };
 
 template <class X, class Y, class R, class Theta>
-struct IsCurvilinear2DMapping<CircularToCartesian<R, Theta, X, Y>> : std::true_type
+struct HasOPoint<CircularToCartesian<R, Theta, X, Y>> : std::true_type
 {
 };
 

--- a/src/coord_transformations/coord_transformation_tools.hpp
+++ b/src/coord_transformations/coord_transformation_tools.hpp
@@ -200,7 +200,7 @@ public:
 };
 
 template <class Mapping>
-struct IsCurvilinear2DMapping : std::false_type
+struct HasOPoint : std::false_type
 {
 };
 
@@ -248,8 +248,8 @@ static constexpr bool has_inv_jacobian_v
 
 /// Indicates that a coordinate change operator is 2D with a curvilinear mapping showing an O-point.
 template <class Mapping>
-static constexpr bool is_curvilinear_2d_mapping_v = mapping_detail::IsCurvilinear2DMapping<
-        std::remove_const_t<std::remove_reference_t<Mapping>>>::value;
+static constexpr bool has_o_point_v
+        = mapping_detail::HasOPoint<std::remove_const_t<std::remove_reference_t<Mapping>>>::value;
 
 template <class Mapping>
 static constexpr bool is_analytical_mapping_v = mapping_detail::IsAnalyticalMapping<Mapping>::value;

--- a/src/coord_transformations/czarny_to_cartesian.hpp
+++ b/src/coord_transformations/czarny_to_cartesian.hpp
@@ -427,7 +427,7 @@ struct MappingAccessibility<ExecSpace, CzarnyToCartesian<R, Theta, X, Y>> : std:
 };
 
 template <class X, class Y, class R, class Theta>
-struct IsCurvilinear2DMapping<CzarnyToCartesian<X, Y, R, Theta>> : std::true_type
+struct HasOPoint<CzarnyToCartesian<X, Y, R, Theta>> : std::true_type
 {
 };
 

--- a/src/coord_transformations/discrete_to_cartesian.hpp
+++ b/src/coord_transformations/discrete_to_cartesian.hpp
@@ -430,8 +430,7 @@ struct MappingAccessibility<
 };
 
 template <class X, class Y, class SplineEvaluator, class R, class Theta, class MemorySpace>
-struct IsCurvilinear2DMapping<DiscreteToCartesian<X, Y, SplineEvaluator, R, Theta, MemorySpace>>
-    : std::true_type
+struct HasOPoint<DiscreteToCartesian<X, Y, SplineEvaluator, R, Theta, MemorySpace>> : std::true_type
 {
 };
 

--- a/src/multipatch/connectivity/onion_patch_locator.hpp
+++ b/src/multipatch/connectivity/onion_patch_locator.hpp
@@ -68,7 +68,7 @@ class OnionPatchLocator<
         PhysicalToLogicalMapping,
         ExecSpace>
 {
-    static_assert(is_curvilinear_2d_mapping_v<LogicalToPhysicalMapping>);
+    static_assert(has_o_point_v<LogicalToPhysicalMapping>);
 
     using X = typename LogicalToPhysicalMapping::cartesian_tag_x;
     using Y = typename LogicalToPhysicalMapping::cartesian_tag_y;

--- a/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
@@ -669,12 +669,12 @@ private:
             using TargetMapping = typename PatchLocator::
                     template get_mapping_on_logical_dim_t<TargetDim1, TargetDim2>;
 
-            static_assert(is_curvilinear_2d_mapping_v<CurrentMapping>);
+            static_assert(has_o_point_v<CurrentMapping>);
             static_assert((std::is_same_v<
                            Coord<typename CurrentMapping::curvilinear_tag_r,
                                  typename CurrentMapping::curvilinear_tag_theta>,
                            Coord<CurrentDim1, CurrentDim2>>));
-            static_assert(is_curvilinear_2d_mapping_v<TargetMapping>);
+            static_assert(has_o_point_v<TargetMapping>);
             static_assert((std::is_same_v<
                            Coord<typename TargetMapping::curvilinear_tag_r,
                                  typename TargetMapping::curvilinear_tag_theta>,

--- a/tests/advection/r_theta_test_cases.hpp
+++ b/tests/advection/r_theta_test_cases.hpp
@@ -37,7 +37,7 @@
 template <class Mapping>
 class FunctionToBeAdvected_cos_4_ellipse
 {
-    static_assert(is_curvilinear_2d_mapping_v<Mapping>);
+    static_assert(has_o_point_v<Mapping>);
     using X = typename Mapping::cartesian_tag_x;
     using Y = typename Mapping::cartesian_tag_y;
     using R = typename Mapping::curvilinear_tag_r;
@@ -100,7 +100,7 @@ public:
 template <class Mapping>
 class FunctionToBeAdvected_gaussian
 {
-    static_assert(is_curvilinear_2d_mapping_v<Mapping>);
+    static_assert(has_o_point_v<Mapping>);
     using X = typename Mapping::cartesian_tag_x;
     using Y = typename Mapping::cartesian_tag_y;
     using R = typename Mapping::curvilinear_tag_r;

--- a/tests/coord_transformations/coord_transformations_static_properties.cpp
+++ b/tests/coord_transformations/coord_transformations_static_properties.cpp
@@ -21,7 +21,7 @@ TEST(MappingStaticAsserts, CirctoCart)
     static_assert(is_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(has_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(has_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
-    static_assert(is_curvilinear_2d_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
+    static_assert(has_o_point_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(is_analytical_mapping_v<CircularToCartesian<R, Theta, X, Y>>);
     static_assert(has_singular_o_point_inv_jacobian_v<CircularToCartesian<R, Theta, X, Y>>);
 }
@@ -39,7 +39,7 @@ TEST(MappingStaticAsserts, CzarnytoCart)
     static_assert(is_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(has_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(has_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
-    static_assert(is_curvilinear_2d_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
+    static_assert(has_o_point_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(is_analytical_mapping_v<CzarnyToCartesian<R, Theta, X, Y>>);
     static_assert(has_singular_o_point_inv_jacobian_v<CzarnyToCartesian<R, Theta, X, Y>>);
 }
@@ -55,7 +55,7 @@ TEST(MappingStaticAsserts, DiscToCart)
     using Mapping = DiscreteToCartesian<X, Y, SplineRThetaEvaluator_host>;
     static_assert(is_mapping_v<Mapping>);
     static_assert(has_jacobian_v<Mapping>);
-    static_assert(is_curvilinear_2d_mapping_v<Mapping>);
+    static_assert(has_o_point_v<Mapping>);
     static_assert(!is_analytical_mapping_v<Mapping>);
     static_assert(has_singular_o_point_inv_jacobian_v<Mapping>);
 }

--- a/tests/geometryRTheta/polar_poisson/test_cases.hpp
+++ b/tests/geometryRTheta/polar_poisson/test_cases.hpp
@@ -26,7 +26,7 @@ public:
      * coordinates into the physical (Cartesian) coordinates.
      */
     using coordinate_converter_type = CurvilinearToCartesian;
-    static_assert(is_curvilinear_2d_mapping_v<CurvilinearToCartesian>);
+    static_assert(has_o_point_v<CurvilinearToCartesian>);
 
 private:
     using X = typename CurvilinearToCartesian::cartesian_tag_x;


### PR DESCRIPTION
Rename static variable `is_curvilinear_2d_mapping_v` to the more accurate: `has_o_point_v`. Fixes #351 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
