### PR TITLE
Ensure calling host function from device function raises a compilation error

### DIFF
--- a/toolchains/persee/v100/gpu_debug.cmake
+++ b/toolchains/persee/v100/gpu_debug.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 # Using CUDA 12.9 triggers a spurious warning when compiling for Nvidia Volta architectures. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra -Wno-deprecated-gpu-targets")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Werror -Wno-sign-compare -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -Wno-unused-but-set-variable -Wno-error=deprecated-declarations")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Werror -Werror cross-execution-space-call -Wno-sign-compare -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -Wno-unused-but-set-variable -Wno-error=deprecated-declarations")
 
 # Activate/deactivate parts of the code
 if (DEFINED ENV{DDC_BUILD_TESTING})


### PR DESCRIPTION
Ensure calling host function from device function raises a compilation error when using the persee GPU debug toolchain.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
