### PR TITLE
Remove Google Test submodule

### DIFF
--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -13,8 +13,6 @@ runs:
       if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> $GITHUB_ENV; echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV; fi
       FOUND_POISSON_2D=$(grep -P "(src/pde_solvers/polarpoissonlikesolver.hpp)|(src/pde_solvers/polarpoissonlikeassembler.hpp)|(tests/geometryRTheta/polar_poisson/.*)" -x changed_files.txt || true)
       if [ -z "$FOUND_POISSON_2D" ]; then echo "POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "POISSON_2D_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
-      FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
-      if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "DDC_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
     shell: bash
   - name: "Check filters"
     if: github.event_name != 'pull_request' && github.event_name != 'merge_request'
@@ -22,7 +20,5 @@ runs:
       echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> $GITHUB_ENV
       echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV
       echo "POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV
-      FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
-      if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "DDC_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
     shell: bash
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "vendor/googletest"]
-	path = vendor/googletest
-	url = https://github.com/google/googletest.git
-	branch = master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove 2D `Interpolator` classes:
   - `IInterpolator2D`
   - `SplineInterpolator2D`
+- Remove Google Test submodule.
 
 ## [v0.7.0] - 2026-03-18
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,6 @@ option(GYSELALIBXX_COMPILE_SOURCE "Enable compilation of the source code (this s
 set(GYSELALIBXX_DEFAULT_CXX_FLAGS "-O1" CACHE STRING "Default flags for C++ specific to Gyselalib++")
 option(ACTIVATE_RESTART_TESTS "Activate tests which check that a simulation gives the same results after restart." ON)
 
-set(GYSELALIBXX_DEPENDENCY_POLICIES "AUTO" "EMBEDDED" "INSTALLED")
-
-set(GYSELALIBXX_INCLUDE_TESTING_DEPENDENCIES ${GYSELALIBXX_BUILD_TESTING} CACHE BOOL "Indicates if the testing dependencies should be included. By default they are only included if the tests are built.")
-
 ###############################################################################################
 #                                     Get dependencies
 ###############################################################################################
@@ -62,23 +58,7 @@ find_package(paraconf 1.0.0...<2 REQUIRED COMPONENTS C)
 ### Look for a pre-installed PDI
 find_package(PDI 1.10.1...<2 REQUIRED COMPONENTS C)
 
-## if tests are enabled, use googletest from `vendor/`
-### we use it to write unit tests
-if("${GYSELALIBXX_INCLUDE_TESTING_DEPENDENCIES}")
-  set(GYSELALIBXX_GTest_DEPENDENCY_POLICY "AUTO" CACHE STRING "Policy to find the `GTest` package. Options: ${GYSELALIBXX_DEPENDENCY_POLICIES}")
-  set_property(CACHE GYSELALIBXX_GTest_DEPENDENCY_POLICY PROPERTY STRINGS ${GYSELALIBXX_DEPENDENCY_POLICIES})
-
-  if("${GYSELALIBXX_GTest_DEPENDENCY_POLICY}" STREQUAL "AUTO")
-    find_package(GTest "1.12" QUIET)
-    if(NOT "${GTest_FOUND}")
-      add_subdirectory(vendor/googletest SYSTEM)
-    endif()
-  elseif("${GYSELALIBXX_GTest_DEPENDENCY_POLICY}" STREQUAL "EMBEDDED")
-    add_subdirectory(vendor/googletest SYSTEM)
-  elseif("${GYSELALIBXX_GTest_DEPENDENCY_POLICY}" STREQUAL "INSTALLED")
-    find_package(GTest "1.12" REQUIRED)
-  endif()
-endif()
+find_package(GTest 1.12 REQUIRED)
 
 find_package(Kokkos 4.4.1...<5 REQUIRED)
 

--- a/bin/ci_tools/reusable_ci_jobs.yml
+++ b/bin/ci_tools/reusable_ci_jobs.yml
@@ -10,8 +10,6 @@
     - if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "POLAR_SPLINES_TEST_DEGREE_MIN=1" >> build.env; echo "POLAR_SPLINES_TEST_DEGREE_MIN=6" >> build.env; fi
     - FOUND_POISSON_2D=$(grep "\(src/pde_solvers/polarpoissonlikesolver.hpp\)\|\(tests/geometryRTheta/polar_poisson/.*\)" -x changed_files.txt || true)
     - if [ -z "$FOUND_POISSON_2D" ]; then echo "POISSON_2D_BUILD_TESTING=OFF" >> build.env; else echo "POISSON_2D_BUILD_TESTING=ON" >> build.env; fi
-    - FOUND_DDC=$(grep "vendor/ddc" changed_files.txt || true)
-    - if [ -z "$FOUND_DDC" ]; then echo "DDC_BUILD_TESTING=OFF" >> build.env; else echo "DDC_BUILD_TESTING=ON" >> build.env; fi
   artifacts:
     expire_in: 1 week
     reports:

--- a/docs/first_steps/profiling.md
+++ b/docs/first_steps/profiling.md
@@ -4,22 +4,14 @@ Gyselalib++ is built on DDC which is in turn built on [Kokkos](https://kokkos.or
 
 ## General Profiling with Kokkos Tools
 
-Kokkos Tools must be compiled before they can be used. If you have a system installation or an instance of Kokkos Tools elsewhere on you system then this can be used. Otherwise the Kokkos-tools repository can be found as a submodule of Gyselalib++ in `vendor/kokkos-tools/`.
-
-To compile all Kokkos Tools libraries simply run:
-
-```bash
-cd $GYSELALIB_ROOT/vendor/kokkos-tools
-cmake -B build .
-cmake --build build
-```
+Kokkos Tools must be compiled before they can be used. If you have a system installation or an instance of Kokkos Tools elsewhere on you system then this can be used.
 
 Kokkos Tools provide hooks to measure and annotate performance data. You can enable a tool by setting the `KOKKOS_PROFILE_LIBRARY` environment variable to point to the shared library implementing the tool.
 
 For example:
 
 ```bash
-export KOKKOS_TOOLS_LIBS=$GYSELALIB_ROOT/vendor/kokkos-tools/build/profiling/simple-kernel-timer/libkp_kernel_timer.so
+export KOKKOS_TOOLS_LIBS=libkp_kernel_timer.so
 ```
 
 Gyselalib++ will then automatically invoke the tool for all Kokkos kernels.

--- a/src/collisions/README.md
+++ b/src/collisions/README.md
@@ -2,7 +2,7 @@
 
 Collision operator in $`(v_\parallel,\mu)`$ applied to all against all species at the same time. As such, the operator is $O(N^2)$ in number of species.
 
-It was rewritten from Fortran into C++. The operator's name is KOkkos coLIsion OPerator (KOLIOP) and is provided as a submodule (see `/vendor`).
+It was rewritten from Fortran into C++. The operator's name is KOkkos coLIsion OPerator (KOLIOP).
 
 While the operator is in C++, the interface with Fortran and other C++ code is made through a C layer. This is also known as the hourglass pattern (conceptually, the narrow neck of the device represent the lowering to C).
 


### PR DESCRIPTION
In this PR I suggest to remove the last submodule in order to simplify the main CMakeLists.txt. I am not aware of any toolchain relying on this submodule, I don't expect any impact.

I also removed some leftovers of the DDC, Koliop and Kokkos Tools submodules.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
