### PR TITLE
Reduce memory requirements for `SplinePolarFootFinder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decrease memory usage in `BslAdvection1D`.
 - Fix `compute_coeffs_on_mapping` to allow integration when a coordinate change allows the determinant of the Jacobian to be calculated with less information than is required to calculate the Jacobian matrix.
 - Fix hardcoded Homogeneous Hermite boundary conditions in `BslAdvection1D`.
+- Decrease memory usage in `SplinePolarFootFinder`.
 
 ### Changed
 

--- a/bin/ci_tools/gyselalib_static_analysis.py
+++ b/bin/ci_tools/gyselalib_static_analysis.py
@@ -272,6 +272,10 @@ def search_for_unnecessary_auto(file):
                 start = end + 1
                 end = next(i for i,v in enumerate(config.data[start:], start) if v['str'] == ';')
 
+            if config.data[start+2]['str'] == '[':
+                # Allow lambdas to be saved to auto
+                continue
+
             if any(v['str'] == 'gko' for v in config.data[start:end]) and any(v['str'] == 'create' for v in config.data[start:end]):
                 continue
 

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -166,10 +166,8 @@ private:
                     ddc::detail::TypeSeq<GridR, GridTheta>,
                     ddc::detail::TypeSeq<BSplinesR, BSplinesTheta>>>;
 
-    using TimeStepper = typename TimeStepperBuilder::template time_stepper_t<
-            FieldMem<CoordRTheta, IdxRangeBatched, MemSpace>,
-            DVectorFieldMem<IdxRangeBatched, VectorIndexSet<X_adv, Y_adv>, MemSpace>,
-            ExecSpace>;
+    using TimeStepper = typename TimeStepperBuilder::
+            template time_stepper_t<CoordRTheta, DVector<X_adv, Y_adv>>;
 
     TimeStepperBuilder const& m_time_stepper_builder;
 
@@ -281,36 +279,23 @@ public:
                     advection_field,
             double dt) const final
     {
-        VectorSplineCoeffsMem advection_field_in_adv_domain_coefs(
-                m_builder_advection_field.batched_spline_domain(get_idx_range(advection_field)));
+        static_assert(ddc::type_seq_size_v<VectorIndexSetAdvectionDims> == 2);
+        using AdvDim1 = ddc::type_seq_element_t<0, VectorIndexSetAdvectionDims>;
+        using AdvDim2 = ddc::type_seq_element_t<1, VectorIndexSetAdvectionDims>;
 
-        // Compute the advection field in the advection domain.
-        auto advection_field_in_adv_domain = create_mirror_view_and_copy_on_vector_space<
-                PseudoCartesianBasis>(ExecSpace(), advection_field, m_pseudo_physical_to_physical);
+        DVectorFieldMem<IdxRangeSplineBatched, VectorIndexSetAdvectionDims, memory_space>
+                advection_field_coefs_alloc(m_builder_advection_field.batched_spline_domain(
+                        get_idx_range(advection_field)));
+        DVectorField<IdxRangeSplineBatched, VectorIndexSetAdvectionDims, memory_space>
+                advection_field_coefs(advection_field_coefs_alloc);
 
         // Get the coefficients of the advection field in the advection domain.
         m_builder_advection_field(
-                ddcHelper::get<X_adv>(advection_field_in_adv_domain_coefs),
-                ddcHelper::get<X_adv>(get_const_field(advection_field_in_adv_domain)));
+                ddcHelper::get<AdvDim1>(advection_field_coefs),
+                ddcHelper::get<AdvDim1>(get_const_field(advection_field)));
         m_builder_advection_field(
-                ddcHelper::get<Y_adv>(advection_field_in_adv_domain_coefs),
-                ddcHelper::get<Y_adv>(get_const_field(advection_field_in_adv_domain)));
-
-
-        // The function describing how the derivative of the evolve function is calculated.
-        std::function<void(DVectorFieldAdvection, CConstFieldFeet)> dy
-                = [&](DVectorFieldAdvection updated_advection_field, CConstFieldFeet feet) {
-                      m_evaluator_advection_field(
-                              get_field(ddcHelper::get<X_adv>(updated_advection_field)),
-                              get_const_field(feet),
-                              get_const_field(
-                                      ddcHelper::get<X_adv>(advection_field_in_adv_domain_coefs)));
-                      m_evaluator_advection_field(
-                              get_field(ddcHelper::get<Y_adv>(updated_advection_field)),
-                              get_const_field(feet),
-                              get_const_field(
-                                      ddcHelper::get<Y_adv>(advection_field_in_adv_domain_coefs)));
-                  };
+                ddcHelper::get<AdvDim2>(advection_field_coefs),
+                ddcHelper::get<AdvDim2>(get_const_field(advection_field)));
 
         CoordXY_adv coord_centre(m_logical_to_pseudo_physical(CoordRTheta(0, 0)));
         LogicalToPseudoPhysicalMapping logical_to_pseudo_physical_proxy
@@ -321,45 +306,67 @@ public:
         IdxRangeOperator idx_range = get_idx_range(feet);
         IdxRangeTheta idx_range_theta(idx_range);
 
-        // The function describing how the value(s) are updated using the derivative.
-        std::function<void(CFieldFeet, DVectorConstFieldAdvection, double)> update_function
-                = [&](CFieldFeet feet, DVectorConstFieldAdvection advection_field, double dt) {
-                      // Compute the characteristic feet at t^n:
-                      const std::source_location location = std::source_location::current();
-                      ddc::parallel_for_each(
-                              location.function_name(),
-                              ExecSpace(),
-                              get_idx_range(feet),
-                              KOKKOS_LAMBDA(IdxOperator const idx) {
-                                  CoordRTheta const coord_rtheta(feet(idx));
-                                  CoordXY_adv const coord_xy
-                                          = logical_to_pseudo_physical_proxy(coord_rtheta);
+        TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
-                                  CoordXY_adv const feet_xy = coord_xy - dt * advection_field(idx);
+        // Compute the characteristic feet at t^n:
+        const std::source_location location = std::source_location::current();
+        ddc::parallel_for_each(
+                location.function_name(),
+                ExecSpace(),
+                get_idx_range(feet),
+                KOKKOS_LAMBDA(IdxOperator const idx) {
+                    IdxBatch idx_batch(idx);
+                    IdxRTheta idx_rtheta(idx);
+                    // The function describing how the derivative of the evolve function is calculated.
+                    std::function<void(DVector<X_adv, Y_adv>&, CoordRTheta const&)> dy
+                            = [&](DVector<X_adv, Y_adv>& updated_advection_field,
+                                  CoordRTheta const& foot) {
+                                  DVector<AdvDim1, AdvDim2> updated_advection_field_adv_space;
+                                  ddcHelper::get<AdvDim1>(updated_advection_field_adv_space)
+                                          = m_evaluator_advection_field(
+                                                  foot,
+                                                  get_const_field(ddcHelper::get<AdvDim1>(
+                                                          advection_field_coefs)[idx_batch]));
+                                  ddcHelper::get<AdvDim2>(updated_advection_field_adv_space)
+                                          = m_evaluator_advection_field(
+                                                  foot,
+                                                  get_const_field(ddcHelper::get<AdvDim2>(
+                                                          advection_field_coefs)[idx_batch]));
+                                  updated_advection_field
+                                          = to_vector_space<VectorIndexSet<X_adv, Y_adv>>(
+                                                  m_pseudo_physical_to_physical,
+                                                  foot,
+                                                  updated_advection_field_adv_space);
+                              };
 
-                                  if (norm_inf(feet_xy - coord_centre) < 1e-15) {
-                                      feet(idx) = CoordRTheta(0, 0);
-                                  } else {
-                                      feet(idx) = pseudo_physical_to_logical_proxy(feet_xy);
-                                      ddc::select<Theta>(feet(idx))
-                                              = ddcHelper::restrict_to_idx_range(
-                                                      ddc::select<Theta>(feet(idx)),
-                                                      idx_range_theta);
-                                  }
-                              });
+                    // The function describing how the value(s) are updated using the derivative.
+                    std::function<void(CoordRTheta&, DVector<X_adv, Y_adv> const&, double)>
+                            update_function = [&](CoordRTheta& foot_rtheta,
+                                                  DVector<X_adv, Y_adv> const& advection_field,
+                                                  double dt) {
+                                CoordXY_adv const coord_xy
+                                        = logical_to_pseudo_physical_proxy(foot_rtheta);
+                                CoordXY_adv const foot_xy = coord_xy - dt * advection_field;
 
-                      // Treatment to conserve the C0 property of the advected function:
-                      unify_value_at_centre_pt(feet);
-                      // Test if the values are the same at the centre point
-                      is_unified(feet);
-                  };
+                                if (norm_inf(foot_xy - coord_centre) < 1e-15) {
+                                    foot_rtheta = CoordRTheta(0, 0);
+                                } else {
+                                    foot_rtheta = pseudo_physical_to_logical_proxy(foot_xy);
+                                    ddc::select<Theta>(foot_rtheta)
+                                            = ddcHelper::restrict_to_idx_range(
+                                                    ddc::select<Theta>(foot_rtheta),
+                                                    idx_range_theta);
+                                }
+                            };
 
-        TimeStepper time_stepper
-                = m_time_stepper_builder.template preallocate<TimeStepper>(get_idx_range(feet));
+                    feet(idx) = ddc::coordinate(idx_rtheta);
+                    // Solve the characteristic equation
+                    time_stepper.update(feet(idx), dt, dy, update_function);
+                });
 
-        // Solve the characteristic equation
-        time_stepper.update(ExecSpace(), feet, dt, dy, update_function);
-
+        // Treatment to conserve the C0 property of the advected function:
+        unify_value_at_centre_pt(feet);
+        // Test if the values are the same at the centre point
         is_unified(feet);
     }
 

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -308,6 +308,10 @@ public:
 
         TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
+        SplineRThetaEvaluatorAdvection const& evaluator_advection_field_proxy
+                = m_evaluator_advection_field;
+        PseudoPhysicalToPhysicalMapping pseudo_physical_to_physical = m_pseudo_physical_to_physical;
+
         // Compute the characteristic feet at t^n:
         const std::source_location location = std::source_location::current();
         ddc::parallel_for_each(
@@ -318,46 +322,41 @@ public:
                     IdxBatch idx_batch(idx);
                     IdxRTheta idx_rtheta(idx);
                     // The function describing how the derivative of the evolve function is calculated.
-                    std::function<void(DVector<X_adv, Y_adv>&, CoordRTheta const&)> dy
-                            = [&](DVector<X_adv, Y_adv>& updated_advection_field,
+                    auto dy = [&](DVector<X_adv, Y_adv>& updated_advection_field,
                                   CoordRTheta const& foot) {
-                                  DVector<AdvDim1, AdvDim2> updated_advection_field_adv_space;
-                                  ddcHelper::get<AdvDim1>(updated_advection_field_adv_space)
-                                          = m_evaluator_advection_field(
-                                                  foot,
-                                                  get_const_field(ddcHelper::get<AdvDim1>(
-                                                          advection_field_coefs)[idx_batch]));
-                                  ddcHelper::get<AdvDim2>(updated_advection_field_adv_space)
-                                          = m_evaluator_advection_field(
-                                                  foot,
-                                                  get_const_field(ddcHelper::get<AdvDim2>(
-                                                          advection_field_coefs)[idx_batch]));
-                                  updated_advection_field
-                                          = to_vector_space<VectorIndexSet<X_adv, Y_adv>>(
-                                                  m_pseudo_physical_to_physical,
-                                                  foot,
-                                                  updated_advection_field_adv_space);
-                              };
+                        DVector<AdvDim1, AdvDim2> updated_advection_field_adv_space;
+                        ddcHelper::get<AdvDim1>(updated_advection_field_adv_space)
+                                = evaluator_advection_field_proxy(
+                                        foot,
+                                        get_const_field(ddcHelper::get<AdvDim1>(
+                                                advection_field_coefs)[idx_batch]));
+                        ddcHelper::get<AdvDim2>(updated_advection_field_adv_space)
+                                = evaluator_advection_field_proxy(
+                                        foot,
+                                        get_const_field(ddcHelper::get<AdvDim2>(
+                                                advection_field_coefs)[idx_batch]));
+                        updated_advection_field = to_vector_space<VectorIndexSet<X_adv, Y_adv>>(
+                                pseudo_physical_to_physical,
+                                foot,
+                                updated_advection_field_adv_space);
+                    };
 
                     // The function describing how the value(s) are updated using the derivative.
-                    std::function<void(CoordRTheta&, DVector<X_adv, Y_adv> const&, double)>
-                            update_function = [&](CoordRTheta& foot_rtheta,
-                                                  DVector<X_adv, Y_adv> const& advection_field,
-                                                  double dt) {
-                                CoordXY_adv const coord_xy
-                                        = logical_to_pseudo_physical_proxy(foot_rtheta);
-                                CoordXY_adv const foot_xy = coord_xy - dt * advection_field;
+                    auto update_function = [&](CoordRTheta& foot_rtheta,
+                                               DVector<X_adv, Y_adv> const& advection_field,
+                                               double dt) {
+                        CoordXY_adv const coord_xy = logical_to_pseudo_physical_proxy(foot_rtheta);
+                        CoordXY_adv const foot_xy = coord_xy - dt * advection_field;
 
-                                if (norm_inf(foot_xy - coord_centre) < 1e-15) {
-                                    foot_rtheta = CoordRTheta(0, 0);
-                                } else {
-                                    foot_rtheta = pseudo_physical_to_logical_proxy(foot_xy);
-                                    ddc::select<Theta>(foot_rtheta)
-                                            = ddcHelper::restrict_to_idx_range(
-                                                    ddc::select<Theta>(foot_rtheta),
-                                                    idx_range_theta);
-                                }
-                            };
+                        if (norm_inf(foot_xy - coord_centre) < 1e-15) {
+                            foot_rtheta = CoordRTheta(0, 0);
+                        } else {
+                            foot_rtheta = pseudo_physical_to_logical_proxy(foot_xy);
+                            ddc::select<Theta>(foot_rtheta) = ddcHelper::restrict_to_idx_range(
+                                    ddc::select<Theta>(foot_rtheta),
+                                    idx_range_theta);
+                        }
+                    };
 
                     feet(idx) = ddc::coordinate(idx_rtheta);
                     // Solve the characteristic equation

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -335,9 +335,16 @@ public:
                                         foot,
                                         get_const_field(ddcHelper::get<AdvDim2>(
                                                 advection_field_coefs)[idx_batch]));
+                        // Ensure coord is inside the domain as splines can't extrapolate
+                        // derivates (clamping)
+                        CoordRTheta advection_location_for_mapping(
+                                Kokkos::
+                                        min(ddc::select<R>(foot),
+                                            ddc::discrete_space<BSplinesR>().rmax()),
+                                ddc::select<Theta>(foot));
                         updated_advection_field = to_vector_space<VectorIndexSet<X_adv, Y_adv>>(
                                 pseudo_physical_to_physical,
-                                foot,
+                                advection_location_for_mapping,
                                 updated_advection_field_adv_space);
                     };
 

--- a/src/timestepper/crank_nicolson.hpp
+++ b/src/timestepper/crank_nicolson.hpp
@@ -112,12 +112,7 @@ public:
             dy_calculator(k_new, y);
 
             // Calculation of step
-            // k_total = k1 + k_new
-            timestepper_detail::assemble_helper<ExecSpace, DerivType>::assemble_k_total(
-                    k_total,
-                    KOKKOS_LAMBDA(std::array<DerivType, 2> k) { return k[0] + k[1]; },
-                    k1,
-                    k_new);
+            k_total = k1 + k_new;
 
             // Save the old characteristic feet
             timestepper_detail::copy_helper<ValType>::copy(y_old, y);

--- a/src/timestepper/crank_nicolson.hpp
+++ b/src/timestepper/crank_nicolson.hpp
@@ -338,6 +338,25 @@ public:
                               typename TimeStepper::exec_space>>);
         return TimeStepper(idx_range, m_max_counter, m_epsilon);
     }
+
+    /**
+     * @brief Allocate the TimeStepper object for scalar (non-FieldLike) types.
+     * @tparam ChosenTimeStepper The type of the TimeStepper to be constructed (obtained from time_stepper_t).
+     */
+    template <class TimeStepper>
+    auto preallocate() const
+    {
+        static_assert(
+                !timestepper_detail::FieldLike<typename TimeStepper::ValFieldMem>,
+                "An index range must be provided to preallocate for FieldLike timesteppers.");
+        static_assert(std::is_same_v<
+                      TimeStepper,
+                      time_stepper_t<
+                              typename TimeStepper::ValFieldMem,
+                              typename TimeStepper::DerivFieldMem,
+                              typename TimeStepper::exec_space>>);
+        return TimeStepper(m_max_counter, m_epsilon);
+    }
 };
 
 namespace detail {

--- a/src/timestepper/itimestepper.hpp
+++ b/src/timestepper/itimestepper.hpp
@@ -152,17 +152,7 @@ KOKKOS_FUNCTION void fill_k_total(DerivFieldType k_total, Idx i, DVector<DDims..
 }
 
 template <class ExecSpace, class DerivFieldType>
-struct assemble_helper
-{
-    static_assert(!FieldLike<DerivFieldType>);
-
-    template <class FuncType, class... T>
-    static KOKKOS_FUNCTION void assemble_k_total(DerivFieldType& k_total, FuncType func, T... k)
-    {
-        std::array<DerivFieldType, sizeof...(T)> k_arr({k...});
-        k_total = func(k_arr);
-    }
-};
+struct assemble_helper;
 
 template <class ExecSpace, class ElementType, class IdxRangeType, class MemSpace>
 struct assemble_helper<ExecSpace, FieldMem<ElementType, IdxRangeType, MemSpace>>

--- a/src/timestepper/rk3.hpp
+++ b/src/timestepper/rk3.hpp
@@ -97,12 +97,7 @@ public:
 
         // --------- Calculate k3 ------------
         // Calculation of step
-        // k_total = 2 * k2 - k1
-        timestepper_detail::assemble_helper<ExecSpace, DerivType>::assemble_k_total(
-                k_total,
-                KOKKOS_LAMBDA(std::array<DerivType, 2> k) { return 2 * k[1] - k[0]; },
-                k1,
-                k2);
+        k_total = 2 * k2 - k1;
 
         // Collect initial conditions
         timestepper_detail::copy_helper<ValType>::copy(y_prime, y);
@@ -115,13 +110,7 @@ public:
 
         // --------- Update y ------------
         // Calculation of step
-        // k_total = k1 + 4 * k2 + k3
-        timestepper_detail::assemble_helper<ExecSpace, DerivType>::assemble_k_total(
-                k_total,
-                KOKKOS_LAMBDA(std::array<DerivType, 3> k) { return k[0] + 4 * k[1] + k[2]; },
-                k1,
-                k2,
-                k3);
+        k_total = k1 + 4 * k2 + k3;
 
         // Calculate y_{n+1} := y_n + (k1 + 4 * k2 + k3) * h/6
         y_update(y, k_total, dt / 6.);

--- a/src/timestepper/rk4.hpp
+++ b/src/timestepper/rk4.hpp
@@ -118,16 +118,7 @@ public:
 
         // --------- Update y ------------
         // Calculation of step
-        // k_total = k1 + 2 * k2 + 2 * k3 + k4
-        timestepper_detail::assemble_helper<ExecSpace, DerivType>::assemble_k_total(
-                k_total,
-                KOKKOS_LAMBDA(std::array<DerivType, 4> k) {
-                    return k[0] + 2 * k[1] + 2 * k[2] + k[3];
-                },
-                k1,
-                k2,
-                k3,
-                k4);
+        k_total = k1 + 2 * k2 + 2 * k3 + k4;
 
         // Calculate y_{n+1} := y_n + (k1 + 2 * k2 + 2 * k3 + k4) * h/6
         y_update(y, k_total, dt / 6.);


### PR DESCRIPTION
Reduce memory requirements for `SplinePolarFootFinder` by changing the vector space for the vector advection field $A$ after interpolating the spline.

Before: $(a_r, a_\theta)$ -> $(a_x, a_y)$ -> interpolate (a_x, a_y)
After: $(a_r, a_\theta)$ -> interpolate $(a_r, a_\theta)$ -> $(a_x, a_y)$

This means that the advection field in the pseudo-Cartesian vector space does not have to be stored at all points.

Allow lambdas to be saved in `auto` typed variables to avoid using `std::function` on the GPU.


---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
