### PR TITLE
Generalise `Interpolator` concept to ND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `NDLagrangeEvaluator` class.
 - Add `eval_basis_and_n_derivs` function to Lagrange basis operators.
 - Add `deriv` function to Lagrange evaluation.
+- Add `concepts::InterpolationBuilder1D` and `concepts::Interpolation1D`.
 
 ### Fixed
 
@@ -29,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `DiscreteToCartesian` -> `DiscretePoloidalCSSplineMapping`.
 - Renamed `DiscreteToCartesianBuilder` -> `DiscretePoloidalCSSplineMappingBuilder`.
 - Changed `BslAdvectionPolar` template parameters and constructor to take a builder and evaluator instead of an `Interpolator2D`.
+- Changed new `concepts::InterpolationEvaluator` concept and associated `InterpolationEvaluatorTraits` class to generalise to ND.
+- Changed new `concepts::InterpolationBuilder` concept and associated `InterpolationBuilderTraits` class to generalise to ND.
 
 ### Deprecated
 

--- a/bin/ci_tools/gyselalib_static_analysis.py
+++ b/bin/ci_tools/gyselalib_static_analysis.py
@@ -826,7 +826,8 @@ if __name__ == '__main__':
 
     cppcheck_command = ['cppcheck', '--dump', '--library=googletest', '--check-level=exhaustive', '--enable=style',
                         '--std=c++17', '--max-ctu-depth=5', '--suppress=unusedStructMember', '--suppress=useStlAlgorithm',
-                        '--error-exitcode=1', '--suppress=knownConditionTrueFalse', '--suppress=ctuOneDefinitionRuleViolation']
+                        '--error-exitcode=1', '--suppress=knownConditionTrueFalse', '--suppress=ctuOneDefinitionRuleViolation',
+                        '--inline-suppr']
     for f in multipatch_geom:
         if no_file_filter or f in (*filter_files, spec_info):
             print("------------- Checking ", f, " -------------")

--- a/bin/ci_tools/gyselalib_static_analysis.py
+++ b/bin/ci_tools/gyselalib_static_analysis.py
@@ -405,7 +405,7 @@ def search_for_bad_aliases(file):
                        "can be multi-D. Please use Grid1D")
                 report_error(STYLE, file, linenr, msg)
             # Beginning with verbs is ok as are some specific prefixes
-            valid_start_names = ('Idx', 'MultipatchIdx', 'HasIdx', 'InternalIdx', 'Select', 'Find', 'InputIdx', 'TypeSeq', 'MatchingIdxSlice')
+            valid_start_names = ('Idx', 'MultipatchIdx', 'HasIdx', 'InternalIdx', 'Select', 'Find', 'InputIdx', 'TypeSeq', 'MatchingIdxSlice', 'To')
             if 'Idx' in a_name and not any(a_name.startswith(valid_start_name) for valid_start_name in valid_start_names):
                 prefix = 'Multipatch' if 'Multipatch' in a_name else ''
                 name = a_name.replace('Multipatch','')

--- a/bin/run_cppcheck
+++ b/bin/run_cppcheck
@@ -44,6 +44,7 @@ if __name__ == '__main__':
            '--library=googletest', '--max-ctu-depth=5', '--check-level=exhaustive',
            '--std=c++17', '--suppress=unusedStructMember', '--suppress=useStlAlgorithm',
            '--suppress=knownConditionTrueFalse', '--suppress=ctuOneDefinitionRuleViolation',
+           '--inline-suppr',
            f'--addon={GYSELALIB_ROOT}/bin/ci_tools/check_naming_conventions',
            f'--addon={GYSELALIB_ROOT}/bin/ci_tools/check_for_memory_misuse',
            f'--project={build_dir}/relevant_compile_commands.json']

--- a/src/advection/bsl_advection_vx.hpp
+++ b/src/advection/bsl_advection_vx.hpp
@@ -18,7 +18,7 @@ template <class Geometry, concepts::Interpolation1D FunctionInterpolator, class 
 class BslAdvectionVelocity
     : public IAdvectionVelocity<
               Geometry,
-              interpolation_grid_type<typename FunctionInterpolator::BuilderType>,
+              interpolation_grid_t<typename FunctionInterpolator::BuilderType>,
               DataType>
 {
     static_assert(std::is_floating_point_v<DataType>);
@@ -26,7 +26,7 @@ class BslAdvectionVelocity
     using FunctionBuilder = typename FunctionInterpolator::BuilderType;
     using FunctionEvaluator = typename FunctionInterpolator::EvaluatorType;
 
-    using GridV = interpolation_grid_type<typename FunctionInterpolator::BuilderType>;
+    using GridV = interpolation_grid_t<typename FunctionInterpolator::BuilderType>;
 
     using IdxRangeFdistribu = typename Geometry::IdxRangeFdistribu;
     using IdxRangeSpatial = typename Geometry::IdxRangeSpatial;

--- a/src/advection/bsl_advection_vx.hpp
+++ b/src/advection/bsl_advection_vx.hpp
@@ -14,12 +14,11 @@
 /**
  * @brief A class which computes the velocity advection along the dimension of interest GridV. Working for every Cartesian geometry.
  */
-template <class Geometry, concepts::Interpolation FunctionInterpolator, class DataType = double>
+template <class Geometry, concepts::Interpolation1D FunctionInterpolator, class DataType = double>
 class BslAdvectionVelocity
     : public IAdvectionVelocity<
               Geometry,
-              typename InterpolationBuilderTraits<
-                      typename FunctionInterpolator::BuilderType>::interpolation_grid_type,
+              interpolation_grid_type<typename FunctionInterpolator::BuilderType>,
               DataType>
 {
     static_assert(std::is_floating_point_v<DataType>);
@@ -27,7 +26,7 @@ class BslAdvectionVelocity
     using FunctionBuilder = typename FunctionInterpolator::BuilderType;
     using FunctionEvaluator = typename FunctionInterpolator::EvaluatorType;
 
-    using GridV = typename InterpolationBuilderTraits<FunctionBuilder>::interpolation_grid_type;
+    using GridV = interpolation_grid_type<typename FunctionInterpolator::BuilderType>;
 
     using IdxRangeFdistribu = typename Geometry::IdxRangeFdistribu;
     using IdxRangeSpatial = typename Geometry::IdxRangeSpatial;

--- a/src/advection/bsl_advection_x.hpp
+++ b/src/advection/bsl_advection_x.hpp
@@ -17,7 +17,7 @@ template <class Geometry, concepts::Interpolation1D FunctionInterpolator, class 
 class BslAdvectionSpatial
     : public IAdvectionSpatial<
               Geometry,
-              interpolation_grid_type<typename FunctionInterpolator::BuilderType>,
+              interpolation_grid_t<typename FunctionInterpolator::BuilderType>,
               DataType>
 {
     static_assert(std::is_floating_point_v<DataType>);
@@ -25,7 +25,7 @@ class BslAdvectionSpatial
     using FunctionBuilder = typename FunctionInterpolator::BuilderType;
     using FunctionEvaluator = typename FunctionInterpolator::EvaluatorType;
 
-    using GridX = interpolation_grid_type<typename FunctionInterpolator::BuilderType>;
+    using GridX = interpolation_grid_t<typename FunctionInterpolator::BuilderType>;
 
     using GridV = typename Geometry::template velocity_dim_for<GridX>;
     using IdxRangeFdistrib = typename Geometry::IdxRangeFdistribu;

--- a/src/advection/bsl_advection_x.hpp
+++ b/src/advection/bsl_advection_x.hpp
@@ -13,12 +13,11 @@
 /**
  * @brief A class which computes the spatial advection along the dimension of interest GridX. Working for every Cartesian geometry.
  */
-template <class Geometry, concepts::Interpolation FunctionInterpolator, class DataType = double>
+template <class Geometry, concepts::Interpolation1D FunctionInterpolator, class DataType = double>
 class BslAdvectionSpatial
     : public IAdvectionSpatial<
               Geometry,
-              typename InterpolationBuilderTraits<
-                      typename FunctionInterpolator::BuilderType>::interpolation_grid_type,
+              interpolation_grid_type<typename FunctionInterpolator::BuilderType>,
               DataType>
 {
     static_assert(std::is_floating_point_v<DataType>);
@@ -26,7 +25,7 @@ class BslAdvectionSpatial
     using FunctionBuilder = typename FunctionInterpolator::BuilderType;
     using FunctionEvaluator = typename FunctionInterpolator::EvaluatorType;
 
-    using GridX = typename InterpolationBuilderTraits<FunctionBuilder>::interpolation_grid_type;
+    using GridX = interpolation_grid_type<typename FunctionInterpolator::BuilderType>;
 
     using GridV = typename Geometry::template velocity_dim_for<GridX>;
     using IdxRangeFdistrib = typename Geometry::IdxRangeFdistribu;

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -60,7 +60,7 @@ concept Interpolation = requires
  * @tparam T The interpolation type to check.
  */
 template <typename T>
-concept Interpolation1D = Interpolation<Builder> && InterpolationBuilder1D<typename T::BuilderType>;
+concept Interpolation1D = Interpolation<T> && InterpolationBuilder1D<typename T::BuilderType>;
 
 } // namespace concepts
 

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -37,9 +37,14 @@ concept Interpolation = requires
 {
     typename T::BuilderType;
     typename T::EvaluatorType;
+    {
+        T::rank()
+        } -> std::same_as<std::size_t>;
 }
 &&concepts::InterpolationBuilder<typename T::BuilderType>&& concepts::InterpolationEvaluator<
-        typename T::EvaluatorType>&& requires(T const& t)
+        typename T::
+                EvaluatorType> && (InterpolationBuilderTraits<typename T::BuilderType>::rank() == InterpolationEvaluatorTraits<typename T::EvaluatorType>::rank())
+        && requires(T const& t)
 {
     {
         t.get_builder()

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -12,10 +12,10 @@
 /**
  * @brief An enum describing how a function is extrapolated outside the interpolation domain.
  *
- * - @c PERIODIC : the function is assumed to be periodic. The value at a point outside
+ * - PERIODIC : the function is assumed to be periodic. The value at a point outside
  *   the domain is taken as the value at the equivalent point inside the domain.
- * - @c NULL_VALUE : the function evaluates to zero outside the domain.
- * - @c CONSTANT : the function is clamped to the value at the nearest boundary point.
+ * - NULL_VALUE : the function evaluates to zero outside the domain.
+ * - CONSTANT : the function is clamped to the value at the nearest boundary point.
  */
 enum ExtrapolationRule { PERIODIC, NULL_VALUE, CONSTANT };
 
@@ -24,7 +24,7 @@ namespace concepts {
 /**
  * @brief A concept describing an interpolation object that owns a matching builder–evaluator pair.
  *
- * An @c Interpolation bundles a builder (which converts function values on the
+ * An Interpolation bundles a builder (which converts function values on the
  * interpolation mesh into interpolation coefficients) and an evaluator (which
  * reconstructs function values from those coefficients) into a single owning object.
  *
@@ -54,10 +54,18 @@ concept Interpolation = requires
         } -> std::same_as<typename T::EvaluatorType const&>;
 };
 
+/**
+ * @brief A concept describing a 1D interpolation object.
+ *
+ * @tparam T The interpolation type to check.
+ */
+template <typename T>
+concept Interpolation1D = Interpolation<Builder> && InterpolationBuilder1D<typename T::BuilderType>;
+
 } // namespace concepts
 
 /**
- * @brief A type trait that is true when @c Basis is a Lagrange basis type.
+ * @brief A type trait that is true when Basis is a Lagrange basis type.
  *
  * Evaluates to true for both UniformLagrangeBasis and NonUniformLagrangeBasis
  * instantiations, false for all other types.
@@ -69,7 +77,7 @@ constexpr bool is_lagrange_basis_v
         = is_uniform_lagrange_basis_v<Basis> || is_non_uniform_lagrange_basis_v<Basis>;
 
 /**
- * @brief A type trait that is true when @c Basis is a B-spline basis type.
+ * @brief A type trait that is true when Basis is a B-spline basis type.
  *
  * Evaluates to true for both ddc::UniformBSplines and ddc::NonUniformBSplines
  * instantiations, false for all other types.

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include <optional>
 #include <type_traits>
 
 #include "ddc_aliases.hpp"
@@ -10,11 +9,21 @@
  * @brief A traits struct for accessing type aliases of an interpolation builder.
  *
  * The primary template delegates to the builder's own type aliases, so any class
- * that defines them directly (e.g. IdentityInterpolationBuilder, SplineBuilder1D)
+ * that defines them directly (e.g. IdentityInterpolationBuilder)
  * satisfies the InterpolationBuilder concept without specialisation.
  *
  * Specialise this struct to adapt external builders whose alias names differ from
  * the convention (e.g. ddc::SplineBuilder).
+ *
+ * Defines:
+ *   Type aliases:
+ *   - data_type
+ *   - interpolation_idx_range_type
+ *   Static functions:
+ *   - rank()
+ *   Type calculators:
+ *   - batched_basis_idx_range_type
+ *   - batched_derivs_idx_range_type  (1D builders only; not required by the concept)
  *
  * @tparam Builder The interpolation builder type.
  */
@@ -24,21 +33,21 @@ struct InterpolationBuilderTraits
     /// @brief The data type that the data is saved on.
     using data_type = typename Builder::data_type;
 
-    /// @brief The discrete grid on which interpolation values are given.
-    using interpolation_grid_type = typename Builder::interpolation_grid_type;
-
-    /// @brief The 1D index range for the interpolation mesh.
+    /// @brief The ND index range for the interpolation mesh.
     using interpolation_idx_range_type = typename Builder::interpolation_idx_range_type;
 
-    /// @brief The discrete dimension for the interpolation coefficients.
-    using basis_domain_type = typename Builder::basis_domain_type;
+    /// @brief The number of interpolation dimensions.
+    static constexpr std::size_t rank()
+    {
+        return interpolation_idx_range_type::rank();
+    }
 
-    /// @brief Batched domain with interpolation_grid_type replaced by basis_domain_type.
+    /// @brief Batched domain with the interpolation grid(s) replaced by the basis grid(s).
     template <class IdxRangeBatchedInterpolation>
     using batched_basis_idx_range_type =
             typename Builder::template batched_basis_idx_range_type<IdxRangeBatchedInterpolation>;
 
-    /// @brief Batched domain with interpolation_grid_type replaced by deriv_type.
+    /// @brief Batched domain with the interpolation grid replaced by the deriv type.
     template <class IdxRangeBatchedInterpolation>
     using batched_derivs_idx_range_type =
             typename Builder::template batched_derivs_idx_range_type<IdxRangeBatchedInterpolation>;
@@ -96,6 +105,12 @@ public:
     /// @brief The 1D index range for the interpolation mesh.
     using interpolation_idx_range_type = typename Builder::interpolation_domain_type;
 
+    /// @brief The number of interpolation dimensions (always 1 for SplineBuilder).
+    static constexpr std::size_t rank()
+    {
+        return 1;
+    }
+
     /// @brief The discrete dimension for the B-spline coefficients.
     using basis_domain_type = typename Builder::bsplines_type;
 
@@ -135,34 +150,31 @@ auto batched_basis_idx_range(
 namespace concepts {
 
 /**
- * @brief A concept describing an interpolation builder.
+ * @brief A concept describing an ND interpolation builder.
  *
  * An interpolation builder is a callable that takes function values on an interpolation
  * mesh and computes the coefficients of an interpolation representation (e.g. spline or
- * Lagrange) of that function.
+ * Lagrange) of that function. The builder may operate over one or more interpolation
+ * dimensions simultaneously (N ≥ 1).
  *
  * Type information is accessed through InterpolationBuilderTraits<Builder>, which has a
  * primary template delegating to Builder's own aliases and can be specialised for
  * external builders (e.g. ddc::SplineBuilder).
  *
- * The template alias and method requirements are verified using interpolation_idx_range_type
- * as a representative domain.
+ * The callable requirement is verified using @c interpolation_idx_range_type as the
+ * representative non-batched domain:
+ *  - @c b(coeffs, vals) — build interpolation coefficients from function values.
  */
 template <class Builder>
 concept InterpolationBuilder = requires
 {
     typename Builder::exec_space;
     typename Builder::memory_space;
-    typename Builder::continuous_dimension_type;
     typename InterpolationBuilderTraits<Builder>::data_type;
-    typename InterpolationBuilderTraits<Builder>::interpolation_grid_type;
     typename InterpolationBuilderTraits<Builder>::interpolation_idx_range_type;
-    typename InterpolationBuilderTraits<Builder>::basis_domain_type;
-    typename Builder::deriv_type;
 }
 &&requires(
         Builder const& b,
-        typename InterpolationBuilderTraits<Builder>::interpolation_idx_range_type domain,
         Field<typename InterpolationBuilderTraits<Builder>::data_type,
               typename InterpolationBuilderTraits<Builder>::template batched_basis_idx_range_type<
                       typename InterpolationBuilderTraits<Builder>::interpolation_idx_range_type>,
@@ -170,28 +182,9 @@ concept InterpolationBuilder = requires
         ConstField<
                 typename InterpolationBuilderTraits<Builder>::data_type,
                 typename InterpolationBuilderTraits<Builder>::interpolation_idx_range_type,
-                typename Builder::memory_space> vals,
-        std::optional<ConstField<
-                typename InterpolationBuilderTraits<Builder>::data_type,
-                typename InterpolationBuilderTraits<Builder>::
-                        template batched_derivs_idx_range_type<typename InterpolationBuilderTraits<
-                                Builder>::interpolation_idx_range_type>,
-                typename Builder::memory_space>> derivs)
+                typename Builder::memory_space> vals)
 {
     {b(coeffs, vals)};
-    {b(coeffs, vals, derivs, derivs)};
-    {
-        b.batched_derivs_xmin_domain(domain)
-        } -> std::same_as<
-                typename InterpolationBuilderTraits<Builder>::
-                        template batched_derivs_idx_range_type<typename InterpolationBuilderTraits<
-                                Builder>::interpolation_idx_range_type>>;
-    {
-        b.batched_derivs_xmax_domain(domain)
-        } -> std::same_as<
-                typename InterpolationBuilderTraits<Builder>::
-                        template batched_derivs_idx_range_type<typename InterpolationBuilderTraits<
-                                Builder>::interpolation_idx_range_type>>;
 };
 
 } // namespace concepts

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -135,8 +135,8 @@ public:
 /**
  * @brief Get the batched basis index range for a builder.
  *
- * Dispatches to @c batched_basis_idx_range if available (e.g. IdentityInterpolationBuilder),
- * otherwise falls back to @c batched_spline_domain (e.g. ddc::SplineBuilder).
+ * Dispatches to batched_basis_idx_range if available (e.g. IdentityInterpolationBuilder),
+ * otherwise falls back to batched_spline_domain (e.g. ddc::SplineBuilder).
  *
  * @param builder The interpolation builder.
  * @param batched_interpolation_domain The batched interpolation domain.
@@ -168,9 +168,9 @@ namespace concepts {
  * primary template delegating to Builder's own aliases and can be specialised for
  * external builders (e.g. ddc::SplineBuilder).
  *
- * The callable requirement is verified using @c interpolation_idx_range_type as the
+ * The callable requirement is verified using interpolation_idx_range_type as the
  * representative non-batched domain:
- *  - @c b(coeffs, vals) — build interpolation coefficients from function values.
+ *  - b(coeffs, vals) — build interpolation coefficients from function values.
  */
 template <class Builder>
 concept InterpolationBuilder = requires
@@ -197,9 +197,9 @@ concept InterpolationBuilder = requires
 /**
  * @brief A concept describing a 1D interpolation builder.
  *
- * Refines @c InterpolationBuilder with the additional requirements that:
- *   - The builder operates over exactly one interpolation dimension (@c rank() == 1).
- *   - @c InterpolationBuilderTraits<Builder>::basis_domain_type is defined, i.e. the
+ * Refines InterpolationBuilder with the additional requirements that:
+ *   - The builder operates over exactly one interpolation dimension (rank() == 1).
+ *   - InterpolationBuilderTraits<Builder>::basis_domain_type is defined, i.e. the
  *     builder exposes a discrete dimension for its basis coefficients.
  */
 template <class Builder>

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <optional>
 #include <type_traits>
 
 #include "ddc_aliases.hpp"
@@ -204,7 +205,43 @@ concept InterpolationBuilder = requires
  */
 template <class Builder>
 concept InterpolationBuilder1D
-        = InterpolationBuilder<Builder> &&(InterpolationBuilderTraits<Builder>::rank() == 1);
+        = InterpolationBuilder<Builder> &&(InterpolationBuilderTraits<Builder>::rank() == 1)
+          && requires(
+                  Builder const& b,
+                  typename InterpolationBuilderTraits<Builder>::interpolation_idx_range_type domain,
+                  Field<typename InterpolationBuilderTraits<Builder>::data_type,
+                        typename InterpolationBuilderTraits<Builder>::
+                                template batched_basis_idx_range_type<
+                                        typename InterpolationBuilderTraits<
+                                                Builder>::interpolation_idx_range_type>,
+                        typename Builder::memory_space> coeffs,
+                  ConstField<
+                          typename InterpolationBuilderTraits<Builder>::data_type,
+                          typename InterpolationBuilderTraits<
+                                  Builder>::interpolation_idx_range_type,
+                          typename Builder::memory_space> vals,
+                  std::optional<ConstField<
+                          typename InterpolationBuilderTraits<Builder>::data_type,
+                          typename InterpolationBuilderTraits<Builder>::
+                                  template batched_derivs_idx_range_type<
+                                          typename InterpolationBuilderTraits<
+                                                  Builder>::interpolation_idx_range_type>,
+                          typename Builder::memory_space>> derivs)
+{
+    {b(coeffs, vals, derivs, derivs)};
+    {
+        b.batched_derivs_xmin_domain(domain)
+        } -> std::same_as<
+                typename InterpolationBuilderTraits<Builder>::
+                        template batched_derivs_idx_range_type<typename InterpolationBuilderTraits<
+                                Builder>::interpolation_idx_range_type>>;
+    {
+        b.batched_derivs_xmax_domain(domain)
+        } -> std::same_as<
+                typename InterpolationBuilderTraits<Builder>::
+                        template batched_derivs_idx_range_type<typename InterpolationBuilderTraits<
+                                Builder>::interpolation_idx_range_type>>;
+};
 
 } // namespace concepts
 

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -19,6 +19,7 @@
  *   Type aliases:
  *   - data_type
  *   - interpolation_idx_range_type
+ *   - coeff_idx_range_type
  *   Static functions:
  *   - rank()
  *   Type calculators:
@@ -35,6 +36,9 @@ struct InterpolationBuilderTraits
 
     /// @brief The ND index range for the interpolation mesh.
     using interpolation_idx_range_type = typename Builder::interpolation_idx_range_type;
+
+    /// @brief The index range for the interpolation coefficients.
+    using coeff_idx_range_type = typename Builder::coeff_idx_range_type;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -104,6 +108,9 @@ public:
 
     /// @brief The 1D index range for the interpolation mesh.
     using interpolation_idx_range_type = typename Builder::interpolation_domain_type;
+
+    /// @brief The index range for the interpolation coefficients.
+    using coeff_idx_range_type = IdxRange<typename Builder::bsplines_type>;
 
     /// @brief The number of interpolation dimensions (always 1 for SplineBuilder).
     static constexpr std::size_t rank()
@@ -187,4 +194,23 @@ concept InterpolationBuilder = requires
     {b(coeffs, vals)};
 };
 
+/**
+ * @brief A concept describing a 1D interpolation builder.
+ *
+ * Refines @c InterpolationBuilder with the additional requirements that:
+ *   - The builder operates over exactly one interpolation dimension (@c rank() == 1).
+ *   - @c InterpolationBuilderTraits<Builder>::basis_domain_type is defined, i.e. the
+ *     builder exposes a discrete dimension for its basis coefficients.
+ */
+template <class Builder>
+concept InterpolationBuilder1D
+        = InterpolationBuilder<Builder> &&(InterpolationBuilderTraits<Builder>::rank() == 1);
+
 } // namespace concepts
+
+/// @brief The discrete grid on which interpolation values are given (1D builders only).
+template <concepts::InterpolationBuilder1D BuilderType>
+using interpolation_grid_type = ddc::type_seq_element_t<
+        0,
+        ddc::to_type_seq_t<
+                typename InterpolationBuilderTraits<BuilderType>::interpolation_idx_range_type>>;

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -247,7 +247,7 @@ concept InterpolationBuilder1D
 
 /// @brief The discrete grid on which interpolation values are given (1D builders only).
 template <concepts::InterpolationBuilder1D BuilderType>
-using interpolation_grid_type = ddc::type_seq_element_t<
+using interpolation_grid_t = ddc::type_seq_element_t<
         0,
         ddc::to_type_seq_t<
                 typename InterpolationBuilderTraits<BuilderType>::interpolation_idx_range_type>>;

--- a/src/interpolation/i_interpolation_evaluator.hpp
+++ b/src/interpolation/i_interpolation_evaluator.hpp
@@ -61,7 +61,8 @@ struct InterpolationEvaluatorTraits
     using evaluation_idx_range_type = typename Evaluator::evaluation_idx_range_type;
 
     /// @brief The ND coordinate type corresponding to the evaluation mesh.
-    using coord_type = ddc::coordinate_of_t<typename evaluation_idx_range_type::discrete_element_type>;
+    using coord_type
+            = ddc::coordinate_of_t<typename evaluation_idx_range_type::discrete_element_type>;
 
     /// @brief The type of the ND index range on which the interpolation coefficients are defined.
     using coeff_idx_range_type = typename Evaluator::coeff_idx_range_type;
@@ -181,7 +182,9 @@ concept InterpolationEvaluator = requires
 }
 &&requires()
 {
-    {InterpolationEvaluatorTraits<Evaluator>::rank()} -> std::same_as<std::size_t>;
+    {
+        InterpolationEvaluatorTraits<Evaluator>::rank()
+        } -> std::same_as<std::size_t>;
 }
 &&requires(
         Evaluator const& e,

--- a/src/interpolation/i_interpolation_evaluator.hpp
+++ b/src/interpolation/i_interpolation_evaluator.hpp
@@ -16,6 +16,18 @@
  * Specialise this struct to adapt external evaluators whose alias names differ
  * (e.g. ddc::SplineEvaluator).
  *
+ * Defines:
+ *   Type aliases:
+ *   - data_type
+ *   - evaluation_idx_range_type
+ *   - coord_type
+ *   - coeff_idx_range_type
+ *   Static functions
+ *   - rank()
+ *   Type calculators
+ *   - batched_evaluation_idx_range_type
+ *   - batched_coeff_idx_range_type
+ *
  * @tparam Evaluator The interpolation evaluator type.
  */
 template <class Evaluator>
@@ -24,11 +36,20 @@ struct InterpolationEvaluatorTraits
     /// @brief The data type that the data is saved on.
     using data_type = typename Evaluator::data_type;
 
-    /// @brief The 1D index range for the evaluation mesh.
+    /// @brief The ND index range for the evaluation mesh.
     using evaluation_idx_range_type = typename Evaluator::evaluation_idx_range_type;
 
-    /// @brief The discrete dimension for the interpolation coefficients.
-    using coeff_grid_type = typename Evaluator::coeff_grid_type;
+    /// @brief The ND coordinate type corresponding to the evaluation mesh.
+    using coord_type = ddc::coordinate_of_t<typename evaluation_idx_range_type::discrete_element_type>;
+
+    /// @brief The type of the ND index range on which the interpolation coefficients are defined.
+    using coeff_idx_range_type = typename Evaluator::coeff_idx_range_type;
+
+    /// @brief The number of interpolation dimensions.
+    static constexpr std::size_t rank()
+    {
+        return evaluation_idx_range_type::rank();
+    }
 
     /// @brief Batched index range for the evaluation
     template <class BatchedInterpolationIdxRange>
@@ -36,7 +57,7 @@ struct InterpolationEvaluatorTraits
             typename Evaluator::template batched_evaluation_idx_range_type<
                     BatchedInterpolationIdxRange>;
 
-    /// @brief Batched domain with the evaluation grid replaced by coeff_grid_type.
+    /// @brief Batched domain with the evaluation grid replaced by the coefficient grid(s).
     template <class D>
     using batched_coeff_idx_range_type =
             typename Evaluator::template batched_coeff_idx_range_type<D>;
@@ -86,8 +107,20 @@ public:
     /// @brief The 1D index range for the evaluation mesh.
     using evaluation_idx_range_type = typename Evaluator::evaluation_domain_type;
 
+    /// @brief The 1D coordinate type corresponding to the evaluation mesh.
+    using coord_type = Coord<typename EvaluationDDim::continuous_dimension_type>;
+
+    /// @brief The type of the ND index range on which the interpolation coefficients are defined.
+    using coeff_idx_range_type = typename Evaluator::spline_domain_type;
+
+    /// @brief The number of interpolation dimensions (always 1 for SplineEvaluator).
+    static constexpr std::size_t rank()
+    {
+        return 1;
+    }
+
     /// @brief The discrete dimension for the B-spline coefficients.
-    using coeff_grid_type = typename Evaluator::bsplines_type;
+    //using coeff_grid_type = typename Evaluator::bsplines_type;
 
     /// @brief Batched index range for the evaluation
     template <class BatchedInterpolationIdxRange>
@@ -104,11 +137,12 @@ public:
 namespace concepts {
 
 /**
- * @brief A concept describing an interpolation evaluator.
+ * @brief A concept describing an ND interpolation evaluator.
  *
  * An interpolation evaluator is a callable that takes a field of interpolation
  * coefficients (on a basis domain) and produces function values on an evaluation
- * mesh, optionally at user-supplied coordinates.
+ * mesh, optionally at user-supplied coordinates. The evaluator may operate over
+ * one or more interpolation dimensions simultaneously (N ≥ 1).
  *
  * Type information is accessed through InterpolationEvaluatorTraits<Evaluator>, which
  * has a primary template delegating to the evaluator's own aliases and can be
@@ -122,12 +156,11 @@ concept InterpolationEvaluator = requires
 {
     typename Evaluator::exec_space;
     typename Evaluator::memory_space;
-    typename Evaluator::continuous_dimension_type;
     typename InterpolationEvaluatorTraits<Evaluator>::data_type;
     typename InterpolationEvaluatorTraits<Evaluator>::evaluation_idx_range_type;
-    typename InterpolationEvaluatorTraits<Evaluator>::coeff_grid_type;
-    typename Evaluator::lower_extrapolation_rule_type;
-    typename Evaluator::upper_extrapolation_rule_type;
+    typename InterpolationEvaluatorTraits<Evaluator>::coord_type;
+    typename InterpolationEvaluatorTraits<Evaluator>::coeff_idx_range_type;
+    typename InterpolationEvaluatorTraits<Evaluator>::rank;
 }
 &&requires(
         Evaluator const& e,
@@ -141,7 +174,7 @@ concept InterpolationEvaluator = requires
                                 Evaluator>::evaluation_idx_range_type>,
                 typename Evaluator::memory_space> coeffs,
         ConstField<
-                Coord<typename Evaluator::continuous_dimension_type>,
+                typename InterpolationEvaluatorTraits<Evaluator>::coord_type,
                 typename InterpolationEvaluatorTraits<Evaluator>::evaluation_idx_range_type,
                 typename Evaluator::memory_space> coords)
 {
@@ -156,7 +189,7 @@ concept InterpolationEvaluator = requires
                         template batched_coeff_idx_range_type<typename InterpolationEvaluatorTraits<
                                 Evaluator>::evaluation_idx_range_type>,
                 typename Evaluator::memory_space> coeffs,
-        Coord<typename Evaluator::continuous_dimension_type> coord)
+        typename InterpolationEvaluatorTraits<Evaluator>::coord_type coord)
 {
     {
         e(coord, coeffs)

--- a/src/interpolation/i_interpolation_evaluator.hpp
+++ b/src/interpolation/i_interpolation_evaluator.hpp
@@ -5,6 +5,27 @@
 
 #include "ddc_aliases.hpp"
 
+namespace detail {
+
+/**
+ * @brief Convert an index type over grids to the matching index type over derivative dimensions.
+ *
+ * Given @c Idx<Grid1, Grid2, ...>, produces
+ * @c Idx<ddc::Deriv<Grid1::continuous_dimension_type>, ddc::Deriv<Grid2::continuous_dimension_type>, ...>.
+ *
+ * @tparam IdxElem An @c Idx<Grids...> type.
+ */
+template <class IdxElem>
+struct ToDerivIdx;
+
+template <class... Grids>
+struct ToDerivIdx<Idx<Grids...>>
+{
+    using type = Idx<ddc::Deriv<typename Grids::continuous_dimension_type>...>;
+};
+
+} // namespace detail
+
 /**
  * @brief A traits struct for accessing type aliases of an interpolation evaluator.
  *
@@ -73,7 +94,7 @@ struct InterpolationEvaluatorTraits
  * Mapping:
  *   evaluation_discrete_dimension_type -> (defines evaluation_idx_range_type)
  *   evaluation_domain_type             -> evaluation_idx_range_type
- *   bsplines_type                      -> coeff_grid_type
+ *   spline_domain_type                 -> coeff_idx_range_type
  *   batched_spline_domain_type<D>      -> batched_coeff_idx_range_type<D>
  */
 template <
@@ -119,9 +140,6 @@ public:
         return 1;
     }
 
-    /// @brief The discrete dimension for the B-spline coefficients.
-    //using coeff_grid_type = typename Evaluator::bsplines_type;
-
     /// @brief Batched index range for the evaluation
     template <class BatchedInterpolationIdxRange>
     using batched_evaluation_idx_range_type =
@@ -160,7 +178,10 @@ concept InterpolationEvaluator = requires
     typename InterpolationEvaluatorTraits<Evaluator>::evaluation_idx_range_type;
     typename InterpolationEvaluatorTraits<Evaluator>::coord_type;
     typename InterpolationEvaluatorTraits<Evaluator>::coeff_idx_range_type;
-    typename InterpolationEvaluatorTraits<Evaluator>::rank;
+}
+&&requires()
+{
+    {InterpolationEvaluatorTraits<Evaluator>::rank()} -> std::same_as<std::size_t>;
 }
 &&requires(
         Evaluator const& e,
@@ -176,10 +197,14 @@ concept InterpolationEvaluator = requires
         ConstField<
                 typename InterpolationEvaluatorTraits<Evaluator>::coord_type,
                 typename InterpolationEvaluatorTraits<Evaluator>::evaluation_idx_range_type,
-                typename Evaluator::memory_space> coords)
+                typename Evaluator::memory_space> coords,
+        typename detail::ToDerivIdx<typename InterpolationEvaluatorTraits<
+                Evaluator>::evaluation_idx_range_type::discrete_element_type>::type deriv_order)
 {
     {e(eval, coeffs)};
     {e(eval, coords, coeffs)};
+    {e.deriv(deriv_order, eval, coeffs)};
+    {e.deriv(deriv_order, eval, coords, coeffs)};
 }
 &&requires(
         Evaluator const& e,
@@ -189,10 +214,15 @@ concept InterpolationEvaluator = requires
                         template batched_coeff_idx_range_type<typename InterpolationEvaluatorTraits<
                                 Evaluator>::evaluation_idx_range_type>,
                 typename Evaluator::memory_space> coeffs,
-        typename InterpolationEvaluatorTraits<Evaluator>::coord_type coord)
+        typename InterpolationEvaluatorTraits<Evaluator>::coord_type coord,
+        typename detail::ToDerivIdx<typename InterpolationEvaluatorTraits<
+                Evaluator>::evaluation_idx_range_type::discrete_element_type>::type deriv_order)
 {
     {
         e(coord, coeffs)
+        } -> std::same_as<typename InterpolationEvaluatorTraits<Evaluator>::data_type>;
+    {
+        e.deriv(deriv_order, coord, coeffs)
         } -> std::same_as<typename InterpolationEvaluatorTraits<Evaluator>::data_type>;
 };
 

--- a/src/interpolation/identity_interpolation_builder.hpp
+++ b/src/interpolation/identity_interpolation_builder.hpp
@@ -43,6 +43,9 @@ public:
     /// @brief The grid on which the interpolation coefficients should be provided.
     using basis_domain_type = typename Basis::template Impl<Basis, MemorySpace>::knot_grid;
 
+    /// @brief The index range for the interpolation coefficients.
+    using coeff_idx_range_type = IdxRange<basis_domain_type>;
+
     /// @brief The type of the Deriv dimension at the boundaries.
     using deriv_type = ddc::Deriv<continuous_dimension_type>;
 

--- a/src/interpolation/lagrange_evaluator.hpp
+++ b/src/interpolation/lagrange_evaluator.hpp
@@ -336,10 +336,10 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class IdxDerivDims, class Layout, class BatchedLagrangeIdxRange, class... CoordsDims>
-    KOKKOS_FUNCTION DataType deriv(
-            IdxDerivDims const& deriv_order,
-            Coord<CoordsDims...> const& coord_eval,
-            ConstField<DataType, BatchedLagrangeIdxRange, memory_space, Layout> const lagrange_coef)
+    KOKKOS_FUNCTION DataType
+    deriv(IdxDerivDims const& deriv_order,
+          Coord<CoordsDims...> const& coord_eval,
+          ConstField<DataType, BatchedLagrangeIdxRange, memory_space, Layout> const lagrange_coef)
             const
     {
         return eval_no_bc(deriv_order, coord_eval, lagrange_coef);

--- a/src/interpolation/lagrange_evaluator.hpp
+++ b/src/interpolation/lagrange_evaluator.hpp
@@ -336,7 +336,7 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class IdxDerivDims, class Layout, class BatchedLagrangeIdxRange, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION DataType deriv(
             IdxDerivDims const& deriv_order,
             Coord<CoordsDims...> const& coord_eval,
             ConstField<DataType, BatchedLagrangeIdxRange, memory_space, Layout> const lagrange_coef)

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -81,6 +81,12 @@ public:
             extrapolation_rule_t<MinExtrapRule, CoeffGridType>,
             extrapolation_rule_t<MaxExtrapRule, CoeffGridType>>;
 
+    /// @brief The number of interpolation dimensions.
+    static constexpr std::size_t rank()
+    {
+        return 1;
+    }
+
 private:
     extrapolation_rule_t<MinExtrapRule, CoeffGridType> m_min_extrapolation;
     extrapolation_rule_t<MaxExtrapRule, CoeffGridType> m_max_extrapolation;

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -69,6 +69,12 @@ public:
             extrapolation_rule_t<MinExtrapRule, Basis>,
             extrapolation_rule_t<MaxExtrapRule, Basis>>;
 
+    /// @brief The number of interpolation dimensions.
+    static constexpr std::size_t rank()
+    {
+        return 1;
+    }
+
 private:
     extrapolation_rule_t<MinExtrapRule, Basis> m_min_extrapolation;
     extrapolation_rule_t<MaxExtrapRule, Basis> m_max_extrapolation;

--- a/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
@@ -400,7 +400,7 @@ public:
         static_assert((std::is_same_v<InterestDim, Dim1>) || (std::is_same_v<InterestDim, Dim2>));
         if constexpr (std::is_same_v<InterestDim, Dim1>) {
             return deriv_dim_1(coord_eval, patches_splines);
-        } else if constexpr (std::is_same_v<InterestDim, Dim2>) {
+        } else {
             return deriv_dim_2(coord_eval, patches_splines);
         }
     }
@@ -618,7 +618,7 @@ private:
                 return m_extrapolation_rule(coord, patches_splines, patch_idx);
             } else {
                 Kokkos::abort("The spline derivatives cannot be evaluated at coordinates "
-                              "outside of the domain.");
+                              "outside of the domain.");// cppcheck-suppress missingReturn
             }
         } else {
             if (patch_idx == TestPatchIdx) {

--- a/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
@@ -618,7 +618,7 @@ private:
                 return m_extrapolation_rule(coord, patches_splines, patch_idx);
             } else {
                 Kokkos::abort("The spline derivatives cannot be evaluated at coordinates "
-                              "outside of the domain.");// cppcheck-suppress missingReturn
+                              "outside of the domain."); // cppcheck-suppress missingReturn
             }
         } else {
             if (patch_idx == TestPatchIdx) {

--- a/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_evaluator_2d.hpp
@@ -617,8 +617,9 @@ private:
                 replace_periodic_coord_inside<AnyPatch>(coord);
                 return m_extrapolation_rule(coord, patches_splines, patch_idx);
             } else {
-                Kokkos::abort("The spline derivatives cannot be evaluated at coordinates "
-                              "outside of the domain."); // cppcheck-suppress missingReturn
+                Kokkos::abort( // cppcheck-suppress missingReturn
+                        "The spline derivatives cannot be evaluated at coordinates "
+                        "outside of the domain.");
             }
         } else {
             if (patch_idx == TestPatchIdx) {


### PR DESCRIPTION
Generalise `concepts::Interpolator` to ND by removing 1D concepts (e.g. Grid, Basis) from `InterpolationBuilderTraits` and `InterpolationEvaluatorTraits`. Instead `IdxRange` objects are saved.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
