### PR TITLE
Improve quadrature for axi-symmetric geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix missing load of `pdiplugin-pycall` in some Spack-based toolchains.
 - Fix missing update of Spack repos before loading environments.
+- Fix `compute_coeffs_on_mapping` to allow integration when a coordinate change allows the determinant of the Jacobian to be calculated with less information than is required to calculate the Jacobian matrix.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Take pointwise values for `PolarSplineFEMPoissonLikeSolver::update_coefficients`.
 - Allow pointwise values to be passed to `PolarSplineFEMPoissonLikeSolver::operator()`.
 - Rename `polarpoissonlikesolver.hpp` -> `polar_spline_fem_poisson_like_solver.hpp`.
+- Allow the components and determinant of the Jacobian of a coordinate transformation to be any floating point precision.
 
 ### Deprecated
 

--- a/src/coord_transformations/coord_transformation_tools.hpp
+++ b/src/coord_transformations/coord_transformation_tools.hpp
@@ -61,8 +61,7 @@ concept MappingWithInvJacobian
 };
 
 template <typename T, class IntegrationCoord>
-concept MappingWithIntegrationCoord
-        = Mapping<T> && requires(T const& t, IntegrationCoord const& x)
+concept MappingWithIntegrationCoord = Mapping<T> && requires(T const& t, IntegrationCoord const& x)
 {
     {
         t.jacobian(x)

--- a/src/coord_transformations/coord_transformation_tools.hpp
+++ b/src/coord_transformations/coord_transformation_tools.hpp
@@ -60,6 +60,15 @@ concept MappingWithInvJacobian
         } -> std::same_as<double>;
 };
 
+template <typename T, class IntegrationCoord>
+concept MappingWithIntegrationCoord
+        = Mapping<T> && requires(T const& t, IntegrationCoord const& x)
+{
+    {
+        t.jacobian(x)
+        } -> std::same_as<double>;
+};
+
 template <typename T>
 concept AnalyticalMapping = Mapping<T> && requires(T const& t)
 {

--- a/src/coord_transformations/coord_transformation_tools.hpp
+++ b/src/coord_transformations/coord_transformation_tools.hpp
@@ -27,6 +27,26 @@ concept Mapping = requires
         } -> std::same_as<typename T::CoordResult>;
 };
 
+template <typename T, typename CoordTransform>
+concept JacobianMatrix
+        = is_tensor_type_v<T> && std::is_floating_point_v<typename T::element_type> && std::same_as<
+                T,
+                Tensor<typename T::element_type,
+                       get_contravariant_dims_t<
+                               ddc::to_type_seq_t<typename CoordTransform::CoordResult>>,
+                       get_covariant_dims_t<
+                               ddc::to_type_seq_t<typename CoordTransform::CoordArg>>>>;
+
+template <typename T, typename CoordTransform>
+concept InvJacobianMatrix
+        = is_tensor_type_v<T> && std::is_floating_point_v<typename T::element_type> && std::same_as<
+                T,
+                Tensor<typename T::element_type,
+                       get_contravariant_dims_t<
+                               ddc::to_type_seq_t<typename CoordTransform::CoordArg>>,
+                       get_covariant_dims_t<
+                               ddc::to_type_seq_t<typename CoordTransform::CoordResult>>>>;
+
 template <typename T>
 concept MappingWithJacobian = Mapping<T> && requires
 {
@@ -35,15 +55,13 @@ concept MappingWithJacobian = Mapping<T> && requires
 {
     {
         t.jacobian_matrix(x)
-        } -> std::same_as<
-                DTensor<get_contravariant_dims_t<ddc::to_type_seq_t<typename T::CoordResult>>,
-                        get_covariant_dims_t<ddc::to_type_seq_t<typename T::CoordArg>>>>;
+        } -> JacobianMatrix<T>;
     {
         t.template jacobian_component<int, int>(x)
-        } -> std::same_as<double>;
+        } -> std::floating_point;
     {
         t.jacobian(x)
-        } -> std::same_as<double>;
+        } -> std::floating_point;
 };
 
 template <typename T>
@@ -52,12 +70,10 @@ concept MappingWithInvJacobian
 {
     {
         t.inv_jacobian_matrix(x)
-        } -> std::same_as<
-                DTensor<get_contravariant_dims_t<ddc::to_type_seq_t<typename T::CoordArg>>,
-                        get_covariant_dims_t<ddc::to_type_seq_t<typename T::CoordResult>>>>;
+        } -> InvJacobianMatrix<T>;
     {
         t.template inv_jacobian_component<int, int>(x)
-        } -> std::same_as<double>;
+        } -> std::floating_point;
 };
 
 template <typename T, class IntegrationCoord>
@@ -65,7 +81,7 @@ concept MappingWithIntegrationCoord = Mapping<T> && requires(T const& t, Integra
 {
     {
         t.jacobian(x)
-        } -> std::same_as<double>;
+        } -> std::floating_point;
 };
 
 template <typename T>

--- a/src/quadrature/volume_quadrature_nd.hpp
+++ b/src/quadrature/volume_quadrature_nd.hpp
@@ -47,8 +47,17 @@ DFieldMem<IdxRangeCoeffs, typename ExecSpace::memory_space> compute_coeffs_on_ma
         Mapping& mapping,
         DFieldMem<IdxRangeCoeffs, typename ExecSpace::memory_space>&& coefficients_alloc)
 {
-    using CoordJ = typename Mapping::CoordJacobian;
-    using IdxJ = find_idx_t<CoordJ, IdxRangeCoeffs>;
+    // Get type information about Jacobian definition
+    using CoordJacobian = typename Mapping::CoordJacobian;
+    using IdxJacobian = find_idx_t<CoordJacobian, IdxRangeCoeffs>;
+    using TypeSeqJacobian = ddc::to_type_seq_t<IdxJacobian>;
+    // Strip any Grids not found in the index range
+    using TypeSeqJ = ddc::type_seq_remove_t<TypeSeqJacobian, ddc::detail::TypeSeq<void>>;
+    using IdxRangeJ = ddc::detail::convert_type_seq_to_discrete_domain_t<TypeSeqJ>;
+    using IdxJ = typename IdxRangeJ::discrete_element_type;
+    using CoordJ = ddc::coordinate_of_t<IdxJ>;
+    // Check that the resulting coordinate is valid for retrieving the determinant of the Jacobian
+    static_assert(concepts::MappingWithIntegrationCoord<Mapping, CoordJ>);
 
     using IdxCoeffs = typename IdxRangeCoeffs::discrete_element_type;
     IdxRangeCoeffs grid = get_idx_range(coefficients_alloc);

--- a/src/quadrature/volume_quadrature_nd.hpp
+++ b/src/quadrature/volume_quadrature_nd.hpp
@@ -57,7 +57,10 @@ DFieldMem<IdxRangeCoeffs, typename ExecSpace::memory_space> compute_coeffs_on_ma
     using IdxJ = typename IdxRangeJ::discrete_element_type;
     using CoordJ = ddc::coordinate_of_t<IdxJ>;
     // Check that the resulting coordinate is valid for retrieving the determinant of the Jacobian
-    static_assert(concepts::MappingWithIntegrationCoord<Mapping, CoordJ>);
+    static_assert(
+            concepts::MappingWithIntegrationCoord<Mapping, CoordJ>,
+            "The provided index range does not give enough positional information to define the "
+            "determinant of the Jacobian");
 
     using IdxCoeffs = typename IdxRangeCoeffs::discrete_element_type;
     IdxRangeCoeffs grid = get_idx_range(coefficients_alloc);


### PR DESCRIPTION
Fix `compute_coeffs_on_mapping` to allow integration when a coordinate change allows the determinant of the Jacobian to be calculated with less information than is required to calculate the Jacobian matrix.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
