### PR TITLE
Split coefficient calculation from sparsity pattern calculation in polar Poisson-like solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `BslAdvectionVelocity` to stop providing values for the derivatives at the boundaries.
 - Add labels to all parallel constructs and many variable allocations.
 - Completed the porting of `PolarSplineFEMPoissonLikeAssembler` to GPU (less memory, fewer data transfers, faster execution).
+- Changed interface of PolarSplineFEMPoissonLikeSolver to split initialisation from coefficient setting.
 
 ### Deprecated
 

--- a/simulations/geometryRTheta/diocotron/diocotron.cpp
+++ b/simulations/geometryRTheta/diocotron/diocotron.cpp
@@ -44,13 +44,14 @@
 
 
 namespace {
+using DiscreteMappingBuilder
+        = DiscreteToCartesianBuilder<X, Y, SplineRThetaBuilder, SplineRThetaEvaluatorConstBound>;
 using PoissonSolver = PolarSplineFEMPoissonLikeSolver<
         GridR,
         GridTheta,
         PolarBSplinesRTheta,
-        SplineRThetaEvaluatorNullBound>;
-using DiscreteMappingBuilder
-        = DiscreteToCartesianBuilder<X, Y, SplineRThetaBuilder, SplineRThetaEvaluatorConstBound>;
+        SplineRThetaEvaluatorNullBound,
+        typename DiscreteMappingBuilder::MappingType>;
 using LogicalToPhysicalMapping = CircularToCartesian<R, Theta, X, Y>;
 
 namespace fs = std::filesystem;
@@ -182,11 +183,10 @@ int main(int argc, char** argv)
     builder(get_field(coeff_alpha_spline), get_const_field(coeff_alpha));
     builder(get_field(coeff_beta_spline), get_const_field(coeff_beta));
 
-    PoissonSolver poisson_solver(
+    PoissonSolver poisson_solver(discrete_mapping, spline_evaluator);
+    poisson_solver.update_coefficients(
             get_const_field(coeff_alpha_spline),
-            get_const_field(coeff_beta_spline),
-            discrete_mapping,
-            spline_evaluator);
+            get_const_field(coeff_beta_spline));
 
     // --- Predictor corrector operator ---------------------------------------------------------------
 #if defined(PREDCORR)

--- a/simulations/geometryRTheta/vortex_merger/vortex_merger.cpp
+++ b/simulations/geometryRTheta/vortex_merger/vortex_merger.cpp
@@ -44,13 +44,14 @@
 
 
 namespace {
+using DiscreteMappingBuilder
+        = DiscreteToCartesianBuilder<X, Y, SplineRThetaBuilder, SplineRThetaEvaluatorConstBound>;
 using PoissonSolver = PolarSplineFEMPoissonLikeSolver<
         GridR,
         GridTheta,
         PolarBSplinesRTheta,
-        SplineRThetaEvaluatorNullBound>;
-using DiscreteMappingBuilder
-        = DiscreteToCartesianBuilder<X, Y, SplineRThetaBuilder, SplineRThetaEvaluatorConstBound>;
+        SplineRThetaEvaluatorNullBound,
+        typename DiscreteMappingBuilder::MappingType>;
 using LogicalToPhysicalMapping = CircularToCartesian<R, Theta, X, Y>;
 
 } // end namespace
@@ -163,11 +164,10 @@ int main(int argc, char** argv)
     builder(get_field(coeff_alpha_spline), get_const_field(coeff_alpha));
     builder(get_field(coeff_beta_spline), get_const_field(coeff_beta));
 
-    PoissonSolver poisson_solver(
+    PoissonSolver poisson_solver(discrete_mapping, spline_evaluator);
+    poisson_solver.update_coefficients(
             get_const_field(coeff_alpha_spline),
-            get_const_field(coeff_beta_spline),
-            discrete_mapping,
-            spline_evaluator);
+            get_const_field(coeff_beta_spline));
 
     // --- Predictor corrector operator ---------------------------------------------------------------
     BslImplicitPredCorrRTheta predcorr_operator(

--- a/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
+++ b/src/geometryRTheta/advection_field/advection_field_rtheta.hpp
@@ -82,8 +82,6 @@
  *
  * @tparam Mapping
  *      A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
- *
- * @see PolarSplineFEMPoissonLikeSolver
  */
 template <class Mapping>
 class AdvectionFieldFinder

--- a/src/geometryRTheta/initialisation/vortex_merger_equilibrium.hpp
+++ b/src/geometryRTheta/initialisation/vortex_merger_equilibrium.hpp
@@ -20,7 +20,7 @@
  * @tparam Mapping
  *      A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
  */
-template <class Mapping>
+template <class Mapping, class PolarPoissonLikeSolver>
 class VortexMergerEquilibria
 {
 private:
@@ -28,11 +28,7 @@ private:
     IdxRangeRTheta const& m_grid;
     SplineRThetaBuilder const& m_builder;
     SplineRThetaEvaluatorNullBound const& m_evaluator;
-    PolarSplineFEMPoissonLikeSolver<
-            GridR,
-            GridTheta,
-            PolarBSplinesRTheta,
-            SplineRThetaEvaluatorNullBound> const& m_poisson_solver;
+    PolarPoissonLikeSolver const& m_poisson_solver;
 
 public:
     /**
@@ -57,11 +53,7 @@ public:
             IdxRangeRTheta const& grid,
             SplineRThetaBuilder const& builder,
             SplineRThetaEvaluatorNullBound const& evaluator,
-            PolarSplineFEMPoissonLikeSolver<
-                    GridR,
-                    GridTheta,
-                    PolarBSplinesRTheta,
-                    SplineRThetaEvaluatorNullBound> const& poisson_solver)
+            PolarPoissonLikeSolver const& poisson_solver)
         : m_mapping(mapping)
         , m_grid(grid)
         , m_builder(builder)

--- a/src/geometryRTheta/time_solver/bsl_predcorr.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr.hpp
@@ -37,12 +37,12 @@
  * for @f$ n \geq 0 @f$,
  *
  * First, it advects on a half time step:
- * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarPoissonLikeSolver;
  * - 2. From @f$\phi^n@f$, it computes @f$A^n@f$ with a AdvectionFieldFinder;
  * - 3. From @f$\rho^n@f$ and @f$A^n@f$, it computes @f$\rho^{n+1/2}@f$ with a BslAdvectionPolar on @f$\frac{dt}{2}@f$;
  *
  * Secondly, it advects on a full time step:
- * - 4. From @f$\rho^{n+1/2}@f$, it computes @f$\phi^{n+1/2}@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 4. From @f$\rho^{n+1/2}@f$, it computes @f$\phi^{n+1/2}@f$ with a PolarPoissonLikeSolver;
  * - 5. From @f$\phi^{n+1/2}@f$, it computes @f$A^{n+1/2}@f$ with a AdvectionFieldFinder;
  * - 6. From @f$\rho^n@f$ and @f$A^{n+1/2}@f$, it computes @f$\rho^{n+1}@f$ with a BslAdvectionPolar on @f$dt@f$.
  *
@@ -52,7 +52,7 @@
  *      A IFootFinder class.
  *
  */
-template <class Mapping, class FootFinder>
+template <class Mapping, class FootFinder, class PolarPoissonLikeSolver>
 class BslPredCorrRTheta : public ITimeSolverRTheta
 {
     using BslAdvectionRTheta = BslAdvectionPolar<
@@ -68,11 +68,7 @@ private:
 
     BslAdvectionRTheta const& m_advection_solver;
 
-    PolarSplineFEMPoissonLikeSolver<
-            GridR,
-            GridTheta,
-            PolarBSplinesRTheta,
-            SplineRThetaEvaluatorNullBound> const& m_poisson_solver;
+    PolarPoissonLikeSolver const& m_poisson_solver;
 
     SplineRThetaBuilder const& m_builder;
     SplineRThetaEvaluatorNullBound const& m_spline_evaluator;
@@ -101,11 +97,7 @@ public:
             BslAdvectionRTheta const& advection_solver,
             SplineRThetaBuilder const& builder,
             SplineRThetaEvaluatorNullBound const& rhs_evaluator,
-            PolarSplineFEMPoissonLikeSolver<
-                    GridR,
-                    GridTheta,
-                    PolarBSplinesRTheta,
-                    SplineRThetaEvaluatorNullBound> const& poisson_solver)
+            PolarPoissonLikeSolver const& poisson_solver)
         : m_mapping(mapping)
         , m_advection_solver(advection_solver)
         , m_poisson_solver(poisson_solver)

--- a/src/geometryRTheta/time_solver/bsl_predcorr.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr.hpp
@@ -50,6 +50,8 @@
  *      A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
  * @tparam FootFinder
  *      A IFootFinder class.
+ * @tparam PolarPoissonLikeSolver
+ *      The type of the solver for the Poisson-like equation on the polar plane.
  *
  */
 template <class Mapping, class FootFinder, class PolarPoissonLikeSolver>

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -40,14 +40,14 @@
  * for @f$ n \geq 0 @f$,
  *
  * First, it predicts:
- * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarPoissonLikeSolver;
  * - 2. From @f$\phi^n@f$, it computes @f$A^n@f$ with a AdvectionFieldFinder;
  * - 3. From @f$\rho^n@f$ and @f$A^n@f$, it computes @f$\rho^P@f$ with a BslAdvectionPolar on @f$ dt @f$;
  *
  * We write @f$X^P@f$ the characteristic feet such that @f$\partial_t X^P = A^n(X^n)@f$.
  *
  * Secondly, it corrects:
- * - 4. From @f$\rho^P@f$, it computes @f$\phi^P@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 4. From @f$\rho^P@f$, it computes @f$\phi^P@f$ with a PolarPoissonLikeSolver;
  * - 5. From @f$\phi^P@f$, it computes @f$A^P@f$ with a AdvectionFieldFinder;
  * - 6. From @f$\rho^n@f$ and @f$\frac{A^{P}(X^n) + A^n(X^P)}{2} @f$, it computes @f$\rho^{n+1}@f$ with a BslAdvectionPolar on @f$ dt @f$.
  *
@@ -86,11 +86,7 @@ private:
     EulerBuilder const m_euler;
     SplinePolarFootFinderType const m_find_feet;
 
-    PolarSplineFEMPoissonLikeSolver<
-            GridR,
-            GridTheta,
-            PolarBSplinesRTheta,
-            SplineRThetaEvaluatorNullBound> const& m_poisson_solver;
+    PolarPoissonLikeSolver const& m_poisson_solver;
 
     SplineRThetaBuilder const& m_builder;
     SplineRThetaEvaluatorConstBound const& m_evaluator;
@@ -124,11 +120,7 @@ public:
             BslAdvectionRTheta const& advection_solver,
             IdxRangeRTheta const& grid,
             SplineRThetaBuilder const& builder,
-            PolarSplineFEMPoissonLikeSolver<
-                    GridR,
-                    GridTheta,
-                    PolarBSplinesRTheta,
-                    SplineRThetaEvaluatorNullBound> const& poisson_solver,
+            PolarPoissonLikeSolver const& poisson_solver,
             SplineRThetaEvaluatorConstBound const& advection_evaluator)
         : m_logical_to_physical(logical_to_physical)
         , m_advection_solver(advection_solver)

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_explicit.hpp
@@ -57,8 +57,13 @@
  *      A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
  * @tparam LogicalToPseudoPhysicalMapping
  *      A class describing a mapping from curvilinear coordinates to pseudo-Cartesian coordinates.
+ * @tparam PolarPoissonLikeSolver
+ *      The type of the solver for the Poisson-like equation on the polar plane.
  */
-template <class LogicalToPhysicalMapping, class LogicalToPseudoPhysicalMapping>
+template <
+        class LogicalToPhysicalMapping,
+        class LogicalToPseudoPhysicalMapping,
+        class PolarPoissonLikeSolver>
 class BslExplicitPredCorrRTheta : public ITimeSolverRTheta
 {
 private:

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
@@ -40,14 +40,14 @@
  * for @f$ n \geq 0 @f$,
  *
  * First, it predicts:
- * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 1. From @f$\rho^n@f$, it computes @f$\phi^n@f$ with a PolarPoissonLikeSolver;
  * - 2. From @f$\phi^n@f$, it computes @f$A^n@f$ with a AdvectionFieldFinder;
  * - 3. From @f$\rho^n@f$ and @f$A^n@f$, it computes implicitly @f$\rho^P@f$ with a BslAdvectionPolar on @f$ \frac{dt}{4} @f$:
  *      - the characteristic feet @f$X^P@f$ is such that @f$X^P = X^k@f$ with @f$X^k@f$ the result of the implicit method:
  *          - @f$ X^k = X^n - \frac{dt}{4} \partial_t X^k@f$.
  * 
  * Secondly, it corrects: 
- * - 4. From @f$\rho^P@f$, it computes @f$\phi^P@f$ with a PolarSplineFEMPoissonLikeSolver;
+ * - 4. From @f$\rho^P@f$, it computes @f$\phi^P@f$ with a PolarPoissonLikeSolver;
  * - 5. From @f$\phi^P@f$, it computes @f$A^P@f$ with a AdvectionFieldFinder;
  * - 6. From @f$\rho^n@f$ and @f$ A^{P} @f$, it computes @f$\rho^{n+1}@f$ with a BslAdvectionPolar on @f$ \frac{dt}{2} @f$.
  *      - the characteristic feet @f$X^C@f$ is such that @f$X^C = X^k@f$ with @f$X^k@f$ the result of the implicit method:
@@ -59,7 +59,7 @@
  * @tparam LogicalToPseudoPhysicalMapping
  *      A class describing a mapping from curvilinear coordinates to pseudo-Cartesian coordinates.
  */
-template <class LogicalToPhysicalMapping, class LogicalToPseudoPhysicalMapping>
+template <class LogicalToPhysicalMapping, class LogicalToPseudoPhysicalMapping, class PolarPoissonLikeSolver>
 class BslImplicitPredCorrRTheta : public ITimeSolverRTheta
 {
 private:
@@ -86,11 +86,7 @@ private:
     EulerBuilder const m_euler;
     SplinePolarFootFinderType const m_foot_finder;
 
-    PolarSplineFEMPoissonLikeSolver<
-            GridR,
-            GridTheta,
-            PolarBSplinesRTheta,
-            SplineRThetaEvaluatorNullBound> const& m_poisson_solver;
+    PolarPoissonLikeSolver const& m_poisson_solver;
 
     SplineRThetaBuilder const& m_builder;
     SplineRThetaEvaluatorConstBound const& m_evaluator;
@@ -124,11 +120,7 @@ public:
             BslAdvectionRTheta const& advection_solver,
             IdxRangeRTheta const& grid,
             SplineRThetaBuilder const& builder,
-            PolarSplineFEMPoissonLikeSolver<
-                    GridR,
-                    GridTheta,
-                    PolarBSplinesRTheta,
-                    SplineRThetaEvaluatorNullBound> const& poisson_solver,
+            PolarPoissonLikeSolver const& poisson_solver,
             SplineRThetaEvaluatorConstBound const& advection_evaluator)
         : m_logical_to_physical(logical_to_physical)
         , m_advection_solver(advection_solver)

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
@@ -59,7 +59,10 @@
  * @tparam LogicalToPseudoPhysicalMapping
  *      A class describing a mapping from curvilinear coordinates to pseudo-Cartesian coordinates.
  */
-template <class LogicalToPhysicalMapping, class LogicalToPseudoPhysicalMapping, class PolarPoissonLikeSolver>
+template <
+        class LogicalToPhysicalMapping,
+        class LogicalToPseudoPhysicalMapping,
+        class PolarPoissonLikeSolver>
 class BslImplicitPredCorrRTheta : public ITimeSolverRTheta
 {
 private:

--- a/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
+++ b/src/geometryRTheta/time_solver/bsl_predcorr_second_order_implicit.hpp
@@ -58,6 +58,8 @@
  *      A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
  * @tparam LogicalToPseudoPhysicalMapping
  *      A class describing a mapping from curvilinear coordinates to pseudo-Cartesian coordinates.
+ * @tparam PolarPoissonLikeSolver
+ *      The type of the solver for the Poisson-like equation on the polar plane.
  */
 template <
         class LogicalToPhysicalMapping,

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -378,13 +378,12 @@ private:
     const int m_matrix_size;
 
     // Domains
-    IdxRangeBSPolar m_idxrange_fem_non_singular;
+    IdxRangeBSPolar m_idxrange_fem_tensor_basis;
     IdxRangeBSR m_idxrange_bsplines_r;
     IdxRangeBSTheta m_idxrange_bsplines_theta;
 
     IdxRangeQuadratureR m_idxrange_quadrature_r;
     IdxRangeQuadratureTheta m_idxrange_quadrature_theta;
-    IdxRangeQuadratureRTheta m_idxrange_quadrature_singular;
     IdxRangeQuadratureRTheta m_idxrange_quadrature;
 
     const int m_batch_idx {0}; // TODO: Remove when batching is supported
@@ -401,7 +400,7 @@ public:
         : m_nbasis_r(ddc::discrete_space<BSplinesR>().nbasis() - m_n_overlap_cells - 1)
         , m_nbasis_theta(ddc::discrete_space<BSplinesTheta>().nbasis())
         , m_matrix_size(ddc::discrete_space<PolarBSplinesRTheta>().nbasis() - m_nbasis_theta)
-        , m_idxrange_fem_non_singular(
+        , m_idxrange_fem_tensor_basis(
                   ddc::discrete_space<PolarBSplinesRTheta>().tensor_bspline_idx_range().remove_last(
                           IdxStepBSPolar {m_nbasis_theta}))
         , m_idxrange_bsplines_r(ddc::discrete_space<BSplinesR>().full_domain().remove_first(
@@ -416,10 +415,6 @@ public:
                   Idx<QDimThetaMesh>(0),
                   IdxStep<QDimThetaMesh>(
                           s_n_gauss_legendre_theta * ddc::discrete_space<BSplinesTheta>().ncells()))
-        , m_idxrange_quadrature_singular(
-                  m_idxrange_quadrature_r.take_first(
-                          IdxStep<QDimRMesh> {m_n_overlap_cells * s_n_gauss_legendre_r}),
-                  m_idxrange_quadrature_theta)
         , m_idxrange_quadrature(m_idxrange_quadrature_r, m_idxrange_quadrature_theta)
         , m_int_volume(int_volume)
     {
@@ -456,7 +451,7 @@ public:
         constexpr int n_elements_singular
                 = PolarBSplinesRTheta::n_singular_basis() * PolarBSplinesRTheta::n_singular_basis();
         // Number of non-zero elements in the matrix corresponding to the inner product of
-        // polar splines at the singular point and the other splines
+        // polar bsplines which traverse the singular point and other polar bsplines
         const int n_elements_overlap = 2
                                        * (PolarBSplinesRTheta::n_singular_basis()
                                           * BSplinesR::degree() * m_nbasis_theta);
@@ -606,6 +601,8 @@ public:
                 m_idxrange_bsplines_theta);
 
         const int n_singular = idxrange_singular.size();
+        // Number of tensor product polar bsplines which overlap with polar bsplines which
+        // traverse the singular point
         const int n_overlapping_singular = idxrange_non_singular_near_centre.size();
 
         const std::source_location location = std::source_location::current();
@@ -661,7 +658,7 @@ public:
         IdxRangeBSR idx_range_fem_r = ddc::discrete_space<BSplinesR>().full_domain().remove_first(
                 IdxStepBSR(PolarBSplinesRTheta::continuity + 1));
 
-        IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_non_singular.front();
+        IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_tensor_basis.front();
 
         const int n_singular = idxrange_singular.size();
         const std::source_location location = std::source_location::current();
@@ -672,7 +669,7 @@ public:
                 location.function_name(),
                 Kokkos::TeamPolicy<>(
                         Kokkos::DefaultExecutionSpace(),
-                        m_idxrange_fem_non_singular.size(),
+                        m_idxrange_fem_tensor_basis.size(),
                         Kokkos::AUTO),
                 KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
                     // Calculate the index of the test b-spline
@@ -792,7 +789,10 @@ public:
     {
         IdxRangeBSPolar idxrange_singular
                 = PolarBSplinesRTheta::template singular_idx_range<PolarBSplinesRTheta>();
-        IdxRangeQuadratureRTheta idx_range_quad_singular = m_idxrange_quadrature_singular;
+        IdxRangeQuadratureRTheta idx_range_quad_singular(
+                m_idxrange_quadrature_r.take_first(
+                        IdxStep<QDimRMesh> {m_n_overlap_cells * s_n_gauss_legendre_r}),
+                m_idxrange_quadrature_theta);
 
         DField<IdxRangeQuadratureRTheta> int_volume_proxy = m_int_volume;
 
@@ -893,7 +893,10 @@ public:
         IdxQuadratureRTheta idxrange_quadrature_front = m_idxrange_quadrature.front();
 
         const int batch_idx = m_batch_idx;
+        // Number of polar bsplines which traverse the singular point
         const int n_singular = idxrange_singular.size();
+        // Number of tensor product polar bsplines which overlap with polar bsplines which
+        // traverse the singular point
         const int n_overlapping_singular = idxrange_non_singular_near_centre.size();
 
         const std::source_location location = std::source_location::current();
@@ -1026,7 +1029,7 @@ public:
         IdxRangeBSR central_radial_bspline_idx_range(
                 m_idxrange_bsplines_r.take_first(IdxStep<BSplinesR> {BSplinesR::degree()}));
 
-        IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_non_singular.front();
+        IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_tensor_basis.front();
 
         DField<IdxRangeQuadratureRTheta> int_volume_proxy = m_int_volume;
 
@@ -1042,7 +1045,7 @@ public:
                 location.function_name(),
                 Kokkos::TeamPolicy<>(
                         Kokkos::DefaultExecutionSpace(),
-                        m_idxrange_fem_non_singular.size(),
+                        m_idxrange_fem_tensor_basis.size(),
                         Kokkos::AUTO),
                 KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
                     // Calculate the index of the test b-spline

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -482,9 +482,9 @@ public:
                 preconditioner_max_block_size);
         auto [values, col_idx, nnz_per_row] = gko_matrix->get_batch_csr();
         init_nnz_per_line(nnz_per_row);
-        compute_singular_col_idx(col_idx, nnz_per_row);
-        compute_overlapping_singular_col_idx(col_idx, nnz_per_row);
-        compute_stencil_col_idx(col_idx, nnz_per_row);
+        compute_singular_singular_col_idx(col_idx, nnz_per_row);
+        compute_singular_tensor_col_idx(col_idx, nnz_per_row);
+        compute_tensor_tensor_col_idx(col_idx, nnz_per_row);
     }
 
     /**
@@ -518,7 +518,7 @@ public:
         //CSR data storage
         auto [values, col_idx, nnz_per_row] = gko_matrix->get_batch_csr();
 
-        compute_singular_elements(
+        compute_singular_singular_elements(
                 coeff_alpha,
                 coeff_beta,
                 mapping,
@@ -526,7 +526,7 @@ public:
                 values,
                 col_idx,
                 nnz_per_row);
-        compute_overlapping_singular_elements(
+        compute_singular_tensor_elements(
                 coeff_alpha,
                 coeff_beta,
                 mapping,
@@ -534,7 +534,7 @@ public:
                 values,
                 col_idx,
                 nnz_per_row);
-        compute_stencil_elements(
+        compute_tensor_tensor_elements(
                 coeff_alpha,
                 coeff_beta,
                 mapping,
@@ -547,15 +547,15 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to the singular area.
-     *        ie: the region enclosing the O-point.
+     * @brief Computes the column indices of the matrix elements corresponding to the
+     * inner products of singular basis functions and singular basis functions.
      *
      * @param[out] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix).
      * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
-    void compute_singular_col_idx(
+    void compute_singular_singular_col_idx(
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
                     col_idx_csr,
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
@@ -581,15 +581,15 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to singular elements overlapping
-     *        with regular grid.
+     * @brief Computes the column indices of the matrix elements corresponding to the
+     * inner products of singular basis functions and tensor basis functions.
      *
      * @param[out] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
      * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
-    void compute_overlapping_singular_col_idx(
+    void compute_singular_tensor_col_idx(
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
                     col_idx_csr,
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
@@ -633,15 +633,15 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to the regular stencil
-     *        ie: out to singular or overlapping areas.
+     * @brief Computes the column indices of the matrix elements corresponding to the
+     * inner products of tensor basis functions and tensor basis functions.
      *
      * @param[out] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
      * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
-    void compute_stencil_col_idx(
+    void compute_tensor_tensor_col_idx(
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
                     col_idx_csr,
             Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
@@ -756,8 +756,8 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to the singular area.
-     *        ie: the region enclosing the O-point.
+     * @brief Computes the matrix elements corresponding to the inner products of singular
+     * basis functions and singular basis functions.
      *
      * @param[in] coeff_alpha
      *      The spline representation of the @f$ \alpha @f$ function in the
@@ -778,7 +778,7 @@ public:
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
-    void compute_singular_elements(
+    void compute_singular_singular_elements(
             ConstSpline2D coeff_alpha,
             ConstSpline2D coeff_beta,
             Mapping const& mapping,
@@ -843,8 +843,8 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to singular elements overlapping
-     *        with regular grid.
+     * @brief Computes the matrix elements corresponding to the inner products of singular
+     * basis functions and tensor basis functions.
      *
      * @param[in] coeff_alpha
      *      The spline representation of the @f$ \alpha @f$ function in the
@@ -865,7 +865,7 @@ public:
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
-    void compute_overlapping_singular_elements(
+    void compute_singular_tensor_elements(
             ConstSpline2D coeff_alpha,
             ConstSpline2D coeff_beta,
             Mapping const& mapping,
@@ -986,8 +986,8 @@ public:
     }
 
     /**
-     * @brief Computes the matrix element corresponding to the regular stencil
-     *        ie: out to singular or overlapping areas.
+     * @brief Computes the matrix elements corresponding to the inner products of tensor
+     * basis functions and tensor basis functions.
      *
      * @param[in] coeff_alpha
      *      The spline representation of the @f$ \alpha @f$ function in the
@@ -1008,7 +1008,7 @@ public:
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
-    void compute_stencil_elements(
+    void compute_tensor_tensor_elements(
             ConstSpline2D coeff_alpha,
             ConstSpline2D coeff_beta,
             Mapping const& mapping,

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -424,21 +424,11 @@ public:
         , m_int_volume(int_volume)
     {
     }
+
     /**
-     * @brief Assemble the stiffness matrix.
+     * @brief Compute the sparsity pattern for the stiffness matrix.
      * 
      * @param[out] gko_matrix The pointer to the assembled matrix.
-     * @param[in] coeff_alpha
-     *      The spline representation of the @f$ \alpha @f$ function in the
-     *      definition of the Poisson-like equation.
-     * @param[in] coeff_beta
-     *      The spline representation of the  @f$ \beta @f$ function in the
-     *      definition of the Poisson-like equation.
-     * @param[in] mapping
-     *      The mapping from the logical domain to the physical domain where
-     *      the equation is defined.
-     * @param[in] spline_evaluator
-     *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
      * @param[in] max_iter
      *      The maximum number of iterations possible for the batched CSR solver.
      * @param[in] res_tol
@@ -452,15 +442,10 @@ public:
      *
      * @tparam Mapping A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
      */
-    template <typename Mapping>
-    void operator()(
+    void setup_sparse_matrix(
             std::unique_ptr<
                     MatrixBatchCsr<Kokkos::DefaultExecutionSpace, MatrixBatchCsrSolver::CG>>&
                     gko_matrix,
-            ConstSpline2D coeff_alpha,
-            ConstSpline2D coeff_beta,
-            Mapping const& mapping,
-            SplineRThetaEvaluatorNullBound const& spline_evaluator,
             std::optional<int> max_iter = std::nullopt,
             std::optional<double> res_tol = std::nullopt,
             std::optional<bool> batch_solver_logger = std::nullopt,
@@ -497,6 +482,51 @@ public:
                 preconditioner_max_block_size);
         auto [values, col_idx, nnz_per_row] = gko_matrix->get_batch_csr();
         init_nnz_per_line(nnz_per_row);
+        compute_singular_col_idx(col_idx, nnz_per_row);
+        compute_overlapping_singular_col_idx(col_idx, nnz_per_row);
+        compute_stencil_col_idx(col_idx, nnz_per_row);
+    }
+
+    /**
+     * @brief Assemble the stiffness matrix.
+     * 
+     * @param[out] gko_matrix The pointer to the assembled matrix.
+     * @param[in] coeff_alpha
+     *      The spline representation of the @f$ \alpha @f$ function in the
+     *      definition of the Poisson-like equation.
+     * @param[in] coeff_beta
+     *      The spline representation of the  @f$ \beta @f$ function in the
+     *      definition of the Poisson-like equation.
+     * @param[in] mapping
+     *      The mapping from the logical domain to the physical domain where
+     *      the equation is defined.
+     * @param[in] spline_evaluator
+     *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
+     * @param[in] max_iter
+     *      The maximum number of iterations possible for the batched CSR solver.
+     * @param[in] res_tol
+     *      The residual tolerance for the batched CSR solver. Be careful! the relative residual
+     *      provided here, will be used as "implicit residual" in ginkgo solver.
+     * @param[in] batch_solver_logger
+     *      Indicates whether log information such as the residual and the number of iterations
+     *      should be monitored.
+     * @param[in] preconditioner_max_block_size
+     *      The maximum size of the Jacobi preconditioner used by the batched CSR solver.
+     *
+     * @tparam Mapping A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
+     */
+    template <typename Mapping>
+    void operator()(
+            std::unique_ptr<
+                    MatrixBatchCsr<Kokkos::DefaultExecutionSpace, MatrixBatchCsrSolver::CG>> const&
+                    gko_matrix,
+            ConstSpline2D coeff_alpha,
+            ConstSpline2D coeff_beta,
+            Mapping const& mapping,
+            SplineRThetaEvaluatorNullBound const& spline_evaluator)
+    {
+        //CSR data storage
+        auto [values, col_idx, nnz_per_row] = gko_matrix->get_batch_csr();
 
         compute_singular_elements(
                 coeff_alpha,
@@ -530,6 +560,92 @@ public:
      * @brief Computes the matrix element corresponding to the singular area.
      *        ie: the region enclosing the O-point.
      *
+     * @param[out] col_idx_csr
+     *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix).
+     * @param[in] nnz_per_row_csr
+     *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
+     */
+    void compute_singular_col_idx(
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    col_idx_csr,
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    nnz_per_row_csr)
+    {
+        IdxRangeBSPolar idxrange_singular
+                = PolarBSplinesRTheta::template singular_idx_range<PolarBSplinesRTheta>();
+        const int n_singular = idxrange_singular.size();
+
+        Kokkos::Profiling::pushRegion("PolarPoissonFillFemMatrix");
+        const std::source_location location = std::source_location::current();
+        // Calculate the matrix elements corresponding to the B-splines which cover the singular point
+        Kokkos::parallel_for(
+                location.function_name(),
+                Kokkos::MDRangePolicy<
+                        Kokkos::Rank<2>,
+                        Kokkos::DefaultExecutionSpace>({0, 0}, {n_singular, n_singular}),
+                KOKKOS_LAMBDA(const int row_idx, const int col_idx) {
+                    const int csr_idx_singular_area = nnz_per_row_csr(row_idx) + col_idx;
+                    //Fill the dense matrix corresponding to the b-splines on the singular point
+                    col_idx_csr(csr_idx_singular_area) = col_idx;
+                });
+    }
+
+    /**
+     * @brief Computes the matrix element corresponding to singular elements overlapping
+     *        with regular grid.
+     *
+     * @param[out] col_idx_csr
+     *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
+     * @param[in] nnz_per_row_csr
+     *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
+     */
+    void compute_overlapping_singular_col_idx(
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    col_idx_csr,
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    nnz_per_row_csr)
+    {
+        // Create index ranges associated with the 2D splines
+        IdxRangeBSPolar idxrange_singular
+                = PolarBSplinesRTheta::template singular_idx_range<PolarBSplinesRTheta>();
+        IdxRangeBSR central_radial_bspline_idx_range(
+                m_idxrange_bsplines_r.take_first(IdxStep<BSplinesR> {BSplinesR::degree()}));
+
+        IdxRangeBSRTheta idxrange_non_singular_near_centre(
+                central_radial_bspline_idx_range,
+                m_idxrange_bsplines_theta);
+
+        const int n_singular = idxrange_singular.size();
+        const int n_overlapping_singular = idxrange_non_singular_near_centre.size();
+
+        const std::source_location location = std::source_location::current();
+
+        // Calculate the matrix elements where bspline products overlap the B-splines which cover the singular point
+        Kokkos::parallel_for(
+                location.function_name(),
+                Kokkos::TeamPolicy<>(
+                        Kokkos::DefaultExecutionSpace(),
+                        n_singular * n_overlapping_singular,
+                        Kokkos::AUTO),
+                KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
+                    const IdxStepBSPolar idx_step_test(team.league_rank() / n_overlapping_singular);
+                    const IdxStepBSPolar idx_step_trial(
+                            team.league_rank() % n_overlapping_singular);
+
+                    const int row_idx = idx_step_test.value();
+                    const int col_idx = idx_step_trial.value() + n_singular;
+
+                    //a_ij
+                    col_idx_csr(nnz_per_row_csr(row_idx) + col_idx) = col_idx;
+                    //a_ji
+                    col_idx_csr(nnz_per_row_csr(col_idx) + row_idx) = row_idx;
+                });
+    }
+
+    /**
+     * @brief Computes the matrix element corresponding to the regular stencil
+     *        ie: out to singular or overlapping areas.
+     *
      * @param[in] coeff_alpha
      *      The spline representation of the @f$ \alpha @f$ function in the
      *      definition of the Poisson-like equation.
@@ -544,8 +660,144 @@ public:
      * @param[out] values_csr
      *             A 2D Kokkos view which stores the values of non-zero elements for the whole batch.
      * @param[out] col_idx_csr
+     *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
+     * @param[in] nnz_per_row_csr
+     *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
+     */
+    void compute_stencil_col_idx(
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    col_idx_csr,
+            Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::DefaultExecutionSpace> const
+                    nnz_per_row_csr)
+    {
+        IdxRangeBSPolar idxrange_singular
+                = PolarBSplinesRTheta::template singular_idx_range<PolarBSplinesRTheta>();
+
+        // Get index range for basis elements (last element removed due to homogeneous Dirichlet)
+        IdxRangeBSTheta full_idx_range_theta
+                = ddc::discrete_space<BSplinesTheta>().full_domain().take_first(
+                        IdxStepBSTheta(ddc::discrete_space<BSplinesTheta>().nbasis()));
+
+        IdxRangeBSR central_radial_bspline_idx_range(
+                m_idxrange_bsplines_r.take_first(IdxStep<BSplinesR> {BSplinesR::degree()}));
+
+        IdxRangeBSR idx_range_fem_r = ddc::discrete_space<BSplinesR>().full_domain().remove_first(
+                IdxStepBSR(PolarBSplinesRTheta::continuity + 1));
+
+        IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_non_singular.front();
+
+        const int n_singular = idxrange_singular.size();
+        const std::source_location location = std::source_location::current();
+
+        // Calculate the matrix elements following a stencil
+        // Teams loop over rows
+        Kokkos::parallel_for(
+                location.function_name(),
+                Kokkos::TeamPolicy<>(
+                        Kokkos::DefaultExecutionSpace(),
+                        m_idxrange_fem_non_singular.size(),
+                        Kokkos::AUTO),
+                KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
+                    // Calculate the index of the test b-spline
+                    IdxBSPolar const idx_test_polar(
+                            idxrange_fem_non_singular_front + IdxStepBSPolar {team.league_rank()});
+
+                    // Calculate the radial and poloidal components of the test b-spline
+                    const IdxBSRTheta idx_test(PolarBSplinesRTheta::get_2d_index(idx_test_polar));
+                    const IdxBSR idx_test_r(idx_test);
+                    const IdxBSTheta idx_test_theta(idx_test);
+
+                    // Calculate the offsets to locate all trial b-splines which are non-zero
+                    // somewhere in the support of the test b-spline.
+                    IdxStepBSR idx_step_trial_r_offset_min(
+                            Kokkos::
+                                    max(IdxStepBSR(-BSplinesR::degree()),
+                                        idx_range_fem_r.front() - idx_test_r));
+                    IdxStepBSR idx_step_trial_r_offset_max(
+                            Kokkos::
+                                    min(IdxStepBSR(BSplinesR::degree() + 1),
+                                        idx_range_fem_r.back() - idx_test_r));
+                    IdxStepBSTheta idx_step_trial_theta_offset_min(-BSplinesTheta::degree());
+                    IdxStepBSTheta idx_step_trial_theta_offset_max(BSplinesTheta::degree() + 1);
+
+                    // Calculate the row index and the first possible column index
+                    int const row_idx = idx_test_polar - idxrange_singular.front();
+                    int col_offset
+                            = n_singular * central_radial_bspline_idx_range.contains(idx_test_r);
+
+                    // Loop over the radial offset to a trial b-spline
+                    for (IdxStepBSR idx_step_trial_r(idx_step_trial_r_offset_min);
+                         idx_step_trial_r < idx_step_trial_r_offset_max;
+                         ++idx_step_trial_r) {
+                        const IdxBSR idx_trial_r = idx_test_r + idx_step_trial_r;
+
+                        // As theta is periodic the theta component must be split in 2 to
+                        // guarantee that col_idx and values (from the CSR format) are
+                        // filled in order.
+                        // Calculate the start and end of the theta offset
+                        IdxBSTheta first_idx_trial_theta = detail_poisson::
+                                mod_add(idx_test_theta,
+                                        idx_step_trial_theta_offset_min,
+                                        full_idx_range_theta);
+                        const IdxBSTheta last_idx_trial_theta = detail_poisson::
+                                mod_add(idx_test_theta,
+                                        idx_step_trial_theta_offset_max,
+                                        full_idx_range_theta);
+                        IdxBSTheta first_periodic_idx_trial_theta = full_idx_range_theta.back() + 1;
+                        // If the start is after the end then the periodicity wraps the b-splines
+                        // first_periodic_idx_trial_theta is modified to fill the wrapped area (at the
+                        // right hand side of the block) last.
+                        if (first_idx_trial_theta > last_idx_trial_theta) {
+                            first_periodic_idx_trial_theta = first_idx_trial_theta;
+                            first_idx_trial_theta = full_idx_range_theta.front();
+                        }
+                        // Loop over the poloidal offset to a trial b-spline
+                        for (IdxBSTheta idx_trial_theta(first_idx_trial_theta);
+                             idx_trial_theta < last_idx_trial_theta;
+                             ++idx_trial_theta) {
+                            const IdxBSRTheta idx_trial(idx_trial_r, idx_trial_theta);
+                            int const col_idx = to_polar(idx_trial) - idxrange_singular.front();
+                            const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
+                            col_idx_csr(aij_idx) = col_idx;
+                            col_offset++;
+                        }
+                        // Loop over the poloidal offset to a trial b-spline for any elements that
+                        // are to the right of zeros following the elements already set
+                        for (IdxBSTheta idx_trial_theta(first_periodic_idx_trial_theta);
+                             idx_trial_theta < full_idx_range_theta.back() + 1;
+                             ++idx_trial_theta) {
+                            const IdxBSRTheta idx_trial(idx_trial_r, idx_trial_theta);
+                            int const col_idx = to_polar(idx_trial) - idxrange_singular.front();
+                            const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
+                            col_idx_csr(aij_idx) = col_idx;
+                            col_offset++;
+                        }
+                    }
+                });
+
+        Kokkos::Profiling::popRegion();
+    }
+
+    /**
+     * @brief Computes the matrix element corresponding to the singular area.
+     *        ie: the region enclosing the O-point.
+     *
+     * @param[in] coeff_alpha
+     *      The spline representation of the @f$ \alpha @f$ function in the
+     *      definition of the Poisson-like equation.
+     * @param[in] coeff_beta
+     *      The spline representation of the  @f$ \beta @f$ function in the
+     *      definition of the Poisson-like equation.
+     * @param[in] mapping
+     *      The mapping from the logical domain to the physical domain where
+     *      the equation is defined.
+     * @param[in] spline_evaluator
+     *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
+     * @param[out] values_csr
+     *             A 2D Kokkos view which stores the values of non-zero elements for the whole batch.
+     * @param[in] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix).
-     * @param[inout] nnz_per_row_csr
+     * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
@@ -609,7 +861,6 @@ public:
                             element);
                     const int csr_idx_singular_area = nnz_per_row_csr(row_idx) + col_idx;
                     //Fill the dense matrix corresponding to the b-splines on the singular point
-                    col_idx_csr(csr_idx_singular_area) = col_idx;
                     values_csr(batch_idx, csr_idx_singular_area) = element;
                 });
     }
@@ -631,9 +882,9 @@ public:
      *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
      * @param[out] values_csr
      *             A 2D Kokkos view which stores the values of non-zero elements for the whole batch.
-     * @param[out] col_idx_csr
+     * @param[in] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
-     * @param[inout] nnz_per_row_csr
+     * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
@@ -751,13 +1002,12 @@ public:
                     const int col_idx = idx_step_trial.value() + n_singular;
 
                     //a_ij
-                    col_idx_csr(nnz_per_row_csr(row_idx) + col_idx) = col_idx;
                     values_csr(batch_idx, nnz_per_row_csr(row_idx) + col_idx) = element;
                     //a_ji
-                    col_idx_csr(nnz_per_row_csr(col_idx) + row_idx) = row_idx;
                     values_csr(batch_idx, nnz_per_row_csr(col_idx) + row_idx) = element;
                 });
     }
+
     /**
      * @brief Computes the matrix element corresponding to the regular stencil
      *        ie: out to singular or overlapping areas.
@@ -777,7 +1027,7 @@ public:
      *             A 2D Kokkos view which stores the values of non-zero elements for the whole batch.
      * @param[out] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
-     * @param[inout] nnz_per_row_csr
+     * @param[in] nnz_per_row_csr
      *               A 1D Kokkos view of length matrix_size+1 which stores the count of the non-zeros along the lines of the matrix.
      */
     template <class Mapping>
@@ -894,9 +1144,7 @@ public:
                                     mapping,
                                     full_quad_idx_range,
                                     int_volume_proxy);
-                            int const col_idx = to_polar(idx_trial) - idxrange_singular.front();
                             const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
-                            col_idx_csr(aij_idx) = col_idx;
                             values_csr(batch_idx, aij_idx) = element;
                             col_offset++;
                         }
@@ -916,9 +1164,7 @@ public:
                                     mapping,
                                     full_quad_idx_range,
                                     int_volume_proxy);
-                            int const col_idx = to_polar(idx_trial) - idxrange_singular.front();
                             const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
-                            col_idx_csr(aij_idx) = col_idx;
                             values_csr(batch_idx, aij_idx) = element;
                             col_offset++;
                         }

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -502,16 +502,6 @@ public:
      *      the equation is defined.
      * @param[in] spline_evaluator
      *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
-     * @param[in] max_iter
-     *      The maximum number of iterations possible for the batched CSR solver.
-     * @param[in] res_tol
-     *      The residual tolerance for the batched CSR solver. Be careful! the relative residual
-     *      provided here, will be used as "implicit residual" in ginkgo solver.
-     * @param[in] batch_solver_logger
-     *      Indicates whether log information such as the residual and the number of iterations
-     *      should be monitored.
-     * @param[in] preconditioner_max_block_size
-     *      The maximum size of the Jacobi preconditioner used by the batched CSR solver.
      *
      * @tparam Mapping A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
      */
@@ -646,19 +636,6 @@ public:
      * @brief Computes the matrix element corresponding to the regular stencil
      *        ie: out to singular or overlapping areas.
      *
-     * @param[in] coeff_alpha
-     *      The spline representation of the @f$ \alpha @f$ function in the
-     *      definition of the Poisson-like equation.
-     * @param[in] coeff_beta
-     *      The spline representation of the  @f$ \beta @f$ function in the
-     *      definition of the Poisson-like equation.
-     * @param[in] mapping
-     *      The mapping from the logical domain to the physical domain where
-     *      the equation is defined.
-     * @param[in] spline_evaluator
-     *      An evaluator for evaluating 2D splines on @f$(r,\theta)@f$.
-     * @param[out] values_csr
-     *             A 2D Kokkos view which stores the values of non-zero elements for the whole batch.
      * @param[out] col_idx_csr
      *             A 1D Kokkos view which stores the column indices for each non-zero component.(only for one matrix)
      * @param[in] nnz_per_row_csr

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -1023,11 +1023,6 @@ public:
         IdxRangeBSPolar idxrange_singular
                 = PolarBSplinesRTheta::template singular_idx_range<PolarBSplinesRTheta>();
 
-        // Get index range for basis elements (last element removed due to homogeneous Dirichlet)
-        IdxRangeBSTheta full_idx_range_theta
-                = ddc::discrete_space<BSplinesTheta>().full_domain().take_first(
-                        IdxStepBSTheta(ddc::discrete_space<BSplinesTheta>().nbasis()));
-
         IdxRangeBSR central_radial_bspline_idx_range(
                 m_idxrange_bsplines_r.take_first(IdxStep<BSplinesR> {BSplinesR::degree()}));
 

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -1083,91 +1083,31 @@ public:
                     // Calculate the radial and poloidal components of the test b-spline
                     const IdxBSRTheta idx_test(PolarBSplinesRTheta::get_2d_index(idx_test_polar));
                     const IdxBSR idx_test_r(idx_test);
-                    const IdxBSTheta idx_test_theta(idx_test);
-
-                    // Calculate the offsets to locate all trial b-splines which are non-zero
-                    // somewhere in the support of the test b-spline.
-                    IdxStepBSR idx_step_trial_r_offset_min(
-                            Kokkos::
-                                    max(IdxStepBSR(-BSplinesR::degree()),
-                                        idx_range_fem_r.front() - idx_test_r));
-                    IdxStepBSR idx_step_trial_r_offset_max(
-                            Kokkos::
-                                    min(IdxStepBSR(BSplinesR::degree() + 1),
-                                        idx_range_fem_r.back() - idx_test_r));
-                    IdxStepBSTheta idx_step_trial_theta_offset_min(-BSplinesTheta::degree());
-                    IdxStepBSTheta idx_step_trial_theta_offset_max(BSplinesTheta::degree() + 1);
 
                     // Calculate the row index and the first possible column index
                     int const row_idx = idx_test_polar - idxrange_singular.front();
-                    int col_offset
+                    int const first_col_idx
                             = n_singular * central_radial_bspline_idx_range.contains(idx_test_r);
 
-                    // Loop over the radial offset to a trial b-spline
-                    for (IdxStepBSR idx_step_trial_r(idx_step_trial_r_offset_min);
-                         idx_step_trial_r < idx_step_trial_r_offset_max;
-                         ++idx_step_trial_r) {
-                        const IdxBSR idx_trial_r = idx_test_r + idx_step_trial_r;
-
-                        // As theta is periodic the theta component must be split in 2 to
-                        // guarantee that col_idx and values (from the CSR format) are
-                        // filled in order.
-                        // Calculate the start and end of the theta offset
-                        IdxBSTheta first_idx_trial_theta = detail_poisson::
-                                mod_add(idx_test_theta,
-                                        idx_step_trial_theta_offset_min,
-                                        full_idx_range_theta);
-                        const IdxBSTheta last_idx_trial_theta = detail_poisson::
-                                mod_add(idx_test_theta,
-                                        idx_step_trial_theta_offset_max,
-                                        full_idx_range_theta);
-                        IdxBSTheta first_periodic_idx_trial_theta = full_idx_range_theta.back() + 1;
-                        // If the start is after the end then the periodicity wraps the b-splines
-                        // first_periodic_idx_trial_theta is modified to fill the wrapped area (at the
-                        // right hand side of the block) last.
-                        if (first_idx_trial_theta > last_idx_trial_theta) {
-                            first_periodic_idx_trial_theta = first_idx_trial_theta;
-                            first_idx_trial_theta = full_idx_range_theta.front();
-                        }
-                        // Loop over the poloidal offset to a trial b-spline
-                        for (IdxBSTheta idx_trial_theta(first_idx_trial_theta);
-                             idx_trial_theta < last_idx_trial_theta;
-                             ++idx_trial_theta) {
-                            const IdxBSRTheta idx_trial(idx_trial_r, idx_trial_theta);
-                            double element = get_matrix_stencil_element(
-                                    team,
-                                    idx_test,
-                                    idx_trial,
-                                    coeff_alpha,
-                                    coeff_beta,
-                                    spline_evaluator,
-                                    mapping,
-                                    full_quad_idx_range,
-                                    int_volume_proxy);
-                            const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
-                            values_csr(batch_idx, aij_idx) = element;
-                            col_offset++;
-                        }
-                        // Loop over the poloidal offset to a trial b-spline for any elements that
-                        // are to the right of zeros following the elements already set
-                        for (IdxBSTheta idx_trial_theta(first_periodic_idx_trial_theta);
-                             idx_trial_theta < full_idx_range_theta.back() + 1;
-                             ++idx_trial_theta) {
-                            const IdxBSRTheta idx_trial(idx_trial_r, idx_trial_theta);
-                            double element = get_matrix_stencil_element(
-                                    team,
-                                    idx_test,
-                                    idx_trial,
-                                    coeff_alpha,
-                                    coeff_beta,
-                                    spline_evaluator,
-                                    mapping,
-                                    full_quad_idx_range,
-                                    int_volume_proxy);
-                            const int aij_idx = nnz_per_row_csr(row_idx) + col_offset;
-                            values_csr(batch_idx, aij_idx) = element;
-                            col_offset++;
-                        }
+                    // Loop over the poloidal offset to a trial b-spline
+                    for (int col_nnz_idx = nnz_per_row_csr[row_idx] + first_col_idx;
+                         col_nnz_idx < nnz_per_row_csr[row_idx + 1];
+                         ++col_nnz_idx) {
+                        int const col_idx = col_idx_csr[col_nnz_idx];
+                        IdxBSPolar const idx_trial_polar = idxrange_singular.front() + col_idx;
+                        const IdxBSRTheta idx_trial
+                                = PolarBSplinesRTheta::get_2d_index(idx_trial_polar);
+                        double element = get_matrix_stencil_element(
+                                team,
+                                idx_test,
+                                idx_trial,
+                                coeff_alpha,
+                                coeff_beta,
+                                spline_evaluator,
+                                mapping,
+                                full_quad_idx_range,
+                                int_volume_proxy);
+                        values_csr(batch_idx, col_nnz_idx) = element;
                     }
                 });
 

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -1026,9 +1026,6 @@ public:
         IdxRangeBSR central_radial_bspline_idx_range(
                 m_idxrange_bsplines_r.take_first(IdxStep<BSplinesR> {BSplinesR::degree()}));
 
-        IdxRangeBSR idx_range_fem_r = ddc::discrete_space<BSplinesR>().full_domain().remove_first(
-                IdxStepBSR(PolarBSplinesRTheta::continuity + 1));
-
         IdxBSPolar idxrange_fem_non_singular_front = m_idxrange_fem_non_singular.front();
 
         DField<IdxRangeQuadratureRTheta> int_volume_proxy = m_int_volume;

--- a/src/pde_solvers/polarpoissonlikeassembler.hpp
+++ b/src/pde_solvers/polarpoissonlikeassembler.hpp
@@ -1058,14 +1058,14 @@ public:
 
                     // Calculate the row index and the first possible column index
                     int const row_idx = idx_test_polar - idxrange_singular.front();
-                    int const first_col_idx
+                    int const csr_idx_first_stencil_element
                             = n_singular * central_radial_bspline_idx_range.contains(idx_test_r);
 
                     // Loop over the poloidal offset to a trial b-spline
-                    for (int col_nnz_idx = nnz_per_row_csr[row_idx] + first_col_idx;
-                         col_nnz_idx < nnz_per_row_csr[row_idx + 1];
-                         ++col_nnz_idx) {
-                        int const col_idx = col_idx_csr[col_nnz_idx];
+                    for (int csr_idx = nnz_per_row_csr[row_idx] + csr_idx_first_stencil_element;
+                         csr_idx < nnz_per_row_csr[row_idx + 1];
+                         ++csr_idx) {
+                        int const col_idx = col_idx_csr[csr_idx];
                         IdxBSPolar const idx_trial_polar = idxrange_singular.front() + col_idx;
                         const IdxBSRTheta idx_trial
                                 = PolarBSplinesRTheta::get_2d_index(idx_trial_polar);
@@ -1079,7 +1079,7 @@ public:
                                 mapping,
                                 full_quad_idx_range,
                                 int_volume_proxy);
-                        values_csr(batch_idx, col_nnz_idx) = element;
+                        values_csr(batch_idx, csr_idx) = element;
                     }
                 });
 

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -326,16 +326,18 @@ public:
                 QDimRMesh,
                 QDimThetaMesh>;
         PoissonAssembler assembler(get_field(m_int_volume_alloc));
+        assembler.setup_sparse_matrix(
+                m_gko_matrix,
+                max_iter,
+                res_tol,
+                batch_solver_logger,
+                preconditioner_max_block_size);
         assembler(
                 m_gko_matrix,
                 coeff_alpha,
                 coeff_beta,
                 mapping,
-                spline_evaluator,
-                max_iter,
-                res_tol,
-                batch_solver_logger,
-                preconditioner_max_block_size);
+                spline_evaluator);
     }
 
     /**

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -26,6 +26,8 @@
  * @tparam PolarBSplinesRTheta The type of the 2D polar B-splines (on the coordinate
  *          system @f$(r,\theta)@f$ including B-splines which traverse the O point).
  * @tparam SplineRThetaEvaluatorNullBound The type of the 2D (cross-product) spline evaluator.
+ * @tparam Mapping The type of the mapping from the logical domain to the physical domain where
+ *          the equation is defined.
  * @tparam IdxRangeFull The full index range of @f$ \phi @f$ including any batch dimensions.
  */
 template <

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -33,6 +33,7 @@ template <
         class GridTheta,
         class PolarBSplinesRTheta,
         class SplineRThetaEvaluatorNullBound,
+        class Mapping,
         class IdxRangeFull = IdxRange<GridR, GridTheta>>
 class PolarSplineFEMPoissonLikeSolver
 {
@@ -154,6 +155,20 @@ private:
     using CoordFieldRTheta = Field<CoordRTheta, IdxRangeRTheta>;
     using DFieldRTheta = DField<IdxRangeRTheta>;
 
+    using PoissonAssembler = PolarSplineFEMPoissonLikeAssembler<
+            GridR,
+            GridTheta,
+            PolarBSplinesRTheta,
+            SplineRThetaEvaluatorNullBound,
+            QDimRMesh,
+            QDimThetaMesh>;
+
+    using PolarSplineEval = PolarSplineEvaluator<
+            Kokkos::DefaultExecutionSpace,
+            Kokkos::DefaultExecutionSpace::memory_space,
+            PolarBSplinesRTheta,
+            ddc::NullExtrapolationRule>;
+
 public:
     // TODO: Are these types needed?
     /**
@@ -205,20 +220,20 @@ private:
     IdxRangeQuadratureRTheta m_idxrange_quadrature_singular;
     IdxRangeQuadratureRTheta m_idxrange_quadrature;
 
-    FieldMem<double, IdxRangeQuadratureRTheta> m_int_volume_alloc;
+    Mapping m_mapping;
+    SplineRThetaEvaluatorNullBound m_spline_evaluator;
 
-    PolarSplineEvaluator<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            PolarBSplinesRTheta,
-            ddc::NullExtrapolationRule>
-            m_polar_spline_evaluator;
+    PolarSplineEval m_polar_spline_evaluator;
     std::unique_ptr<MatrixBatchCsr<Kokkos::DefaultExecutionSpace, MatrixBatchCsrSolver::CG>>
             m_gko_matrix;
     mutable PolarSplineMemRTheta m_phi_spline_coef_alloc;
     mutable DFieldMem<IdxRange<InternalBatchDim, PolarBSplinesRTheta>> m_x_init_alloc;
 
     const int m_batch_idx {0}; // TODO: Remove when batching is supported
+
+    FieldMem<double, IdxRangeQuadratureRTheta> m_int_volume_alloc;
+    PoissonAssembler m_assembler;
+
 public:
     /**
      * @brief Instantiate a polar Poisson-like solver using FEM with B-splines.
@@ -229,12 +244,6 @@ public:
      *
      *  @f$  \phi = 0 @f$, on  @f$ \partial \Omega@f$.
      *
-     * @param[in] coeff_alpha
-     *      The spline representation of the @f$ \alpha @f$ function in the
-     *      definition of the Poisson-like equation.
-     * @param[in] coeff_beta
-     *      The spline representation of the  @f$ \beta @f$ function in the
-     *      definition of the Poisson-like equation.
      * @param[in] mapping
      *      The mapping from the logical domain to the physical domain where
      *      the equation is defined.
@@ -253,10 +262,7 @@ public:
      *
      * @tparam Mapping A class describing a mapping from curvilinear coordinates to Cartesian coordinates.
      */
-    template <class Mapping>
     PolarSplineFEMPoissonLikeSolver(
-            ConstSpline2D coeff_alpha,
-            ConstSpline2D coeff_beta,
             Mapping const& mapping,
             SplineRThetaEvaluatorNullBound const& spline_evaluator,
             std::optional<int> max_iter = std::nullopt,
@@ -284,6 +290,8 @@ public:
                           IdxStep<QDimRMesh> {m_n_overlap_cells * s_n_gauss_legendre_r}),
                   m_idxrange_quadrature_theta)
         , m_idxrange_quadrature(m_idxrange_quadrature_r, m_idxrange_quadrature_theta)
+        , m_mapping(mapping)
+        , m_spline_evaluator(spline_evaluator)
         , m_polar_spline_evaluator(ddc::NullExtrapolationRule())
         , m_phi_spline_coef_alloc(ddc::discrete_space<PolarBSplinesRTheta>().full_domain())
         , m_x_init_alloc(
@@ -294,50 +302,33 @@ public:
                                   1,
                                   ddc::discrete_space<PolarBSplinesRTheta>().nbasis()
                                           - ddc::discrete_space<BSplinesTheta>().nbasis())))
+        , m_int_volume_alloc(calculate_int_volume(mapping))
+        , m_assembler(get_field(m_int_volume_alloc))
     {
         static_assert(has_jacobian_v<Mapping>);
         //initialise x_init
         ddc::parallel_fill(get_field(m_x_init_alloc), 0);
-        // Get break points
-        IdxRange<KnotsR> idxrange_r_edges = ddc::discrete_space<BSplinesR>().break_point_domain();
-        IdxRange<KnotsTheta> idxrange_theta_edges
-                = ddc::discrete_space<BSplinesTheta>().break_point_domain();
-        host_t<FieldMem<Coord<R>, IdxRange<KnotsR>>> breaks_r(idxrange_r_edges);
-        host_t<FieldMem<Coord<Theta>, IdxRange<KnotsTheta>>> breaks_theta(idxrange_theta_edges);
 
-        ddcHelper::dump_coordinates(Kokkos::DefaultHostExecutionSpace(), get_field(breaks_r));
-        ddcHelper::dump_coordinates(Kokkos::DefaultHostExecutionSpace(), get_field(breaks_theta));
-
-        // Define quadrature points and weights
-        GaussLegendre<QDimRMesh, s_n_gauss_legendre_r> gl_coeffs_r(get_const_field(breaks_r));
-        GaussLegendre<QDimThetaMesh, s_n_gauss_legendre_theta> gl_coeffs_theta(
-                get_const_field(breaks_theta));
-        m_int_volume_alloc = compute_coeffs_on_mapping(
-                Kokkos::DefaultExecutionSpace(),
-                mapping,
-                gauss_legendre_quadrature_coefficients<
-                        Kokkos::DefaultExecutionSpace>(gl_coeffs_r, gl_coeffs_theta));
-
-        using PoissonAssembler = PolarSplineFEMPoissonLikeAssembler<
-                GridR,
-                GridTheta,
-                PolarBSplinesRTheta,
-                SplineRThetaEvaluatorNullBound,
-                QDimRMesh,
-                QDimThetaMesh>;
-        PoissonAssembler assembler(get_field(m_int_volume_alloc));
-        assembler.setup_sparse_matrix(
+        m_assembler.setup_sparse_matrix(
                 m_gko_matrix,
                 max_iter,
                 res_tol,
                 batch_solver_logger,
                 preconditioner_max_block_size);
-        assembler(
-                m_gko_matrix,
-                coeff_alpha,
-                coeff_beta,
-                mapping,
-                spline_evaluator);
+    }
+
+    /**
+     * @brief Update the coefficients @f$ alpha @f$ and @f$ beta @f$ that define the equation.
+     * @param[in] coeff_alpha
+     *      The spline representation of the @f$ \alpha @f$ function in the
+     *      definition of the Poisson-like equation.
+     * @param[in] coeff_beta
+     *      The spline representation of the  @f$ \beta @f$ function in the
+     *      definition of the Poisson-like equation.
+     */
+    void update_coefficients(ConstSpline2D coeff_alpha, ConstSpline2D coeff_beta)
+    {
+        m_assembler(m_gko_matrix, coeff_alpha, coeff_beta, m_mapping, m_spline_evaluator);
     }
 
     /**
@@ -538,5 +529,29 @@ public:
         detail_poisson::
                 get_polar_bspline_vals_and_derivs<PolarBSplinesRTheta, false>(val, coord, idx);
         return val;
+    }
+
+private:
+    static FieldMem<double, IdxRangeQuadratureRTheta> calculate_int_volume(Mapping const& mapping)
+    {
+        // Get break points
+        IdxRange<KnotsR> idxrange_r_edges = ddc::discrete_space<BSplinesR>().break_point_domain();
+        IdxRange<KnotsTheta> idxrange_theta_edges
+                = ddc::discrete_space<BSplinesTheta>().break_point_domain();
+        host_t<FieldMem<Coord<R>, IdxRange<KnotsR>>> breaks_r(idxrange_r_edges);
+        host_t<FieldMem<Coord<Theta>, IdxRange<KnotsTheta>>> breaks_theta(idxrange_theta_edges);
+
+        ddcHelper::dump_coordinates(Kokkos::DefaultHostExecutionSpace(), get_field(breaks_r));
+        ddcHelper::dump_coordinates(Kokkos::DefaultHostExecutionSpace(), get_field(breaks_theta));
+
+        // Define quadrature points and weights
+        GaussLegendre<QDimRMesh, s_n_gauss_legendre_r> gl_coeffs_r(get_const_field(breaks_r));
+        GaussLegendre<QDimThetaMesh, s_n_gauss_legendre_theta> gl_coeffs_theta(
+                get_const_field(breaks_theta));
+        return compute_coeffs_on_mapping(
+                Kokkos::DefaultExecutionSpace(),
+                mapping,
+                gauss_legendre_quadrature_coefficients<
+                        Kokkos::DefaultExecutionSpace>(gl_coeffs_r, gl_coeffs_theta));
     }
 };

--- a/src/pde_solvers/polarpoissonlikesolver.hpp
+++ b/src/pde_solvers/polarpoissonlikesolver.hpp
@@ -169,32 +169,6 @@ private:
             PolarBSplinesRTheta,
             ddc::NullExtrapolationRule>;
 
-public:
-    // TODO: Are these types needed?
-    /**
-    * @brief Object storing a value and a value of the derivative
-    * of a 1D function.
-    */
-    struct EvalDeriv1DType
-    {
-        /// The value of the function @f$f(x)@f$.
-        double value;
-        /// The derivative of the function @f$\partial_x f(x)@f$.
-        double derivative;
-    };
-
-    /**
-    * @brief Object storing a value and a value of the derivatives
-    * in each direction of a 2D function.
-    */
-    struct EvalDeriv2DType
-    {
-        /// The value of the function @f$f(r, \theta)@f$.
-        double value;
-        /// The gradient of the function @f$\nabla f(r, \theta)@f$.
-        DVector<R_cov, Theta_cov> derivative;
-    };
-
 private:
     static constexpr int s_n_gauss_legendre_r = BSplinesR::degree() + 1;
     static constexpr int s_n_gauss_legendre_theta = BSplinesTheta::degree() + 1;

--- a/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/polarpoissonfemsolver.cpp
@@ -22,13 +22,6 @@
 #include "spline_definitions_r_theta.hpp"
 #include "test_cases.hpp"
 
-
-using PoissonSolver = PolarSplineFEMPoissonLikeSolver<
-        GridR,
-        GridTheta,
-        PolarBSplinesRTheta,
-        SplineRThetaEvaluatorNullBound>;
-
 #if defined(CIRCULAR_MAPPING)
 using Mapping = CircularToCartesian<R, Theta, X, Y>;
 #elif defined(CZARNY_MAPPING)
@@ -42,6 +35,13 @@ using DiscreteMappingBuilder_host = DiscreteToCartesianBuilder<
         Y,
         SplineRThetaBuilder_host,
         SplineRThetaEvaluatorNullBound_host>;
+
+using PoissonSolver = PolarSplineFEMPoissonLikeSolver<
+        GridR,
+        GridTheta,
+        PolarBSplinesRTheta,
+        SplineRThetaEvaluatorNullBound,
+        typename DiscreteMappingBuilder::MappingType>;
 
 #if defined(CURVILINEAR_SOLUTION)
 using LHSFunction = CurvilinearSolution<Mapping>;
@@ -175,11 +175,11 @@ int main(int argc, char** argv)
               << "ms" << std::endl;
     start_time = std::chrono::system_clock::now();
 
-    PoissonSolver
-            solver(get_const_field(coeff_alpha_spline),
-                   get_const_field(coeff_beta_spline),
-                   discrete_mapping,
-                   evaluator);
+    PoissonSolver solver(discrete_mapping, evaluator);
+
+    solver.update_coefficients(
+            get_const_field(coeff_alpha_spline),
+            get_const_field(coeff_beta_spline));
 
     end_time = std::chrono::system_clock::now();
     std::cout << "Poisson initialisation time : "


### PR DESCRIPTION
Split coefficient calculation from sparsity pattern calculation in polar Poisson-like solver. Remove unused structures `EvalDeriv1D`, `EvalDeriv2D`. This is an important step to support #425 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
