### PR TITLE
Remove last usage of ddc::cartesian_prod_t

### DIFF
--- a/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
+++ b/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
@@ -248,10 +248,8 @@ public:
             ddc::BoundCond const& Bound1 = ddc::BoundCond::HERMITE,
             ddc::BoundCond const& Bound2 = ddc::BoundCond::HERMITE)
         : SingleInterfaceDerivativesCalculator(
-                IdxRange1DPerp_1(
-                        ddc::cartesian_prod_t<IdxRangeA, IdxRangeB>(idx_range_a, idx_range_b)),
-                IdxRange1DPerp_2(
-                        ddc::cartesian_prod_t<IdxRangeA, IdxRangeB>(idx_range_a, idx_range_b)),
+                IdxRange1DPerp_1(idx_range_a, idx_range_b),
+                IdxRange1DPerp_2(idx_range_a, idx_range_b),
                 Bound1,
                 Bound2)
     {
@@ -309,10 +307,8 @@ public:
             IdxRangeB const& idx_range_b,
             std::size_t const number_chosen_cells)
         : SingleInterfaceDerivativesCalculator(
-                IdxRange1DPerp_1(
-                        ddc::cartesian_prod_t<IdxRangeA, IdxRangeB>(idx_range_a, idx_range_b)),
-                IdxRange1DPerp_2(
-                        ddc::cartesian_prod_t<IdxRangeA, IdxRangeB>(idx_range_a, idx_range_b)),
+                IdxRange1DPerp_1(idx_range_a, idx_range_b),
+                IdxRange1DPerp_2(idx_range_a, idx_range_b),
                 number_chosen_cells)
     {
         static_assert(ddc::is_discrete_domain_v<IdxRangeA>);


### PR DESCRIPTION
The constructor of DiscreteDomain already handles the slicing and merging and I plan to remove it in DDC as it does not handle other types of domains. No need for a changelog entry, it is an internal change.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
