### PR TITLE
Fix missing pdiplugin-pycall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed missing load of `pdiplugin-pycall` in some Spack-based toolchains.
+
 ### Changed
 
 - Changed the name of class `SplineBuliderDerivField2D` to fix typo (->`SplineBuilderDerivField2D`).

--- a/toolchains/a100.raven.spack/environment.sh
+++ b/toolchains/a100.raven.spack/environment.sh
@@ -37,6 +37,7 @@ eval -- "$(
         pdiplugin-decl-hdf5 \
         pdiplugin-decl-netcdf \
         pdiplugin-mpi \
+        pdiplugin-pycall \
         pdiplugin-set-value \
         pdiplugin-trace \
         python \
@@ -46,10 +47,10 @@ eval -- "$(
         py-matplotlib \
         py-netcdf4 \
         py-numpy \
+        py-pyyaml \
         py-scipy \
         py-sympy \
-        py-xarray \
-        py-pyyaml
+        py-xarray
 )"
 
 module load gcc/14

--- a/toolchains/genoa.gcc.adastra.spack/environment.sh
+++ b/toolchains/genoa.gcc.adastra.spack/environment.sh
@@ -53,6 +53,7 @@ eval -- "$(
         pdiplugin-decl-hdf5 \
         pdiplugin-decl-netcdf \
         pdiplugin-mpi \
+        pdiplugin-pycall \
         pdiplugin-set-value \
         pdiplugin-trace \
         python \
@@ -62,10 +63,10 @@ eval -- "$(
         py-matplotlib \
         py-netcdf4 \
         py-numpy \
+        py-pyyaml \
         py-scipy \
         py-sympy \
-        py-xarray \
-        py-pyyaml
+        py-xarray
 )"
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`

--- a/toolchains/h100.jean-zay.spack/environment.sh
+++ b/toolchains/h100.jean-zay.spack/environment.sh
@@ -38,6 +38,7 @@ eval -- "$(
         pdiplugin-decl-hdf5 \
         pdiplugin-decl-netcdf \
         pdiplugin-mpi \
+        pdiplugin-pycall \
         pdiplugin-set-value \
         pdiplugin-trace \
         python \
@@ -47,10 +48,10 @@ eval -- "$(
         py-matplotlib \
         py-netcdf4 \
         py-numpy \
+        py-pyyaml \
         py-scipy \
         py-sympy \
-        py-xarray \
-        py-pyyaml
+        py-xarray
 )"
 
 module load arch/h100 cuda/12.8.0

--- a/toolchains/mi250.hipcc.adastra.spack/environment.sh
+++ b/toolchains/mi250.hipcc.adastra.spack/environment.sh
@@ -53,6 +53,7 @@ eval -- "$(
         pdiplugin-decl-hdf5 \
         pdiplugin-decl-netcdf \
         pdiplugin-mpi \
+        pdiplugin-pycall \
         pdiplugin-set-value \
         pdiplugin-trace \
         python \
@@ -62,10 +63,10 @@ eval -- "$(
         py-matplotlib \
         py-netcdf4 \
         py-numpy \
+        py-pyyaml \
         py-scipy \
         py-sympy \
-        py-xarray \
-        py-pyyaml
+        py-xarray
 )"
 
 # Add Kokkos Tools to the `LD_LIBRARY_PATH`


### PR DESCRIPTION
Some users reported that PDI could not load the pycall plugin. In some toolchains it was actually not loaded.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
