### PR TITLE
Remove unuseful template parameters from `LagrangeInterpolator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove ruche toolchain.
 - Remove `GYSELALIBXX_VERSION_*` CMake variables.
 - Remove out-of-date Leonardo toolchain.
+- Remove unuseful defaulted template parameters `MinBound` and `MaxBound` from `LagrangeInterpolator`.
 
 ## [v0.7.0] - 2026-03-18
 

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -19,22 +19,11 @@
  * grid directly as coefficients to the evaluator, which then performs local polynomial
  * reconstruction via the Lagrange basis.
  *
- * The boundary condition (MinBound / MaxBound) and extrapolation rule
- * (MinExtrapRule / MaxExtrapRule) must be consistent: both must be PERIODIC for
- * periodic dimensions and both must be non-PERIODIC for non-periodic dimensions.
- * Note: @c CONSTANT extrapolation is not supported for Lagrange interpolation.
- *
  * @tparam ExecSpace     The Kokkos execution space used for computations.
  * @tparam Basis         The Lagrange basis type (uniform or non-uniform).
  * @tparam InterpGrid    The discrete grid on which function values are provided.
  * @tparam MinExtrapRule The ExtrapolationRule applied below the lower boundary.
  * @tparam MaxExtrapRule The ExtrapolationRule applied above the upper boundary.
- * @tparam MinBound      The ddc::BoundCond at the lower boundary (default: GREVILLE).
- *                       This is included to have an interface interchangeable with SplineBuilder
- *                       but is unused.
- * @tparam MaxBound      The ddc::BoundCond at the upper boundary (default: GREVILLE).
- *                       This is included to have an interface interchangeable with SplineBuilder
- *                       but is unused.
  * @tparam DataType      The floating-point type of the function values (default: double).
  */
 template <
@@ -43,8 +32,6 @@ template <
         class InterpGrid,
         ExtrapolationRule MinExtrapRule,
         ExtrapolationRule MaxExtrapRule,
-        ddc::BoundCond MinBound = ddc::BoundCond::GREVILLE,
-        ddc::BoundCond MaxBound = ddc::BoundCond::GREVILLE,
         class DataType = double>
 class LagrangeInterpolator
 {
@@ -52,8 +39,6 @@ class LagrangeInterpolator
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
-    static_assert(is_periodic == (MinBound == ddc::BoundCond::PERIODIC));
-    static_assert(is_periodic == (MaxBound == ddc::BoundCond::PERIODIC));
     static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
     static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
 

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -75,14 +75,8 @@ struct LagBasisFloatX : UniformLagrangeBasis<X, 3, float>
 {
 };
 
-using LagrangeInterpolatorX = LagrangeInterpolator<
-        Kokkos::DefaultExecutionSpace,
-        LagBasisX,
-        GridX,
-        PERIODIC,
-        PERIODIC,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+using LagrangeInterpolatorX
+        = LagrangeInterpolator<Kokkos::DefaultExecutionSpace, LagBasisX, GridX, PERIODIC, PERIODIC>;
 
 using LagrangeInterpolatorFloatX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -90,8 +84,6 @@ using LagrangeInterpolatorFloatX = LagrangeInterpolator<
         GridX,
         PERIODIC,
         PERIODIC,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC,
         float>;
 
 


### PR DESCRIPTION
Remove unuseful defaulted template parameters `MinBound` and `MaxBound` from `LagrangeInterpolator`.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
