### PR TITLE
Remove hardcoded boundary conditions in `BslAdvection1D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix use of `PolarSplineFEMPoissonLikeSolver` with a ND metric tensor (with N\>2).
 - Decrease memory usage in `BslAdvection1D`.
 - Fix `compute_coeffs_on_mapping` to allow integration when a coordinate change allows the determinant of the Jacobian to be calculated with less information than is required to calculate the Jacobian matrix.
+- Fix hardcoded Homogeneous Hermite boundary conditions in `BslAdvection1D`.
 
 ### Changed
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -119,7 +119,7 @@ private:
     // Type for the derivatives of the function
     using IdxRangeFunctionDeriv = typename InterpolationBuilderTraits<
             FunctionBuilder>::template batched_derivs_idx_range_type<IdxRangeFunction>;
-    using FunctionDerivFieldMem = FieldMem<DataType, IdxRangeFunctionDeriv>;
+    using FunctionDerivConstField = ConstField<DataType, IdxRangeFunctionDeriv>;
 
     using TimeStepper = typename TimeStepperBuilder::template time_stepper_t<
             FieldMem<Coord<typename GridInterest::continuous_dimension_type>, IdxRangeAdvection>,
@@ -246,6 +246,9 @@ public:
             std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_min
             = std::nullopt,
             std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_max
+            = std::nullopt,
+            std::optional<FunctionDerivConstField> const function_derivatives_min = std::nullopt,
+            std::optional<FunctionDerivConstField> const function_derivatives_max
             = std::nullopt) const
     {
         using IdxRangeBatchFunction = ddc::remove_dims_of_t<IdxRangeFunction, GridInterest>;
@@ -273,14 +276,6 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
-
-        // Build derivatives on boundaries and fill with zeros....................................
-        FunctionDerivFieldMem function_derivatives_min(
-                m_function_builder.batched_derivs_xmin_domain(idx_range_function));
-        FunctionDerivFieldMem function_derivatives_max(
-                m_function_builder.batched_derivs_xmax_domain(idx_range_function));
-        ddc::parallel_fill(Kokkos::DefaultExecutionSpace(), function_derivatives_min, 0.);
-        ddc::parallel_fill(Kokkos::DefaultExecutionSpace(), function_derivatives_max, 0.);
 
         // Initialise the characteristics on the mesh points .....................................
         /*
@@ -337,8 +332,8 @@ public:
         m_function_builder(
                 get_field(function_coefs_alloc),
                 get_const_field(allfdistribu),
-                std::optional(get_const_field(function_derivatives_min)),
-                std::optional(get_const_field(function_derivatives_max)));
+                function_derivatives_min,
+                function_derivatives_max);
 
         FunctionBasisConstField function_coefs = get_const_field(function_coefs_alloc);
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -231,11 +231,23 @@ public:
      *
      * @param[in, out] allfdistribu Reference to the advected function, allocated on the device
      * @param[in] advection_field Reference to the advection field, allocated on the device.
+     * @param[in] dt Time step.
      * @param[in] advection_field_derivatives_min Reference to the advection field
      *              derivatives at the left side of the interest dimension, allocated on the device.
+     *              This only needs to be provided if the advection field is represented using a
+     *              spline with Hermite boundary conditions.
      * @param[in] advection_field_derivatives_max Reference to the advection field
      *              derivatives at the right side of the interest dimension, allocated on the device.
-     * @param[in] dt Time step.
+     *              This only needs to be provided if the advection field is represented using a
+     *              spline with Hermite boundary conditions.
+     * @param[in] function_derivatives_min Reference to the function
+     *              derivatives at the left side of the interest dimension, allocated on the device.
+     *              This only needs to be provided if the function is represented using a
+     *              spline with Hermite boundary conditions.
+     * @param[in] function_derivatives_max Reference to the function
+     *              derivatives at the right side of the interest dimension, allocated on the device.
+     *              This only needs to be provided if the function is represented using a
+     *              spline with Hermite boundary conditions.
      *
      * @return A reference to the allfdistribu array after advection on dt.
      */

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -46,7 +46,7 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 };
 
 ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineVxBoundary = ddc::BoundCond::HERMITE;
+ddc::BoundCond constexpr SplineVxBoundary = ddc::BoundCond::HOMOGENEOUS_HERMITE;
 
 
 // Discrete dimensions


### PR DESCRIPTION
Remove hardcoded Homogeneous Hermite boundary conditions in `BslAdvection1D`. Fixes #546 
To reproduce the same boundary condition it is better to use `ddc::BoundCond::HOMOGENEOUS_HERMITE`.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
