### PR TITLE
Disable costly variants in Spack based toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `ACTIVATE_RESTART_TESTS` -> `GYSELALIBXX_ACTIVATE_RESTART_TESTS`.
 - Renamed `POISSON_2D_BUILD_TESTING` -> `GYSELALIBXX_POISSON_2D_BUILD_TESTING`.
 - Pin toolchains to Python 3.13.
+- Disable some costly variants in Spack based toolchains.
 
 ### Deprecated
 

--- a/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
@@ -82,5 +82,7 @@ spack:
       - spec: openmpi@5.0.9+cuda~java~memchecker~rocm~static~wrapper-rpath fabrics=psm2,ucx schedulers=none
         prefix: /mpcdf/soft/SLE_15/packages/skylake/openmpi_gpu/cuda_12.8-12.8.1-gcc_14-14.1.0/5.0.9
     py-dask:
-      variants: ~dataframe
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']
   view: false

--- a/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
+++ b/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
@@ -57,5 +57,7 @@ spack:
       require: openmpi@5.0
     pdi:
       require: ~python
+    py-dask:
+      prefer: ['~dataframe']
     py-pandas:
-      require: ~performance
+      prefer: ['~performance']

--- a/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -66,7 +66,9 @@ spack:
     mpi:
       require: cray-mpich
     py-dask:
-      variants: ~dataframe
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']
   modules:
     default:
       roots: {}

--- a/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
@@ -83,5 +83,7 @@ spack:
           fabrics=ucx schedulers=slurm
         prefix: /lustre/fshomisc/sup/spack_soft/openmpi/4.1.6/gcc-11.4.1-hbuwwfts4cctbzqir427u56mkk6zu3qr
     py-dask:
-      variants: ~dataframe
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']
   view: false

--- a/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -66,7 +66,9 @@ spack:
     mpi:
       require: cray-mpich
     py-dask:
-      variants: ~dataframe
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']
   modules:
     default:
       roots: {}

--- a/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
@@ -60,3 +60,7 @@ spack:
       require: openblas
     mpi:
       require: openmpi +cuda
+    py-dask:
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']

--- a/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
@@ -61,3 +61,7 @@ spack:
       require: openblas
     mpi:
       require: openmpi ~cuda
+    py-dask:
+      prefer: ['~dataframe']
+    py-pandas:
+      prefer: ['~performance']


### PR DESCRIPTION
Disable these two variants avoid installing boost (inodes consuming) and llvm (time consuming). For the usage of `prefer`, https://spack.readthedocs.io/en/latest/frequently_asked_questions.html#why-does-spack-pick-particular-versions-and-variants

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
