### PR TITLE
Remove DDC submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = vendor/googletest
 	url = https://github.com/google/googletest.git
 	branch = master
-[submodule "vendor/ddc"]
-	path = vendor/ddc
-	url = https://github.com/CExA-project/ddc.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed the name of class `SplineBuliderDerivField2D` to fix typo (->`SplineBuilderDerivField2D`).
+- Update DDC to [v0.12.0](https://github.com/CExA-project/ddc/releases/tag/v0.12.0).
+- Changed FindLAPACKE CMake module to the version in DDC.
 
 ### Deprecated
 
 ### Removed
+
+- Remove DDC submodule.
 
 ## [v0.7.0] - 2026-03-18
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,6 @@ set(GYSELALIBXX_DEPENDENCY_POLICIES "AUTO" "EMBEDDED" "INSTALLED")
 
 set(GYSELALIBXX_INCLUDE_TESTING_DEPENDENCIES ${GYSELALIBXX_BUILD_TESTING} CACHE BOOL "Indicates if the testing dependencies should be included. By default they are only included if the tests are built.")
 
-# Set default DDC options when included in GYSELA
-option(DDC_BUILD_BENCHMARKS       "Build DDC benchmarks." OFF)
-option(DDC_BUILD_EXAMPLES         "Build DDC examples" OFF)
-option(DDC_BUILD_TESTS            "Build DDC tests if BUILD_TESTING is enabled" OFF)
-
 ###############################################################################################
 #                                     Get dependencies
 ###############################################################################################
@@ -89,11 +84,7 @@ find_package(Kokkos 4.4.1...<5 REQUIRED)
 
 find_package(KokkosKernels 4.5.1...<5 REQUIRED)
 
-find_package(DDC 0.11.0 QUIET COMPONENTS fft pdi splines)
-if(NOT "${DDC_FOUND}")
-  ## Use the discrete domain computation library (ddc) from `vendor/`
-  add_subdirectory(vendor/ddc SYSTEM)
-endif()
+find_package(DDC 0.12.0 REQUIRED COMPONENTS fft pdi splines)
 
 find_package(koliop 0.1.2 REQUIRED)
 

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -1,399 +1,186 @@
-# Copyright (C) 2009-2014 The University of Tennessee and The University
-#                          of Tennessee Research Foundation.
-#                          All rights reserved.2015, Wenzel Jakob
-# Copyright (C) 2012-2016 Inria. All rights reserved.
-# Copyright (C) 2012-2014 Bordeaux INP, CNRS (LaBRI UMR 5800), Inria, Univ. Bordeaux. All rights reserved.
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
 #
-# SPDX-License-Identifier: CECILL-C
+# SPDX-License-Identifier: MIT
 
-# - Find LAPACKE include dirs and libraries
-# Use this module by invoking find_package with the form:
-#  find_package(LAPACKE
-#               [REQUIRED] # Fail with error if lapacke is not found
-#               [COMPONENTS <comp1> <comp2> ...] # dependencies
-#              )
+# FindLAPACKE.cmake
+# ----------------
+# Finds the LAPACKE library (C interface to LAPACK).
 #
-#  LAPACKE depends on the following libraries:
-#   - LAPACK
+# LAPACKE may be bundled inside an existing LAPACK/BLAS provider (e.g.
+# OpenBLAS) or shipped as an independent liblapacke. This module first
+# delegates to CMake's own FindLAPACK to locate the LAPACK libraries, then
+# checks whether LAPACKE symbols are already present in those libraries
+# before falling back to searching for a standalone liblapacke.
 #
-# This module finds headers and lapacke library.
-# Results are reported in variables:
-#  LAPACKE_FOUND            - True if headers and requested libraries were found
-#  LAPACKE_LINKER_FLAGS     - list of required linker flags (excluding -l and -L)
-#  LAPACKE_INCLUDE_DIRS     - lapacke include directories
-#  LAPACKE_LIBRARY_DIRS     - Link directories for lapacke libraries
-#  LAPACKE_LIBRARIES        - lapacke component libraries to be linked
-#  LAPACKE_INCLUDE_DIRS_DEP - lapacke + dependencies include directories
-#  LAPACKE_LIBRARY_DIRS_DEP - lapacke + dependencies link directories
-#  LAPACKE_LIBRARIES_DEP    - lapacke libraries + dependencies
+# The header lapacke.h is always resolved from the shared object that actually
+# provides the LAPACKE symbols, so that the include path and the library stay
+# in sync.
 #
-# The user can give specific paths where to find the libraries adding cmake
-# options at configure (ex: cmake path/to/project -DLAPACKE_DIR=path/to/lapacke):
-#  LAPACKE_DIR             - Where to find the base directory of lapacke
-#  LAPACKE_INCDIR          - Where to find the header files
-#  LAPACKE_LIBDIR          - Where to find the library files
-# The module can also look for the following environment variables if paths
-# are not given as cmake variable: LAPACKE_DIR, LAPACKE_INCDIR, LAPACKE_LIBDIR
+# Imported target
+# ^^^^^^^^^^^^^^^
+#   LAPACKE::LAPACKE
+#     Compile-and-link target. Carries the correct include directory and links
+#     to whichever library (bundled or standalone) provides LAPACKE.
 #
-# LAPACKE could be directly embedded in LAPACK library (ex: Intel MKL) so that
-# we test a lapacke function with the lapack libraries found and set LAPACKE
-# variables to LAPACK ones if test is successful. To skip this feature and
-# look for a stand alone lapacke, please add the following in your
-# CMakeLists.txt before to call find_package(LAPACKE):
-# set(LAPACKE_STANDALONE TRUE)
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#   LAPACKE_FOUND          - TRUE when both the library and the header are found
+#   LAPACKE_LIBRARIES      - Full list of libraries needed to use LAPACKE
+#                            (may re-use LAPACK_LIBRARIES when bundled)
+#   LAPACKE_INCLUDE_DIRS   - Include directory containing lapacke.h
+#
+# Hints
+# ^^^^^
+#   LAPACKE_ROOT / ENV{LAPACKE_ROOT}
+#     Prefix searched first for the standalone library and header.
+#   LAPACK_ROOT / ENV{LAPACK_ROOT}  (also honoured by FindLAPACK)
+#     Prefix for the underlying LAPACK provider.
+#
+# Notes
+# ^^^^^
+# * BLA_VENDOR (see FindLAPACK docs) can be set before find_package(LAPACKE)
+#   to steer which BLAS/LAPACK flavour is considered, e.g.
+#     set(BLA_VENDOR OpenBLAS)
+#     find_package(LAPACKE REQUIRED)
+# * The check_function_exists() probes require try_compile, so the C language
+#   must be enabled in the calling project.
 
-#=============================================================================
-# Copyright 2012-2013 Inria
-# Copyright 2012-2013 Emmanuel Agullo
-# Copyright 2012-2013 Mathieu Faverge
-# Copyright 2012      Cedric Castagnede
-# Copyright 2013-2016 Florent Pruvost
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file MORSE-Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of Morse, substitute the full
-#  License text for the above reference.)
-#
-# This file has been slightly modified by DDC team.
+# Early exit: if a previous call already succeeded, do not redo all the work.
+# LAPACKE_FOUND is cached by find_package_handle_standard_args on success.
+if(LAPACKE_FOUND)
+    return()
+endif()
 
-if (NOT LAPACKE_FOUND)
-  set(LAPACKE_DIR "" CACHE PATH "Installation directory of LAPACKE library")
-  if (NOT LAPACKE_FIND_QUIETLY)
-    message(STATUS "A cache variable, namely LAPACKE_DIR, has been set to specify the install directory of LAPACKE")
-  endif()
+if(CMAKE_VERSION VERSION_LESS "3.25")
+    message(FATAL_ERROR "CMake >= 3.25 required")
+endif()
 
-  # LAPACKE depends on LAPACK anyway, try to find it
-  if (NOT LAPACK_FOUND)
-    if(LAPACKE_FIND_REQUIRED)
-      find_package(LAPACK REQUIRED) # DDC: Compared to original FindLAPACKE.cmake, LAPACKEXT is replaced with LAPACK
-    else()
-      find_package(LAPACK) # DDC: Compared to original FindLAPACKE.cmake, LAPACKEXT is replaced with LAPACK
+include(CheckFunctionExists)
+include(FindPackageHandleStandardArgs)
+
+# ---------------------------------------------------------------------------
+# Step 1 – Locate LAPACK (and its transitive BLAS dependency).
+# ---------------------------------------------------------------------------
+find_package(LAPACK QUIET)
+
+# ---------------------------------------------------------------------------
+# Step 2 – Check whether LAPACKE is already bundled in the LAPACK libraries.
+#
+# OpenBLAS and MKL both ship LAPACKE symbols inside their main library, so
+# we avoid adding a redundant -llapacke in those cases.
+# ---------------------------------------------------------------------------
+set(_lapacke_bundled FALSE)
+
+if(LAPACK_FOUND)
+    # Save/restore CMAKE_REQUIRED_LIBRARIES to avoid polluting the caller's state.
+    # Only LAPACK_LIBRARIES is needed: a correctly built shared library encodes
+    # its BLAS dependency as a DT_NEEDED entry, so the dynamic linker resolves
+    # it without an explicit -lblas flag. Passing BLAS_LIBRARIES here would mask
+    # a liblapack with missing DT_NEEDED entries.
+    set(_saved_req_libs "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_LIBRARIES ${LAPACK_LIBRARIES})
+
+    # LAPACKE_dgetrf (LU factorisation) is a fundamental routine present in
+    # every complete LAPACKE implementation and a reliable probe symbol.
+    check_function_exists(LAPACKE_dgetrf _lapacke_bundled_check)
+
+    set(CMAKE_REQUIRED_LIBRARIES "${_saved_req_libs}")
+    unset(_saved_req_libs)
+
+    if($CACHE{_lapacke_bundled_check})
+        set(_lapacke_bundled TRUE)
+        message(STATUS "FindLAPACKE: LAPACKE symbols found inside LAPACK libraries (bundled)")
     endif()
-  endif()
-
-  # LAPACKE depends on LAPACK
-  if (LAPACK_FOUND)
-
-    if (NOT LAPACKE_STANDALONE)
-      # check if a lapacke function exists in the LAPACK lib
-      include(CheckFunctionExists)
-      set(CMAKE_REQUIRED_LIBRARIES "${LAPACK_LINKER_FLAGS};${LAPACK_LIBRARIES}")
-      unset(LAPACKE_WORKS CACHE)
-      check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
-      mark_as_advanced(LAPACKE_WORKS)
-      set(CMAKE_REQUIRED_LIBRARIES)
-
-      if(LAPACKE_WORKS)
-        if(NOT LAPACKE_FIND_QUIETLY)
-          message(STATUS "Looking for lapacke: test with lapack succeeds")
-        endif()
-        # test succeeds: LAPACKE is in LAPACK
-        set(LAPACKE_LIBRARIES "${LAPACK_LIBRARIES}")
-        set(LAPACKE_LIBRARIES_DEP "${LAPACK_LIBRARIES}")
-        if (LAPACK_LIBRARY_DIRS)
-          set(LAPACKE_LIBRARY_DIRS "${LAPACK_LIBRARY_DIRS}")
-        endif()
-        if(LAPACK_INCLUDE_DIRS)
-          set(LAPACKE_INCLUDE_DIRS "${LAPACK_INCLUDE_DIRS}")
-          set(LAPACKE_INCLUDE_DIRS_DEP "${LAPACK_INCLUDE_DIRS}")
-        endif()
-        if (LAPACK_LINKER_FLAGS)
-          set(LAPACKE_LINKER_FLAGS "${LAPACK_LINKER_FLAGS}")
-        endif()
-      endif()
-    endif (NOT LAPACKE_STANDALONE)
-
-    if (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
-
-      if(NOT LAPACKE_WORKS AND NOT LAPACKE_FIND_QUIETLY)
-        message(STATUS "Looking for lapacke : test with lapack fails")
-      endif()
-      # test fails: try to find LAPACKE lib exterior to LAPACK
-
-      # Try to find LAPACKE lib
-      #######################
-
-      # Looking for include
-      # -------------------
-
-      # Add system include paths to search include
-      # ------------------------------------------
-      unset(_inc_env)
-      set(ENV_LAPACKE_DIR "$ENV{LAPACKE_DIR}")
-      set(ENV_LAPACKE_INCDIR "$ENV{LAPACKE_INCDIR}")
-      if(ENV_LAPACKE_INCDIR)
-        list(APPEND _inc_env "${ENV_LAPACKE_INCDIR}")
-      elseif(ENV_LAPACKE_DIR)
-        list(APPEND _inc_env "${ENV_LAPACKE_DIR}")
-        list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include")
-        list(APPEND _inc_env "${ENV_LAPACKE_DIR}/include/lapacke")
-      else()
-        if(WIN32)
-          string(REPLACE ":" ";" _inc_env "$ENV{INCLUDE}")
-        else()
-          string(REPLACE ":" ";" _path_env "$ENV{INCLUDE}")
-          list(APPEND _inc_env "${_path_env}")
-          string(REPLACE ":" ";" _path_env "$ENV{C_INCLUDE_PATH}")
-          list(APPEND _inc_env "${_path_env}")
-          string(REPLACE ":" ";" _path_env "$ENV{CPATH}")
-          list(APPEND _inc_env "${_path_env}")
-          string(REPLACE ":" ";" _path_env "$ENV{INCLUDE_PATH}")
-          list(APPEND _inc_env "${_path_env}")
-        endif()
-      endif()
-      list(APPEND _inc_env "${CMAKE_PLATFORM_IMPLICIT_INCLUDE_DIRECTORIES}")
-      list(APPEND _inc_env "${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}")
-      list(REMOVE_DUPLICATES _inc_env)
-
-
-      # Try to find the lapacke header in the given paths
-      # -------------------------------------------------
-      # call cmake macro to find the header path
-      if(LAPACKE_INCDIR)
-        set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-        find_path(LAPACKE_lapacke.h_DIRS
-          NAMES lapacke.h
-          HINTS ${LAPACKE_INCDIR})
-      else()
-        if(LAPACKE_DIR)
-          set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-          find_path(LAPACKE_lapacke.h_DIRS
-            NAMES lapacke.h
-            HINTS ${LAPACKE_DIR}
-            PATH_SUFFIXES "include" "include/lapacke")
-        else()
-          set(LAPACKE_lapacke.h_DIRS "LAPACKE_lapacke.h_DIRS-NOTFOUND")
-          find_path(LAPACKE_lapacke.h_DIRS
-            NAMES lapacke.h
-            HINTS ${_inc_env})
-        endif()
-      endif()
-      mark_as_advanced(LAPACKE_lapacke.h_DIRS)
-
-      # If found, add path to cmake variable
-      # ------------------------------------
-      if (LAPACKE_lapacke.h_DIRS)
-        set(LAPACKE_INCLUDE_DIRS "${LAPACKE_lapacke.h_DIRS}")
-      else ()
-        set(LAPACKE_INCLUDE_DIRS "LAPACKE_INCLUDE_DIRS-NOTFOUND")
-        if(NOT LAPACKE_FIND_QUIETLY)
-          message(STATUS "Looking for lapacke -- lapacke.h not found")
-        endif()
-      endif()
-
-
-      # Looking for lib
-      # ---------------
-
-      # Add system library paths to search lib
-      # --------------------------------------
-      unset(_lib_env)
-      set(ENV_LAPACKE_LIBDIR "$ENV{LAPACKE_LIBDIR}")
-      if(ENV_LAPACKE_LIBDIR)
-        list(APPEND _lib_env "${ENV_LAPACKE_LIBDIR}")
-      elseif(ENV_LAPACKE_DIR)
-        list(APPEND _lib_env "${ENV_LAPACKE_DIR}")
-        list(APPEND _lib_env "${ENV_LAPACKE_DIR}/lib")
-      else()
-        if(WIN32)
-          string(REPLACE ":" ";" _lib_env "$ENV{LIB}")
-        else()
-          if(APPLE)
-            string(REPLACE ":" ";" _lib_env "$ENV{DYLD_LIBRARY_PATH}")
-          else()
-            string(REPLACE ":" ";" _lib_env "$ENV{LD_LIBRARY_PATH}")
-          endif()
-          list(APPEND _lib_env "${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES}")
-          list(APPEND _lib_env "${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
-        endif()
-      endif()
-      list(REMOVE_DUPLICATES _lib_env)
-
-      # Try to find the lapacke lib in the given paths
-      # ----------------------------------------------
-
-      # call cmake macro to find the lib path
-      if(LAPACKE_LIBDIR)
-        set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-        find_library(LAPACKE_lapacke_LIBRARY
-          NAMES lapacke
-          HINTS ${LAPACKE_LIBDIR})
-      else()
-        if(LAPACKE_DIR)
-          set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-          find_library(LAPACKE_lapacke_LIBRARY
-            NAMES lapacke
-            HINTS ${LAPACKE_DIR}
-            PATH_SUFFIXES lib lib32 lib64)
-        else()
-          set(LAPACKE_lapacke_LIBRARY "LAPACKE_lapacke_LIBRARY-NOTFOUND")
-          find_library(LAPACKE_lapacke_LIBRARY
-            NAMES lapacke
-            HINTS ${_lib_env})
-        endif()
-      endif()
-      mark_as_advanced(LAPACKE_lapacke_LIBRARY)
-
-      # If found, add path to cmake variable
-      # ------------------------------------
-      if (LAPACKE_lapacke_LIBRARY)
-        get_filename_component(lapacke_lib_path "${LAPACKE_lapacke_LIBRARY}" PATH)
-        # set cmake variables
-        set(LAPACKE_LIBRARIES    "${LAPACKE_lapacke_LIBRARY}")
-        set(LAPACKE_LIBRARY_DIRS "${lapacke_lib_path}")
-      else ()
-        set(LAPACKE_LIBRARIES    "LAPACKE_LIBRARIES-NOTFOUND")
-        set(LAPACKE_LIBRARY_DIRS "LAPACKE_LIBRARY_DIRS-NOTFOUND")
-        if (NOT LAPACKE_FIND_QUIETLY)
-          message(STATUS "Looking for lapacke -- lib lapacke not found")
-        endif()
-      endif ()
-
-      # check a function to validate the find
-      if(LAPACKE_LIBRARIES)
-
-        set(REQUIRED_LDFLAGS)
-        set(REQUIRED_INCDIRS)
-        set(REQUIRED_LIBDIRS)
-        set(REQUIRED_LIBS)
-
-        # LAPACKE
-        if (LAPACKE_INCLUDE_DIRS)
-          set(REQUIRED_INCDIRS "${LAPACKE_INCLUDE_DIRS}")
-        endif()
-        if (LAPACKE_LIBRARY_DIRS)
-          set(REQUIRED_LIBDIRS "${LAPACKE_LIBRARY_DIRS}")
-        endif()
-        set(REQUIRED_LIBS "${LAPACKE_LIBRARIES}")
-        # LAPACK
-        if (LAPACK_INCLUDE_DIRS)
-          list(APPEND REQUIRED_INCDIRS "${LAPACK_INCLUDE_DIRS}")
-        endif()
-        if (LAPACK_LIBRARY_DIRS)
-          list(APPEND REQUIRED_LIBDIRS "${LAPACK_LIBRARY_DIRS}")
-        endif()
-        list(APPEND REQUIRED_LIBS "${LAPACK_LIBRARIES}")
-        if (LAPACK_LINKER_FLAGS)
-          list(APPEND REQUIRED_LDFLAGS "${LAPACK_LINKER_FLAGS}")
-        endif()
-        # Fortran
-        if (CMAKE_C_COMPILER_ID MATCHES "GNU")
-          find_library(
-            FORTRAN_gfortran_LIBRARY
-            NAMES gfortran
-            HINTS ${_lib_env}
-            )
-          mark_as_advanced(FORTRAN_gfortran_LIBRARY)
-          if (FORTRAN_gfortran_LIBRARY)
-            list(APPEND REQUIRED_LIBS "${FORTRAN_gfortran_LIBRARY}")
-          endif()
-        elseif (CMAKE_C_COMPILER_ID MATCHES "Intel")
-          find_library(
-            FORTRAN_ifcore_LIBRARY
-            NAMES ifcore
-            HINTS ${_lib_env}
-            )
-          mark_as_advanced(FORTRAN_ifcore_LIBRARY)
-          if (FORTRAN_ifcore_LIBRARY)
-            list(APPEND REQUIRED_LIBS "${FORTRAN_ifcore_LIBRARY}")
-          endif()
-        endif()
-        # m
-        find_library(M_LIBRARY NAMES m HINTS ${_lib_env})
-        mark_as_advanced(M_LIBRARY)
-        if(M_LIBRARY)
-          list(APPEND REQUIRED_LIBS "-lm")
-        endif()
-        # set required libraries for link
-        set(CMAKE_REQUIRED_INCLUDES "${REQUIRED_INCDIRS}")
-        set(CMAKE_REQUIRED_LIBRARIES)
-        list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LDFLAGS}")
-        foreach(lib_dir ${REQUIRED_LIBDIRS})
-          list(APPEND CMAKE_REQUIRED_LIBRARIES "-L${lib_dir}")
-        endforeach()
-        list(APPEND CMAKE_REQUIRED_LIBRARIES "${REQUIRED_LIBS}")
-        string(REGEX REPLACE "^ -" "-" CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
-
-        # test link
-        unset(LAPACKE_WORKS CACHE)
-        include(CheckFunctionExists)
-        check_function_exists(LAPACKE_dgeqrf LAPACKE_WORKS)
-        mark_as_advanced(LAPACKE_WORKS)
-
-        if(LAPACKE_WORKS)
-          # save link with dependencies
-          set(LAPACKE_LIBRARIES_DEP "${REQUIRED_LIBS}")
-          set(LAPACKE_LIBRARY_DIRS_DEP "${REQUIRED_LIBDIRS}")
-          set(LAPACKE_INCLUDE_DIRS_DEP "${REQUIRED_INCDIRS}")
-          set(LAPACKE_LINKER_FLAGS "${REQUIRED_LDFLAGS}")
-          list(REMOVE_DUPLICATES LAPACKE_LIBRARY_DIRS_DEP)
-          list(REMOVE_DUPLICATES LAPACKE_INCLUDE_DIRS_DEP)
-          list(REMOVE_DUPLICATES LAPACKE_LINKER_FLAGS)
-        else()
-          if(NOT LAPACKE_FIND_QUIETLY)
-            message(STATUS "Looking for lapacke: test of LAPACKE_dgeqrf with lapacke and lapack libraries fails")
-            message(STATUS "CMAKE_REQUIRED_LIBRARIES: ${CMAKE_REQUIRED_LIBRARIES}")
-            message(STATUS "CMAKE_REQUIRED_INCLUDES: ${CMAKE_REQUIRED_INCLUDES}")
-            message(STATUS "Check in CMakeFiles/CMakeError.log to figure out why it fails")
-          endif()
-        endif()
-        set(CMAKE_REQUIRED_INCLUDES)
-        set(CMAKE_REQUIRED_FLAGS)
-        set(CMAKE_REQUIRED_LIBRARIES)
-      endif(LAPACKE_LIBRARIES)
-
-    endif (LAPACKE_STANDALONE OR NOT LAPACKE_WORKS)
-
-  else(LAPACK_FOUND)
-
-    if (NOT LAPACKE_FIND_QUIETLY)
-      message(FATAL_ERROR "LAPACKE requires LAPACK but LAPACK has not been found."
-        "Please look for LAPACK first.")
-    endif()
-
-  endif(LAPACK_FOUND)
-
-  if (LAPACKE_LIBRARIES)
-    list(GET LAPACKE_LIBRARIES 0 first_lib)
-    get_filename_component(first_lib_path "${first_lib}" PATH)
-    if (${first_lib_path} MATCHES "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)")
-      string(REGEX REPLACE "(/lib(32|64)?$)|(/lib/intel64$|/lib/ia32$)" "" not_cached_dir "${first_lib_path}")
-      set(LAPACKE_DIR_FOUND "${not_cached_dir}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
-    else()
-      set(LAPACKE_DIR_FOUND "${first_lib_path}" CACHE PATH "Installation directory of LAPACKE library" FORCE)
-    endif()
-  endif()
-  mark_as_advanced(LAPACKE_DIR)
-  mark_as_advanced(LAPACKE_DIR_FOUND)
-
-  # check that LAPACKE has been found
-  # ---------------------------------
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(LAPACKE DEFAULT_MSG
-    LAPACKE_LIBRARIES
-    LAPACKE_WORKS)
 
 endif()
 
-# Create target after LAPACKE_FOUND test to create target from LAPACKE found by DDC
-if (NOT TARGET LAPACKE::LAPACKE)
-  add_library(LAPACKE::LAPACKE UNKNOWN IMPORTED)
-  set_target_properties(LAPACKE::LAPACKE PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${LAPACKE_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${LAPACKE_LIBRARIES}"
-  )
+# ---------------------------------------------------------------------------
+# Step 3 – If not bundled, search for a standalone liblapacke.
+# ---------------------------------------------------------------------------
+if(NOT _lapacke_bundled)
+    find_library(LAPACKE_LIBRARY
+        NAMES lapacke
+        HINTS
+            "${LAPACKE_ROOT}"
+            ENV LAPACKE_ROOT
+            "${LAPACK_ROOT}"
+            ENV LAPACK_ROOT
+        PATH_SUFFIXES lib lib64 lib/x86_64-linux-gnu lib/aarch64-linux-gnu
+    )
 
-  foreach(lib IN LISTS LAPACKE_LIBRARIES)
-    if(IS_ABSOLUTE "${lib}")
-      set_target_properties(LAPACKE::LAPACKE PROPERTIES
-          IMPORTED_LOCATION "${lib}"
-      )
-      break()
+    if(LAPACKE_LIBRARY)
+        # Verify the symbols are really there (guards against empty stub libs).
+        # Only liblapacke itself is needed: a correctly built shared library
+        # encodes its LAPACK/BLAS dependencies as DT_NEEDED entries, so the
+        # dynamic linker resolves them without explicit -llapack/-lblas flags.
+        # Passing them here would mask a liblapacke with missing DT_NEEDED.
+        set(_saved_req_libs "${CMAKE_REQUIRED_LIBRARIES}")
+        set(CMAKE_REQUIRED_LIBRARIES "${LAPACKE_LIBRARY}")
+
+        check_function_exists(LAPACKE_dgetrf _lapacke_standalone_check)
+
+        set(CMAKE_REQUIRED_LIBRARIES "${_saved_req_libs}")
+        unset(_saved_req_libs)
+
+        if($CACHE{_lapacke_standalone_check})
+            message(STATUS "FindLAPACKE: found standalone LAPACKE library: ${LAPACKE_LIBRARY}")
+        else()
+            message(WARNING "FindLAPACKE: liblapacke found at ${LAPACKE_LIBRARY} "
+                            "but LAPACKE_dgetrf is not resolvable — ignoring.")
+            unset(LAPACKE_LIBRARY CACHE)
+        endif()
     endif()
-  endforeach()
 endif()
+
+# ---------------------------------------------------------------------------
+# Step 4 – Locate lapacke.h from the library that provides the symbols.
+# ---------------------------------------------------------------------------
+# Prefer an explicit hint, then probe near the providing library.
+find_path(LAPACKE_INCLUDE_DIR
+    NAMES lapacke.h
+    HINTS
+        "${LAPACKE_ROOT}"
+        ENV LAPACKE_ROOT
+        "${LAPACK_ROOT}"
+        ENV LAPACK_ROOT
+    PATH_SUFFIXES include include/openblas include/lapacke include/lapack
+)
+
+# ---------------------------------------------------------------------------
+# Step 5 – Assemble result variables.
+# ---------------------------------------------------------------------------
+if(_lapacke_bundled)
+    # All required symbols live in LAPACK_LIBRARIES; no extra -l needed.
+    set(LAPACKE_LIBRARIES ${LAPACK_LIBRARIES})
+elseif(LAPACKE_LIBRARY)
+    # Standalone: prepend liblapacke, keep LAPACK/BLAS for transitive deps.
+    set(LAPACKE_LIBRARIES ${LAPACKE_LIBRARY} ${LAPACK_LIBRARIES})
+else()
+    set(LAPACKE_LIBRARIES "")
+endif()
+
+set(LAPACKE_INCLUDE_DIRS "${LAPACKE_INCLUDE_DIR}")
+
+# ---------------------------------------------------------------------------
+# Step 6 – Standard "found" handling.
+# ---------------------------------------------------------------------------
+find_package_handle_standard_args(LAPACKE
+    REQUIRED_VARS
+        LAPACKE_LIBRARIES
+        LAPACKE_INCLUDE_DIRS
+    REASON_FAILURE_MESSAGE
+        "Could not find LAPACKE. Set LAPACKE_ROOT or BLA_VENDOR to guide the search."
+)
+
+# ---------------------------------------------------------------------------
+# Step 7 – Create the imported target.
+# ---------------------------------------------------------------------------
+if(LAPACKE_FOUND AND NOT TARGET LAPACKE::LAPACKE)
+    add_library(LAPACKE::LAPACKE INTERFACE IMPORTED)
+    set_target_properties(LAPACKE::LAPACKE PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LAPACKE_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES      "${LAPACKE_LIBRARIES}"
+    )
+endif()
+
+unset(_lapacke_bundled)

--- a/docker/gyselalibxx_env/Dockerfile
+++ b/docker/gyselalibxx_env/Dockerfile
@@ -58,7 +58,7 @@ RUN chmod +x /bin/bash_run \
  && git clone --branch 4.7.01 --depth 1 https://github.com/kokkos/kokkos-kernels.git \
  && git clone --branch develop --depth 1 https://github.com/kokkos/kokkos-tools.git \
  && git clone --branch v0.1.2 --depth 1 https://gitlab.com/cines/code.gysela/libkoliop \
- && git clone --branch v0.11.0 --depth 1 https://github.com/CExA-project/ddc.git \
+ && git clone --branch v0.12.0 --depth 1 https://github.com/CExA-project/ddc.git \
  && export Kokkos_ROOT=/opt/serial/Kokkos \
  && export KokkosFFT_ROOT=/opt/serial/KokkosFFT \
  && export KokkosKernels_ROOT=/opt/serial/KokkosKernels \

--- a/toolchains/a100.raven.spack/environment.sh
+++ b/toolchains/a100.raven.spack/environment.sh
@@ -22,10 +22,10 @@ eval -- "$(
         --env gyselalibxx-spack-environment \
         load --sh \
         cmake \
+        ddc \
         ginkgo \
         googletest \
         kokkos \
-        kokkos-fft \
         kokkos-kernels \
         kokkos-tools \
         koliop \
@@ -56,5 +56,3 @@ module load gcc/14
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
-
-export GYSELALIBXX_OPENBLAS_ROOT="$(spack location -i openblas)"

--- a/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
@@ -2,10 +2,10 @@ spack:
   definitions:
   - packages:
     - cmake
+    - 'ddc@0.12 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +cuda cuda_arch=80
     - googletest +gmock
     - kokkos@4.7 ~openmp +cuda +cuda_relocatable_device_code +cuda_constexpr cuda_arch=80
-    - kokkos-fft@0.4 host_backend=fftw-serial device_backend=cufft
     - kokkos-kernels@4.7 ~shared
     - kokkos-tools
     - 'koliop@0.1.2:0.1'
@@ -63,14 +63,15 @@ spack:
       require: gcc@14.1.0
     gcc:
       externals:
-      - spec: gcc@14.1.0 
+      - spec: gcc@14.1.0
         prefix: /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0
         extra_attributes:
           compilers:
             c: /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0/bin/gcc
             cxx: /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0/bin/g++
             fortran: /mpcdf/soft/SLE_15/packages/x86_64/gcc/14.1.0/bin/gfortran
-
+    kokkos-fft:
+      require: '@0.4 host_backend=fftw-serial device_backend=cufft'
     lapack:
       require: openblas
     mpi:

--- a/toolchains/a100.raven.spack/toolchain.cmake
+++ b/toolchains/a100.raven.spack/toolchain.cmake
@@ -9,7 +9,6 @@ set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra")
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")
 
 # Gyselalibxx options
 set(GYSELALIBXX_DEFAULT_CXX_FLAGS "" CACHE STRING "Default flags for C++ specific to Gyselalib++" FORCE)

--- a/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
+++ b/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
@@ -4,10 +4,10 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.30'
+    - 'ddc@0.12 +fft +pdi +splines'
     - 'ginkgo@1.9'
     - 'googletest@1.14 +gmock'
     - 'kokkos@4.7 +serial'
-    - 'kokkos-fft@0.4 host_backend=fftw-serial'
     - 'kokkos-kernels@4.7'
     - 'kokkos-tools'
     - 'koliop@0.1.2:0.1'
@@ -48,6 +48,8 @@ spack:
       variants: ~fortran ~mpi ~openmp cxxstd=17
     blas:
       require: openblas@0.3
+    kokkos-fft:
+      require: '@0.4 host_backend=fftw-serial'
     lapack:
       require: openblas@0.3
     mpi:

--- a/toolchains/genoa.gcc.adastra.spack/environment.sh
+++ b/toolchains/genoa.gcc.adastra.spack/environment.sh
@@ -70,5 +70,3 @@ eval -- "$(
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
-
-export GYSELALIBXX_OPENBLAS_ROOT="$(spack location -i openblas)"

--- a/toolchains/genoa.gcc.adastra.spack/environment.sh
+++ b/toolchains/genoa.gcc.adastra.spack/environment.sh
@@ -37,11 +37,11 @@ eval -- "$(
         --env gyselalibxx-spack-environment \
         load --sh \
         cmake \
+        ddc \
         gcc \
         ginkgo \
         googletest \
         kokkos \
-        kokkos-fft \
         kokkos-kernels \
         kokkos-tools \
         koliop \

--- a/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -2,10 +2,10 @@ spack:
   definitions:
   - packages:
     - cmake
+    - 'ddc@0.12 +fft +pdi +splines'
     - ginkgo@1.9 +openmp
     - googletest +gmock
     - kokkos@4.7 +openmp
-    - kokkos-fft@0.4 host_backend=fftw-openmp
     - kokkos-kernels@4.7
     - kokkos-tools
     - 'koliop@0.1.2:0.1'
@@ -59,6 +59,8 @@ spack:
       require: gcc@13.2.1
     cxx:
       require: gcc@13.2.1
+    kokkos-fft:
+      require: '@0.4 host_backend=fftw-openmp'
     lapack:
       require: openblas
     mpi:

--- a/toolchains/genoa.gcc.adastra.spack/toolchain.cmake
+++ b/toolchains/genoa.gcc.adastra.spack/toolchain.cmake
@@ -9,4 +9,3 @@ set(CMAKE_Fortran_COMPILER gfortran)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
 set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")

--- a/toolchains/h100.jean-zay.spack/environment.sh
+++ b/toolchains/h100.jean-zay.spack/environment.sh
@@ -22,11 +22,11 @@ eval -- "$(
         --env gyselalibxx-spack-environment \
         load --sh \
         cmake \
+        ddc \
         gcc \
         ginkgo \
         googletest \
         kokkos \
-        kokkos-fft \
         kokkos-kernels \
         kokkos-tools \
         koliop \
@@ -57,5 +57,3 @@ module load arch/h100 cuda/12.8.0
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
-
-export GYSELALIBXX_OPENBLAS_ROOT="$(spack location -i openblas)"

--- a/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
@@ -2,10 +2,10 @@ spack:
   definitions:
   - packages:
     - cmake
+    - 'ddc@0.12 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +cuda cuda_arch=90
     - googletest +gmock
     - kokkos@4.7 ~openmp +cuda +cuda_relocatable_device_code +cuda_constexpr cuda_arch=90
-    - kokkos-fft@0.4 host_backend=fftw-serial device_backend=cufft
     - kokkos-kernels@4.7 ~shared
     - kokkos-tools
     - 'koliop@0.1.2:0.1'
@@ -70,6 +70,8 @@ spack:
               c: /lustre/fshomisc/sup/spack_soft/gcc/14.3.0/gcc-11.4.1-jqsvuauftoo43tclwxs7qicltsslka3y/bin/gcc
               cxx: /lustre/fshomisc/sup/spack_soft/gcc/14.3.0/gcc-11.4.1-jqsvuauftoo43tclwxs7qicltsslka3y/bin/g++
               fortran: /lustre/fshomisc/sup/spack_soft/gcc/14.3.0/gcc-11.4.1-jqsvuauftoo43tclwxs7qicltsslka3y/bin/gfortran
+    kokkos-fft:
+      require: '@0.4 host_backend=fftw-serial device_backend=cufft'
     lapack:
       require: openblas
     mpi:

--- a/toolchains/h100.jean-zay.spack/toolchain.cmake
+++ b/toolchains/h100.jean-zay.spack/toolchain.cmake
@@ -9,7 +9,6 @@ set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra")
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")
 
 # Gyselalibxx options
 set(GYSELALIBXX_DEFAULT_CXX_FLAGS "" CACHE STRING "Default flags for C++ specific to Gyselalib++" FORCE)

--- a/toolchains/mi250.hipcc.adastra.spack/environment.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/environment.sh
@@ -37,11 +37,11 @@ eval -- "$(
         --env gyselalibxx-spack-environment \
         load --sh \
         cmake \
+        ddc \
         gcc \
         ginkgo \
         googletest \
         kokkos \
-        kokkos-fft \
         kokkos-kernels \
         kokkos-tools \
         koliop \
@@ -70,5 +70,3 @@ eval -- "$(
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`
 export LD_LIBRARY_PATH="$(spack location -i kokkos-tools)/lib64:$LD_LIBRARY_PATH"
-
-export GYSELALIBXX_OPENBLAS_ROOT="$(spack location -i openblas)"

--- a/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -2,6 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
+    - 'ddc@0.12 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +rocm amdgpu_target=gfx90a
     - googletest +gmock
     - kokkos@4.7 ~openmp +rocm +hip_relocatable_device_code amdgpu_target=gfx90a
@@ -59,6 +60,8 @@ spack:
       require: gcc@13.2.1
     cxx:
       require: gcc@13.2.1
+    kokkos-fft:
+      require: '@0.4 host_backend=fftw-serial device_backend=hipfft'
     lapack:
       require: openblas
     mpi:

--- a/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -6,7 +6,6 @@ spack:
     - ginkgo@1.9 ~openmp +rocm amdgpu_target=gfx90a
     - googletest +gmock
     - kokkos@4.7 ~openmp +rocm +hip_relocatable_device_code amdgpu_target=gfx90a
-    - kokkos-fft@0.4 host_backend=fftw-serial device_backend=hipfft
     - kokkos-kernels@4.7 ~shared
     - kokkos-tools
     - 'koliop@0.1.2:0.1'

--- a/toolchains/mi250.hipcc.adastra.spack/toolchain.cmake
+++ b/toolchains/mi250.hipcc.adastra.spack/toolchain.cmake
@@ -9,5 +9,4 @@ set(CMAKE_Fortran_COMPILER amdflang)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
 set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -isystem $ENV{GYSELALIBXX_OPENBLAS_ROOT}/include")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-L/opt/cray/pe/mpich/8.1.30/gtl/lib -lmpi_gtl_hsa")

--- a/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
@@ -2,10 +2,10 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.22:3'
+    - 'ddc@0.12 +fft +pdi +splines'
     - 'ginkgo@1.9 +cuda cuda_arch=70 +openmp'
     - 'googletest +gmock'
     - 'kokkos@4.6:4 ~shared +wrapper +cuda +cuda_constexpr +cuda_relocatable_device_code cuda_arch=70 +openmp'
-    - 'kokkos-fft@0.3 host_backend=fftw-openmp device_backend=cufft'
     - 'kokkos-kernels@4.6:4 ~shared'
     - 'kokkos-tools'
     - 'koliop@0.1.2:0.1'
@@ -54,6 +54,8 @@ spack:
       require: gcc@13
     cxx:
       require: gcc@13
+    kokkos-fft:
+      require: '@0.3 host_backend=fftw-openmp device_backend=cufft'
     lapack:
       require: openblas
     mpi:

--- a/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
@@ -2,10 +2,10 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.22:3'
+    - 'ddc@0.12 +fft +pdi +splines'
     - 'ginkgo@1.9 +openmp'
     - 'googletest +gmock'
     - 'kokkos@4.6:4 +openmp'
-    - 'kokkos-fft@0.3 host_backend=fftw-openmp'
     - 'kokkos-kernels@4.6:4'
     - 'kokkos-tools'
     - 'koliop@0.1.2:0.1'
@@ -55,6 +55,8 @@ spack:
       require: gcc@13
     cxx:
       require: gcc@13
+    kokkos-fft:
+      require: '@0.3 host_backend=fftw-openmp'
     lapack:
       require: openblas
     mpi:


### PR DESCRIPTION
Remove DDC submodule, as a consequence:
- Rely on DDC v0.12, see [release notes](https://github.com/CExA-project/ddc/releases/tag/v0.12.0)
- Kokkos-FFT is not a direct dependency anymore
- Update FindLAPACKE to be coherent with DDC 0.12
- Remove the environment variable `GYSELALIBXX_OPENBLAS_ROOT`

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
