### PR TITLE
Reactivate clang test

### DIFF
--- a/.github/workflows/cpu_tests.yml
+++ b/.github/workflows/cpu_tests.yml
@@ -120,9 +120,6 @@ jobs:
             toolchain: 'ci_coverage_toolchain'
           - backend: 'openmp'
             toolchain: 'debug_toolchain'
-          - backend: 'openmp' # Clang + OpenMP leads to compiler failure with Clang 14.0.0
-            compiler:
-              name: 'clang'
       fail-fast: false
     container:
       image: ${{ needs.docker_update.outputs.image_tag }}


### PR DESCRIPTION
Reactivate clang test which was deactivated due to a clang-14 issue. The docker now contains clang-18.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
