### PR TITLE
Fix `PolarSplineFEMPoissonLikeSolver` with a 3D metric tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing load of `pdiplugin-pycall` in some Spack-based toolchains.
 - Fix missing update of Spack repos before loading environments.
 - Fix missing `PDIEvent(initialisation)` in the guiding centre (X,Y) simulation.
+- Fix `ddcHelper::assign_elements` to allow a ND tensor to be truncated to a MD tensor (with M\<N).
+- Fix use of `PolarSplineFEMPoissonLikeSolver` with a ND metric tensor (with N\>2).
 
 ### Changed
 

--- a/src/data_types/tensor_common.hpp
+++ b/src/data_types/tensor_common.hpp
@@ -259,7 +259,7 @@ template <
         class... OutputValidIndexSet,
         class... InputValidIndexSet,
         std::size_t... InternalIdx>
-KOKKOS_INLINE_FUNCTION void assign_elements(
+KOKKOS_INLINE_FUNCTION void assign_elements_from_subset(
         TensorCommon<OutputStorageType, OutputValidIndexSet...>& tensor_to_fill,
         TensorCommon<InputStorageType, InputValidIndexSet...> const& tensor_input,
         std::index_sequence<InternalIdx...>)
@@ -272,6 +272,28 @@ KOKKOS_INLINE_FUNCTION void assign_elements(
                       InputTensorIndexSet>::IdxTypeSeq>>()
       = tensor_input.template get<
               tensor_tools::get_nth_tensor_index_element_t<InternalIdx, InputTensorIndexSet>>()),
+     ...);
+}
+
+template <
+        class InputStorageType,
+        class OutputStorageType,
+        class... OutputValidIndexSet,
+        class... InputValidIndexSet,
+        std::size_t... InternalIdx>
+KOKKOS_INLINE_FUNCTION void assign_elements_to_subset(
+        TensorCommon<OutputStorageType, OutputValidIndexSet...>& tensor_to_fill,
+        TensorCommon<InputStorageType, InputValidIndexSet...> const& tensor_input,
+        std::index_sequence<InternalIdx...>)
+{
+    using OutputTensorIndexSet = ddc::detail::TypeSeq<OutputValidIndexSet...>;
+    ((tensor_to_fill.template get<tensor_tools::to_tensor_index_element_t<
+              ddc::detail::TypeSeq<OutputValidIndexSet...>,
+              typename tensor_tools::get_nth_tensor_index_element_t<
+                      InternalIdx,
+                      OutputTensorIndexSet>::IdxTypeSeq>>()
+      = tensor_input.template get<
+              tensor_tools::get_nth_tensor_index_element_t<InternalIdx, OutputTensorIndexSet>>()),
      ...);
 }
 } // namespace detail
@@ -341,11 +363,21 @@ KOKKOS_INLINE_FUNCTION void assign_elements(
         TensorCommon<OutputStorageType, OutputValidIndexSet...>& tensor_to_fill,
         TensorCommon<InputStorageType, InputValidIndexSet...> const& tensor_input)
 {
-    detail::assign_elements(
-            tensor_to_fill,
-            tensor_input,
-            std::make_index_sequence<
-                    TensorCommon<InputStorageType, InputValidIndexSet...>::size()>());
+    constexpr std::size_t n_input_elements
+            = TensorCommon<InputStorageType, InputValidIndexSet...>::size();
+    constexpr std::size_t n_output_elements
+            = TensorCommon<OutputStorageType, OutputValidIndexSet...>::size();
+    if constexpr (n_input_elements < n_output_elements) {
+        detail::assign_elements_from_subset(
+                tensor_to_fill,
+                tensor_input,
+                std::make_index_sequence<n_input_elements>());
+    } else {
+        detail::assign_elements_to_subset(
+                tensor_to_fill,
+                tensor_input,
+                std::make_index_sequence<n_output_elements>());
+    }
 }
 
 } // namespace ddcHelper

--- a/src/pde_solvers/polar_spline_fem_poisson_like_assembler.hpp
+++ b/src/pde_solvers/polar_spline_fem_poisson_like_assembler.hpp
@@ -1112,14 +1112,18 @@ public:
 
         MetricTensorEvaluator<Mapping, Coord<R, Theta>> get_metric_tensor(mapping);
 
+        using Spatial2DVectorSpace = VectorIndexSet<R, Theta>;
+
         Tensor inv_metric_tensor = get_metric_tensor.inverse(coord);
+        DTensor<Spatial2DVectorSpace, Spatial2DVectorSpace> inv_metric_tensor_2d;
+        ddcHelper::assign_elements(inv_metric_tensor_2d, inv_metric_tensor);
 
         // Assemble the weak integral element
         return int_volume(idx_quad)
                * (alpha
                           * tensor_mul(
                                   index<'i'>(basis_derivs_test_space),
-                                  index<'i', 'j'>(inv_metric_tensor),
+                                  index<'i', 'j'>(inv_metric_tensor_2d),
                                   index<'j'>(basis_derivs_trial_space))
                   + beta * basis_val_test_space * basis_val_trial_space);
     }


### PR DESCRIPTION
Fix use of `PolarSplineFEMPoissonLikeSolver` with a ND metric tensor (with N\>2) by truncating the metric tensor before the calculation. This requires an improvement to `ddcHelper::assign_elements` to allow a tensor to be truncated. This is not allowed in the constructor to prevent accidental truncation.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
