### PR TITLE
Refactor change default number of iterations for matrix equation

### DIFF
--- a/src/matrix_tools/matrix_batch_csr.hpp
+++ b/src/matrix_tools/matrix_batch_csr.hpp
@@ -86,7 +86,7 @@ public:
             std::optional<bool> logger = std::nullopt,
             std::optional<int> preconditioner_max_block_size = std::nullopt)
         : MatrixBatch<ExecSpace>(batch_size, mat_size)
-        , m_max_iter(max_iter.value_or(1000))
+        , m_max_iter(max_iter.value_or(mat_size))
         , m_tol(res_tol.value_or(1e-15))
         , m_with_logger(logger.value_or(false))
         , m_preconditioner_max_block_size(preconditioner_max_block_size.value_or(

--- a/src/matrix_tools/matrix_batch_ell.hpp
+++ b/src/matrix_tools/matrix_batch_ell.hpp
@@ -59,7 +59,7 @@ public:
             std::optional<double> res_tol = std::nullopt,
             std::optional<bool> logger = std::nullopt)
         : MatrixBatch<ExecSpace>(batch_size, mat_size)
-        , m_max_iter(max_iter.value_or(500))
+        , m_max_iter(max_iter.value_or(mat_size))
         , m_tol(res_tol.value_or(1e-15))
         , m_with_logger(logger.value_or(false))
     {

--- a/tests/matrix_tools/matrix_batch_csr.cpp
+++ b/tests/matrix_tools/matrix_batch_csr.cpp
@@ -107,7 +107,7 @@ TEST(MatrixBatchCsrFixture, Coo_to_Csr)
 
     std::unique_ptr<MatrixBatchCsr<Kokkos::DefaultExecutionSpace>> test_instance
             = std::make_unique<MatrixBatchCsr<
-                    Kokkos::DefaultExecutionSpace>>(batch_size, mat_size, non_zero_per_system);
+                    Kokkos::DefaultExecutionSpace>>(batch_size, mat_size, non_zero_per_system, 50);
     convert_coo_to_csr(test_instance, vals_coo_host, row_coo_host, col_coo_host);
     test_instance->setup_solver();
     Kokkos::View<double**, Kokkos::LayoutRight, Kokkos::DefaultHostExecutionSpace>


### PR DESCRIPTION
In order to fix convergence issue,  the matrix size is used as default value for iterative solver.
