### PR TITLE
Reduce unnecessary memory usage in `BslAdvection1D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing load of `pdiplugin-pycall` in some Spack-based toolchains.
 - Fix missing update of Spack repos before loading environments.
 - Fix missing `PDIEvent(initialisation)` in the guiding centre (X,Y) simulation.
+- Decrease memory usage in `BslAdvection1D`.
 
 ### Changed
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -114,6 +114,7 @@ private:
     using IdxRangeFunctionBasis = typename InterpolationBuilderTraits<
             FunctionBuilder>::template batched_basis_idx_range_type<IdxRangeFunction>;
     using FunctionBasisFieldMem = FieldMem<DataType, IdxRangeFunctionBasis>;
+    using FunctionBasisConstField = ConstField<DataType, IdxRangeFunctionBasis>;
 
     // Type for the derivatives of the function
     using IdxRangeFunctionDeriv = typename InterpolationBuilderTraits<
@@ -337,6 +338,8 @@ public:
                 std::optional(get_const_field(function_derivatives_min)),
                 std::optional(get_const_field(function_derivatives_max)));
 
+        FunctionBasisConstField function_coefs = get_const_field(function_coefs_alloc);
+
         FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         // Evaluate the function at the characteristic feet
         ddc::parallel_for_each(
@@ -345,10 +348,8 @@ public:
                 idx_range_function,
                 KOKKOS_LAMBDA(IdxFunction const idx) {
                     IdxAdvection slice_foot_index(idx);
-                    function_evaluator_proxy(
-                            allfdistribu,
-                            slice_feet(slice_foot_index),
-                            get_const_field(function_coefs_alloc));
+                    CoordInterest coord = slice_feet(slice_foot_index);
+                    allfdistribu(idx) = function_evaluator_proxy(coord, function_coefs);
                 });
 
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -330,19 +330,6 @@ public:
             To interpolate the function we want to advect, we build for the feet a Field defined
             on the index range where the function is defined.
         */
-        FieldMem<CoordInterest, IdxRangeFunction>
-                feet_alloc("feet (BslAdvection1D::operator())", idx_range_function);
-        Field<CoordInterest, IdxRangeFunction> feet = get_field(feet_alloc);
-        ddc::parallel_for_each(
-                location.function_name(),
-                Kokkos::DefaultExecutionSpace(),
-                idx_range_function,
-                KOKKOS_LAMBDA(IdxFunction const idx) {
-                    IdxAdvection slice_foot_index(idx);
-                    feet(idx) = slice_feet(slice_foot_index);
-                });
-
-
         // Build interpolation coefficients from the function values
         m_function_builder(
                 get_field(function_coefs_alloc),
@@ -351,10 +338,17 @@ public:
                 std::optional(get_const_field(function_derivatives_max)));
 
         // Evaluate the function at the characteristic feet
-        m_function_evaluator(
-                allfdistribu,
-                get_const_field(feet),
-                get_const_field(function_coefs_alloc));
+        ddc::parallel_for_each(
+                location.function_name(),
+                Kokkos::DefaultExecutionSpace(),
+                idx_range_function,
+                KOKKOS_LAMBDA(IdxFunction const idx) {
+                    IdxAdvection slice_foot_index(idx);
+                    m_function_evaluator(
+                            allfdistribu,
+                            slice_feet(slice_foot_index),
+                            get_const_field(function_coefs_alloc));
+                });
 
 
         Kokkos::Profiling::popRegion();

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -337,6 +337,7 @@ public:
                 std::optional(get_const_field(function_derivatives_min)),
                 std::optional(get_const_field(function_derivatives_max)));
 
+        FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         // Evaluate the function at the characteristic feet
         ddc::parallel_for_each(
                 location.function_name(),
@@ -344,7 +345,7 @@ public:
                 idx_range_function,
                 KOKKOS_LAMBDA(IdxFunction const idx) {
                     IdxAdvection slice_foot_index(idx);
-                    m_function_evaluator(
+                    function_evaluator_proxy(
                             allfdistribu,
                             slice_feet(slice_foot_index),
                             get_const_field(function_coefs_alloc));

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -248,6 +248,8 @@ public:
             std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_max
             = std::nullopt) const
     {
+        using IdxRangeBatchFunction = ddc::remove_dims_of_t<IdxRangeFunction, GridInterest>;
+        using IdxBatchFunction = typename IdxRangeBatchFunction::discrete_element_type;
         Kokkos::Profiling::pushRegion("BslAdvection1D");
 
         // Get index ranges and operators ........................................................
@@ -348,8 +350,10 @@ public:
                 idx_range_function,
                 KOKKOS_LAMBDA(IdxFunction const idx) {
                     IdxAdvection slice_foot_index(idx);
-                    CoordInterest coord = slice_feet(slice_foot_index);
-                    allfdistribu(idx) = function_evaluator_proxy(coord, function_coefs);
+                    IdxBatchFunction batch_idx(idx);
+                    allfdistribu(idx) = function_evaluator_proxy(
+                            slice_feet(slice_foot_index),
+                            function_coefs[batch_idx]);
                 });
 
 


### PR DESCRIPTION
Reduce unnecessary memory usage in `BslAdvection1D`. Currently the feet are copied to a high-dimensional object in order to call the batched version of the DDC builder but this is not necessary. A loop can be used easily.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
