### PR TITLE
Refactor assign_elements by removing InternalIdx

### DIFF
--- a/src/data_types/tensor_common.hpp
+++ b/src/data_types/tensor_common.hpp
@@ -336,8 +336,7 @@ template <
         class InputStorageType,
         class OutputStorageType,
         class... OutputValidIndexSet,
-        class... InputValidIndexSet,
-        std::size_t... InternalIdx>
+        class... InputValidIndexSet>
 KOKKOS_INLINE_FUNCTION void assign_elements(
         TensorCommon<OutputStorageType, OutputValidIndexSet...>& tensor_to_fill,
         TensorCommon<InputStorageType, InputValidIndexSet...> const& tensor_input)


### PR DESCRIPTION
Removed unused InternalIdx template parameter from assign_elements function.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
