### PR TITLE
Add support for arbitrary precision quadrature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `NDIdentityInterpolationBuilder` class.
 - Add a new abstract class `IPolarPoissonLikeSolver`.
 - Add data type parametrisation to `ConstantIdentityInterpolationExtrapolationRule`.
+- Add support for arbitrary precision quadrature.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new abstract class `IPolarPoissonLikeSolver`.
 - Add data type parametrisation to `ConstantIdentityInterpolationExtrapolationRule`.
 - Add support for arbitrary precision quadrature.
+- Add support for arbitrary precision norm calculations.
 
 ### Fixed
 

--- a/src/geometryXVx/utils/fluid_moments.cpp
+++ b/src/geometryXVx/utils/fluid_moments.cpp
@@ -6,9 +6,7 @@
 #include "quadrature.hpp"
 #include "trapezoid_quadrature.hpp"
 
-FluidMoments::FluidMoments(
-        Quadrature<IdxRangeVx, IdxRangeSpXVx, Kokkos::DefaultExecutionSpace::memory_space>
-                integrate_v)
+FluidMoments::FluidMoments(Quadrature<IdxRangeVx, IdxRangeSpXVx> integrate_v)
     : m_integrate_v(integrate_v)
 {
 }

--- a/src/geometryXVx/utils/fluid_moments.hpp
+++ b/src/geometryXVx/utils/fluid_moments.hpp
@@ -59,7 +59,7 @@ public:
      *
      * @param[in] integrate_v A quadrature method which integrates over the velocity space.
      */
-    FluidMoments(Quadrature<IdxRangeVx, IdxRangeSpXVx> integrate_v);
+    explicit FluidMoments(Quadrature<IdxRangeVx, IdxRangeSpXVx> integrate_v);
 
     ~FluidMoments() = default;
 

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -238,7 +238,8 @@ inline double error_norm_inf(
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 double norm_L1(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
+                quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
@@ -258,7 +259,8 @@ double norm_L1(
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 double error_norm_L1(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
+                quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {
@@ -288,7 +290,8 @@ double error_norm_L1(
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 double norm_L2(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
+                quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
@@ -308,7 +311,8 @@ double norm_L2(
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 double error_norm_L2(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
+                quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -235,10 +235,10 @@ inline double error_norm_inf(
  *
  * @return A double containing the L1 norm of the function.
  */
-template <class IdxRangeQuad, class ExecSpace>
+template <class IdxRangeQuad, class ExecSpace, class DataType>
 double norm_L1(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
@@ -255,10 +255,10 @@ double norm_L1(
  * @param[in] exact_function The exact function with which the calculated function is compared.
  * @return A double containing the value of the infinity norm.
  */
-template <class IdxRangeQuad, class ExecSpace>
+template <class IdxRangeQuad, class ExecSpace, class DataType>
 double error_norm_L1(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {
@@ -285,10 +285,10 @@ double error_norm_L1(
  *
  * @return A double containing the L2 norm of the function.
  */
-template <class IdxRangeQuad, class ExecSpace>
+template <class IdxRangeQuad, class ExecSpace, class DataType>
 double norm_L2(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
@@ -305,10 +305,10 @@ double norm_L2(
  * @param[in] exact_function The exact function with which the calculated function is compared.
  * @return A double containing the value of the infinity norm.
  */
-template <class IdxRangeQuad, class ExecSpace>
+template <class IdxRangeQuad, class ExecSpace, class DataType>
 double error_norm_L2(
         ExecSpace exec_space,
-        Quadrature<IdxRangeQuad, IdxRangeQuad, typename ExecSpace::memory_space> quadrature,
+        Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space> quadrature,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
         DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -42,14 +42,14 @@ KOKKOS_FUNCTION double norm_inf(Coord<Tags...> coord)
  *
  * @return A double containing the value of the infinity norm.
  */
-template <class... Tags>
-KOKKOS_FUNCTION double norm_inf(DVector<Tags...> vec)
+template <class ElementType, class... Tags>
+KOKKOS_FUNCTION ElementType norm_inf(Vector<ElementType, Tags...> vec)
 {
-    using index_set = typename DVector<Tags...>::template vector_index_set_t<0>;
+    using index_set = typename Vector<ElementType, Tags...>::template vector_index_set_t<0>;
     static_assert(
             std::is_same_v<index_set, vector_index_set_dual_t<index_set>>,
             "Mapping is needed to calculate norm_inf on a non-orthonormal coordinate system");
-    double result = 0.0;
+    ElementType result = 0.0;
     ((result = Kokkos::max(result, Kokkos::fabs(ddcHelper::get<Tags>(vec)))), ...);
     return result;
 }
@@ -65,7 +65,8 @@ KOKKOS_FUNCTION double norm_inf(DVector<Tags...> vec)
  *
  * @return A double containing the value of the infinity norm.
  */
-KOKKOS_INLINE_FUNCTION double norm_inf(double const coord)
+template<std::floating_point T>
+KOKKOS_INLINE_FUNCTION T norm_inf(T const coord)
 {
     return Kokkos::fabs(coord);
 }
@@ -74,8 +75,8 @@ namespace detail {
 
 // General implementation of the infinity norm. This function is in a namespace to avoid code duplication
 // without creating a function so general that it also captures multipatch types.
-template <class ExecSpace, class FuncType>
-double norm_inf(ExecSpace exec_space, FuncType function)
+template <class DataType, class ExecSpace, class FuncType>
+DataType norm_inf(ExecSpace exec_space, FuncType function)
 {
     static_assert(
             Kokkos::SpaceAccessibility<ExecSpace, typename FuncType::memory_space>::accessible);
@@ -88,14 +89,14 @@ double norm_inf(ExecSpace exec_space, FuncType function)
             exec_space,
             idx_range,
             0.,
-            ddc::reducer::max<double>(),
+            ddc::reducer::max<DataType>(),
             KOKKOS_LAMBDA(IdxFunc const idx) { return ::norm_inf(function(idx)); });
 }
 
 // General implementation of the infinity norm of an error. This function is in a namespace to avoid code duplication
 // without creating a function so general that it also captures multipatch types.
-template <class ExecSpace, class FuncType, class ExactFuncType>
-double error_norm_inf(ExecSpace exec_space, FuncType function, ExactFuncType exact_function)
+template <class DataType, class ExecSpace, class FuncType, class ExactFuncType>
+DataType error_norm_inf(ExecSpace exec_space, FuncType function, ExactFuncType exact_function)
 {
     static_assert(
             Kokkos::SpaceAccessibility<ExecSpace, typename FuncType::memory_space>::accessible);
@@ -107,8 +108,8 @@ double error_norm_inf(ExecSpace exec_space, FuncType function, ExactFuncType exa
             location.function_name(),
             exec_space,
             idx_range,
-            0.,
-            ddc::reducer::max<double>(),
+            DataType(0.),
+            ddc::reducer::max<DataType>(),
             KOKKOS_LAMBDA(IdxFunc const idx) {
                 return ::norm_inf(function(idx) - exact_function(idx));
             });
@@ -123,11 +124,25 @@ double error_norm_inf(ExecSpace exec_space, FuncType function, ExactFuncType exa
  * @return A double containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange>
-inline double norm_inf(
+inline ElementType norm_inf(
         ExecSpace exec_space,
         ConstField<ElementType, IdxRange, typename ExecSpace::memory_space> function)
 {
-    return detail::norm_inf(exec_space, function);
+    return detail::norm_inf<ElementType>(exec_space, function);
+}
+
+/**
+ * @brief Compute the infinity norm for a Field.
+ * @param[in] exec_space The space on which the function is executed (CPU/GPU).
+ * @param[in] function The function whose norm is calculated.
+ * @return A double containing the value of the infinity norm.
+ */
+template <class ExecSpace, class IdxRange, class... CoordDims>
+inline ddc::Real norm_inf(
+        ExecSpace exec_space,
+        ConstField<Coord<CoordDims...>, IdxRange, typename ExecSpace::memory_space> function)
+{
+    return detail::norm_inf<ddc::Real>(exec_space, function);
 }
 
 /**
@@ -137,7 +152,7 @@ inline double norm_inf(
  * @return A double containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
-inline double norm_inf(
+inline ElementType norm_inf(
         ExecSpace exec_space,
         VectorConstField<
                 ElementType,
@@ -145,7 +160,7 @@ inline double norm_inf(
                 VectorIndexSetType,
                 typename ExecSpace::memory_space> function)
 {
-    return detail::norm_inf(exec_space, function);
+    return detail::norm_inf<ElementType>(exec_space, function);
 }
 
 /**
@@ -156,12 +171,28 @@ inline double norm_inf(
  * @return A double containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange>
-inline double error_norm_inf(
+inline ElementType error_norm_inf(
         ExecSpace exec_space,
         ConstField<ElementType, IdxRange, typename ExecSpace::memory_space> function,
         ConstField<ElementType, IdxRange, typename ExecSpace::memory_space> exact_function)
 {
-    return detail::error_norm_inf(exec_space, function, exact_function);
+    return detail::error_norm_inf<ElementType>(exec_space, function, exact_function);
+}
+
+/**
+ * @brief Compute the infinity norm of the error between 2 Fields.
+ * @param[in] exec_space The space on which the function is executed (CPU/GPU).
+ * @param[in] function The calculated function.
+ * @param[in] exact_function The exact function with which the calculated function is compared.
+ * @return A double containing the value of the infinity norm.
+ */
+template <class ExecSpace, class IdxRange, class... CoordDims>
+inline ddc::Real error_norm_inf(
+        ExecSpace exec_space,
+        ConstField<Coord<CoordDims...>, IdxRange, typename ExecSpace::memory_space> function,
+        ConstField<Coord<CoordDims...>, IdxRange, typename ExecSpace::memory_space> exact_function)
+{
+    return detail::error_norm_inf<ddc::Real>(exec_space, function, exact_function);
 }
 
 namespace concepts {
@@ -194,7 +225,7 @@ inline ElementType error_norm_inf(
                   ExactFunc,
                   ElementType,
                   typename IdxRange::discrete_element_type>);
-    return detail::error_norm_inf(exec_space, function, exact_function);
+    return detail::error_norm_inf<ElementType>(exec_space, function, exact_function);
 }
 
 /**
@@ -205,7 +236,7 @@ inline ElementType error_norm_inf(
  * @return A double containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
-inline double error_norm_inf(
+inline ElementType error_norm_inf(
         ExecSpace exec_space,
         VectorConstField<
                 ElementType,
@@ -218,7 +249,7 @@ inline double error_norm_inf(
                 VectorIndexSetType,
                 typename ExecSpace::memory_space> exact_function)
 {
-    return detail::error_norm_inf(exec_space, function, exact_function);
+    return detail::error_norm_inf<ElementType>(exec_space, function, exact_function);
 }
 
 /**
@@ -236,11 +267,11 @@ inline double error_norm_inf(
  * @return A double containing the L1 norm of the function.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
-double norm_L1(
+DataType norm_L1(
         ExecSpace exec_space,
         Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
                 quadrature,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
     return quadrature(
@@ -257,12 +288,12 @@ double norm_L1(
  * @return A double containing the value of the infinity norm.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
-double error_norm_L1(
+DataType error_norm_L1(
         ExecSpace exec_space,
         Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
                 quadrature,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> function,
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
     return quadrature(
@@ -288,11 +319,11 @@ double error_norm_L1(
  * @return A double containing the L2 norm of the function.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
-double norm_L2(
+DataType norm_L2(
         ExecSpace exec_space,
         Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
                 quadrature,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> function)
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
     return std::sqrt(quadrature(
@@ -309,12 +340,12 @@ double norm_L2(
  * @return A double containing the value of the infinity norm.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
-double error_norm_L2(
+DataType error_norm_L2(
         ExecSpace exec_space,
         Quadrature<IdxRangeQuad, IdxRangeQuad, DataType, typename ExecSpace::memory_space>
                 quadrature,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> function,
-        DField<IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> function,
+        Field<DataType, IdxRangeQuad, typename ExecSpace::memory_space> exact_function)
 {
     using IdxQuad = typename IdxRangeQuad::discrete_element_type;
     return std::sqrt(quadrature(

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -21,12 +21,12 @@
  * @param[in] coord
  *      The given vector.
  *
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class... Tags>
-KOKKOS_FUNCTION double norm_inf(Coord<Tags...> coord)
+KOKKOS_FUNCTION ddc::Real norm_inf(Coord<Tags...> coord)
 {
-    double result = 0.0;
+    ddc::Real result = 0.0;
     ((result = Kokkos::max(result, Kokkos::fabs(coord.template get<Tags>()))), ...);
     return result;
 }
@@ -40,7 +40,7 @@ KOKKOS_FUNCTION double norm_inf(Coord<Tags...> coord)
  *
  * @param[in] vec The given vector.
  *
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ElementType, class... Tags>
 KOKKOS_FUNCTION ElementType norm_inf(Vector<ElementType, Tags...> vec)
@@ -61,9 +61,9 @@ KOKKOS_FUNCTION ElementType norm_inf(Vector<ElementType, Tags...> vec)
  * returns the scalar.
  *
  * @param[in] coord
- *      The given double.
+ *      The given scalar.
  *
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <std::floating_point T>
 KOKKOS_INLINE_FUNCTION T norm_inf(T const coord)
@@ -121,7 +121,7 @@ DataType error_norm_inf(ExecSpace exec_space, FuncType function, ExactFuncType e
  * @brief Compute the infinity norm for a Field.
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The function whose norm is calculated.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange>
 inline ElementType norm_inf(
@@ -135,7 +135,7 @@ inline ElementType norm_inf(
  * @brief Compute the infinity norm for a Field.
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The function whose norm is calculated.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class IdxRange, class... CoordDims>
 inline ddc::Real norm_inf(
@@ -149,7 +149,7 @@ inline ddc::Real norm_inf(
  * @brief Compute the infinity norm for a VectorField.
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The function whose norm is calculated.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
 inline ElementType norm_inf(
@@ -168,7 +168,7 @@ inline ElementType norm_inf(
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange>
 inline ElementType error_norm_inf(
@@ -184,7 +184,7 @@ inline ElementType error_norm_inf(
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class IdxRange, class... CoordDims>
 inline ddc::Real error_norm_inf(
@@ -213,7 +213,7 @@ concept CompatibleFunc = requires(F const& f, IdxType idx)
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange, class ExactFunc>
 inline ElementType error_norm_inf(
@@ -233,7 +233,7 @@ inline ElementType error_norm_inf(
  * @param[in] exec_space The space on which the function is executed (CPU/GPU).
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class ExecSpace, class ElementType, class IdxRange, class VectorIndexSetType>
 inline ElementType error_norm_inf(
@@ -264,7 +264,7 @@ inline ElementType error_norm_inf(
  * @param[in] function
  *      A Field to the value of the function on the quadrature grid.
  *
- * @return A double containing the L1 norm of the function.
+ * @return A floating point containing the L1 norm of the function.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 DataType norm_L1(
@@ -285,7 +285,7 @@ DataType norm_L1(
  * @param[in] quadrature The quadrature used to compute the integral.
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 DataType error_norm_L1(
@@ -316,7 +316,7 @@ DataType error_norm_L1(
  * @param[in] function
  *      A Field to the value of the function on the quadrature grid.
  *
- * @return A double containing the L2 norm of the function.
+ * @return A floating point containing the L2 norm of the function.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 DataType norm_L2(
@@ -337,7 +337,7 @@ DataType norm_L2(
  * @param[in] quadrature The quadrature used to compute the integral.
  * @param[in] function The calculated function.
  * @param[in] exact_function The exact function with which the calculated function is compared.
- * @return A double containing the value of the infinity norm.
+ * @return A floating point containing the value of the infinity norm.
  */
 template <class IdxRangeQuad, class ExecSpace, class DataType>
 DataType error_norm_L2(
@@ -351,7 +351,7 @@ DataType error_norm_L2(
     return std::sqrt(quadrature(
             exec_space,
             KOKKOS_LAMBDA(IdxQuad const idx) {
-                double err = function(idx) - exact_function(idx);
+                DataType err = function(idx) - exact_function(idx);
                 return err * err;
             }));
 }

--- a/src/math_tools/l_norm_tools.hpp
+++ b/src/math_tools/l_norm_tools.hpp
@@ -65,7 +65,7 @@ KOKKOS_FUNCTION ElementType norm_inf(Vector<ElementType, Tags...> vec)
  *
  * @return A double containing the value of the infinity norm.
  */
-template<std::floating_point T>
+template <std::floating_point T>
 KOKKOS_INLINE_FUNCTION T norm_inf(T const coord)
 {
     return Kokkos::fabs(coord);

--- a/src/quadrature/gauss_legendre_integration.hpp
+++ b/src/quadrature/gauss_legendre_integration.hpp
@@ -47,7 +47,7 @@ extern template struct GaussLegendreCoefficients<10>;
  * @tparam GLGrid The grid describing the Gauss-Legendre points.
  * @tparam NPoints The number of points in the Gauss-Legendre scheme
  */
-template <class GLGrid, std::size_t NPoints>
+template <class GLGrid, std::size_t NPoints, class DataType = double>
 class GaussLegendre
 {
     static_assert(ddc::is_non_uniform_point_sampling_v<GLGrid>);
@@ -149,10 +149,10 @@ public:
      * @return The Gauss-Legendre quadrature.
      */
     template <class ExecSpace>
-    DFieldMem<IdxRange<GLGrid>, typename ExecSpace::memory_space> gauss_legendre_coefficients()
+    FieldMem<DataType, IdxRange<GLGrid>, typename ExecSpace::memory_space> gauss_legendre_coefficients()
             const
     {
-        DFieldMem<IdxRange<GLGrid>, typename ExecSpace::memory_space> coefficients_alloc(
+        FieldMem<DataType, IdxRange<GLGrid>, typename ExecSpace::memory_space> coefficients_alloc(
                 "coefficients (GaussLegendre::gauss_legendre_coefficients)",
                 m_valid_idx_range);
         auto coefficients_host = ddc::create_mirror_view(get_field(coefficients_alloc));
@@ -249,18 +249,24 @@ private:
  *
  * @return The coefficients which define the spline quadrature method in ND.
  */
-template <class ExecSpace, class... GaussLegendreQuad>
-DFieldMem<IdxRange<typename GaussLegendreQuad::Grid1D...>, typename ExecSpace::memory_space>
+template <class ExecSpace, class DataType = double, class... GaussLegendreQuad>
+FieldMem<
+        DataType,
+        IdxRange<typename GaussLegendreQuad::Grid1D...>,
+        typename ExecSpace::memory_space>
 gauss_legendre_quadrature_coefficients(GaussLegendreQuad const&... gl)
 {
     // Get coefficients for each dimension
-    std::tuple<host_t<DFieldMem<IdxRange<typename GaussLegendreQuad::Grid1D>>>...>
+    std::tuple<host_t<FieldMem<DataType, IdxRange<typename GaussLegendreQuad::Grid1D>>>...>
     current_dim_coeffs(gl.template gauss_legendre_coefficients<Kokkos::HostSpace>()...);
 
     IdxRange<typename GaussLegendreQuad::Grid1D...> idx_range(gl.get_idx_range()...);
 
     // Allocate ND coefficients
-    DFieldMem<IdxRange<typename GaussLegendreQuad::Grid1D...>, typename ExecSpace::memory_space>
+    FieldMem<
+            DataType,
+            IdxRange<typename GaussLegendreQuad::Grid1D...>,
+            typename ExecSpace::memory_space>
             coefficients(idx_range);
     auto coefficients_host = ddc::create_mirror(get_field(coefficients));
     // Serial loop is used due to nvcc bug concerning functions with variadic template arguments
@@ -268,7 +274,8 @@ gauss_legendre_quadrature_coefficients(GaussLegendreQuad const&... gl)
     ddc::host_for_each(idx_range, [&](Idx<typename GaussLegendreQuad::Grid1D...> const idim) {
         // multiply the 1D coefficients by one another
         coefficients_host(idim)
-                = (std::get<host_t<DFieldMem<IdxRange<typename GaussLegendreQuad::Grid1D>>>>(
+                = (std::get<host_t<
+                           FieldMem<DataType, IdxRange<typename GaussLegendreQuad::Grid1D>>>>(
                            current_dim_coeffs)(
                            ddc::select<typename GaussLegendreQuad::Grid1D>(idim))
                    * ... * 1);

--- a/src/quadrature/gauss_legendre_integration.hpp
+++ b/src/quadrature/gauss_legendre_integration.hpp
@@ -51,6 +51,7 @@ template <class GLGrid, std::size_t NPoints, class DataType = double>
 class GaussLegendre
 {
     static_assert(ddc::is_non_uniform_point_sampling_v<GLGrid>);
+    static_assert(std::is_floating_point_v<DataType>);
 
     using Dim = typename GLGrid::continuous_dimension_type;
 

--- a/src/quadrature/gauss_legendre_integration.hpp
+++ b/src/quadrature/gauss_legendre_integration.hpp
@@ -149,8 +149,8 @@ public:
      * @return The Gauss-Legendre quadrature.
      */
     template <class ExecSpace>
-    FieldMem<DataType, IdxRange<GLGrid>, typename ExecSpace::memory_space> gauss_legendre_coefficients()
-            const
+    FieldMem<DataType, IdxRange<GLGrid>, typename ExecSpace::memory_space>
+    gauss_legendre_coefficients() const
     {
         FieldMem<DataType, IdxRange<GLGrid>, typename ExecSpace::memory_space> coefficients_alloc(
                 "coefficients (GaussLegendre::gauss_legendre_coefficients)",

--- a/src/quadrature/neumann_spline_quadrature.hpp
+++ b/src/quadrature/neumann_spline_quadrature.hpp
@@ -17,10 +17,11 @@
 
 
 namespace {
-template <class ExecSpace, class Grid1D>
-using CoefficientFieldMem1D = DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space>;
-template <class ExecSpace, class Grid1D>
-using CoefficientField1D = DField<IdxRange<Grid1D>, typename ExecSpace::memory_space>;
+template <class ExecSpace, class Grid1D, std::floating_point DataType>
+using CoefficientFieldMem1D
+        = FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
+template <class ExecSpace, class Grid1D, std::floating_point DataType>
+using CoefficientField1D = Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
 
 } // namespace
 
@@ -113,12 +114,13 @@ neumann_spline_quadrature_coefficients(
                     typename SplineBuilders::continuous_dimension_type> and ...));
 
     // Get coefficients for each dimension
-    std::tuple<CoefficientFieldMem1D<Kokkos::DefaultHostExecutionSpace, DDims>...>
+    std::tuple<CoefficientFieldMem1D<Kokkos::DefaultHostExecutionSpace, DDims, double>...>
     current_dim_coeffs_alloc(
             neumann_spline_quadrature_coefficients_1d<
                     Kokkos::DefaultHostExecutionSpace>(ddc::select<DDims>(idx_range), builders)...);
-    std::tuple<CoefficientField1D<Kokkos::DefaultHostExecutionSpace, DDims>...> current_dim_coeffs(
-            get_field(std::get<CoefficientFieldMem1D<Kokkos::DefaultHostExecutionSpace, DDims>>(
+    std::tuple<CoefficientField1D<Kokkos::DefaultHostExecutionSpace, DDims, double>...>
+    current_dim_coeffs(get_field(
+            std::get<CoefficientFieldMem1D<Kokkos::DefaultHostExecutionSpace, DDims, double>>(
                     current_dim_coeffs_alloc))...);
     // Allocate ND coefficients
     DFieldMem<IdxRange<DDims...>, typename ExecSpace::memory_space>
@@ -130,7 +132,7 @@ neumann_spline_quadrature_coefficients(
     ddc::host_for_each(idx_range, [&](Idx<DDims...> const idim) {
         // multiply the 1D coefficients by one another
         coefficients(idim)
-                = (std::get<CoefficientField1D<Kokkos::DefaultHostExecutionSpace, DDims>>(
+                = (std::get<CoefficientField1D<Kokkos::DefaultHostExecutionSpace, DDims, double>>(
                            current_dim_coeffs)(ddc::select<DDims>(idim))
                    * ... * 1);
     });

--- a/src/quadrature/quadrature.hpp
+++ b/src/quadrature/quadrature.hpp
@@ -214,8 +214,15 @@ private:
 };
 
 namespace detail {
-template <class NewMemorySpace, class IdxRangeQuadrature, class IdxRangeTotal, class DataType, class MemorySpace>
-struct OnMemorySpace<NewMemorySpace, Quadrature<IdxRangeQuadrature, IdxRangeTotal, DataType, MemorySpace>>
+template <
+        class NewMemorySpace,
+        class IdxRangeQuadrature,
+        class IdxRangeTotal,
+        class DataType,
+        class MemorySpace>
+struct OnMemorySpace<
+        NewMemorySpace,
+        Quadrature<IdxRangeQuadrature, IdxRangeTotal, DataType, MemorySpace>>
 {
     using type = Quadrature<IdxRangeQuadrature, IdxRangeTotal, DataType, NewMemorySpace>;
 };

--- a/src/quadrature/quadrature.hpp
+++ b/src/quadrature/quadrature.hpp
@@ -214,9 +214,9 @@ private:
 };
 
 namespace detail {
-template <class NewMemorySpace, class IdxRangeQuadrature, class IdxRangeTotal, class MemorySpace>
-struct OnMemorySpace<NewMemorySpace, Quadrature<IdxRangeQuadrature, IdxRangeTotal, MemorySpace>>
+template <class NewMemorySpace, class IdxRangeQuadrature, class IdxRangeTotal, class DataType, class MemorySpace>
+struct OnMemorySpace<NewMemorySpace, Quadrature<IdxRangeQuadrature, IdxRangeTotal, DataType, MemorySpace>>
 {
-    using type = Quadrature<IdxRangeQuadrature, IdxRangeTotal, NewMemorySpace>;
+    using type = Quadrature<IdxRangeQuadrature, IdxRangeTotal, DataType, NewMemorySpace>;
 };
 } // namespace detail

--- a/src/quadrature/quadrature.hpp
+++ b/src/quadrature/quadrature.hpp
@@ -24,14 +24,17 @@
 template <
         class IdxRangeQuadrature,
         class IdxRangeTotal = IdxRangeQuadrature,
+        class DataType = double,
         class MemorySpace = Kokkos::DefaultExecutionSpace::memory_space>
 class Quadrature
 {
+    static_assert(std::is_floating_point_v<DataType>);
+
 private:
     /// The type of an element of an index of the quadrature coefficients.
     using IdxQuadrature = typename IdxRangeQuadrature::discrete_element_type;
 
-    using QuadConstField = DConstField<IdxRangeQuadrature, MemorySpace>;
+    using QuadConstField = ConstField<DataType, IdxRangeQuadrature, MemorySpace>;
 
     QuadConstField m_coefficients;
 
@@ -57,7 +60,7 @@ public:
      * @returns The integral of the function over the domain.
      */
     template <class ExecutionSpace, class IntegratorFunction>
-    double operator()(ExecutionSpace exec_space, IntegratorFunction integrated_function) const
+    DataType operator()(ExecutionSpace exec_space, IntegratorFunction integrated_function) const
     {
         static_assert(
                 Kokkos::SpaceAccessibility<ExecutionSpace, MemorySpace>::accessible,
@@ -84,7 +87,7 @@ public:
             return ddc::host_transform_reduce(
                     get_idx_range(coeff_proxy),
                     0.0,
-                    ddc::reducer::sum<double>(),
+                    ddc::reducer::sum<DataType>(),
                     KOKKOS_LAMBDA(IdxQuadrature const ix) {
                         return coeff_proxy(ix) * integrated_function(ix);
                     });
@@ -95,7 +98,7 @@ public:
                     exec_space,
                     get_idx_range(coeff_proxy),
                     0.0,
-                    ddc::reducer::sum<double>(),
+                    ddc::reducer::sum<DataType>(),
                     KOKKOS_LAMBDA(IdxQuadrature const ix) {
                         return coeff_proxy(ix) * integrated_function(ix);
                     });
@@ -120,7 +123,7 @@ public:
     template <class ExecutionSpace, class BatchIdxRange, class IntegratorFunction, class Layout>
     void operator()(
             ExecutionSpace exec_space,
-            Field<double, BatchIdxRange, MemorySpace, Layout> const result,
+            Field<DataType, BatchIdxRange, MemorySpace, Layout> const result,
             IntegratorFunction integrated_function) const
     {
         static_assert(
@@ -169,10 +172,10 @@ public:
                     IdxBatch ib = to_discrete_element(idx, batch_idx_range);
 
                     // Sum over quadrature dimensions
-                    double teamSum = 0;
+                    DataType teamSum = 0;
                     Kokkos::parallel_reduce(
                             Kokkos::TeamThreadRange(team, quad_idx_range.size()),
-                            [&](int const& thread_index, double& sum) {
+                            [&](int const& thread_index, DataType& sum) {
                                 IdxQuadrature iq
                                         = to_discrete_element(thread_index, quad_idx_range);
                                 IdxTotal it(ib, iq);

--- a/src/quadrature/quadrature_coeffs_nd.hpp
+++ b/src/quadrature/quadrature_coeffs_nd.hpp
@@ -11,10 +11,11 @@
 
 
 namespace {
-template <class ExecSpace, class Grid1D>
-using CoefficientFieldMem1D = DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space>;
-template <class ExecSpace, class Grid1D>
-using CoefficientField1D = DField<IdxRange<Grid1D>, typename ExecSpace::memory_space>;
+template <class ExecSpace, class Grid1D, class DataType>
+using CoefficientFieldMem1D
+        = FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
+template <class ExecSpace, class Grid1D, class DataType>
+using CoefficientField1D = Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
 } // namespace
 
 /**
@@ -27,21 +28,22 @@ using CoefficientField1D = DField<IdxRange<Grid1D>, typename ExecSpace::memory_s
  *
  * @returns The coefficients which define the quadrature method in ND.
  */
-template <class ExecSpace, class... DDims>
-DFieldMem<IdxRange<DDims...>, typename ExecSpace::memory_space> quadrature_coeffs_nd(
+template <class ExecSpace, class DataType, class... DDims>
+FieldMem<DataType, IdxRange<DDims...>, typename ExecSpace::memory_space> quadrature_coeffs_nd(
         IdxRange<DDims...> const& idx_range,
-        std::function<DFieldMem<IdxRange<DDims>, typename ExecSpace::memory_space>(
+        std::function<FieldMem<DataType, IdxRange<DDims>, typename ExecSpace::memory_space>(
                 IdxRange<DDims>)>... funcs)
 {
-    DFieldMem<IdxRange<DDims...>, typename ExecSpace::memory_space>
+    FieldMem<DataType, IdxRange<DDims...>, typename ExecSpace::memory_space>
             coefficients_alloc("coefficients (quadrature_coeffs_nd)", idx_range);
-    DField<IdxRange<DDims...>, typename ExecSpace::memory_space> coefficients(
+    Field<DataType, IdxRange<DDims...>, typename ExecSpace::memory_space> coefficients(
             get_field(coefficients_alloc));
     // Get coefficients for each dimension
-    std::tuple<CoefficientFieldMem1D<ExecSpace, DDims>...> current_dim_coeffs_alloc(
+    std::tuple<CoefficientFieldMem1D<ExecSpace, DDims, DataType>...> current_dim_coeffs_alloc(
             funcs(ddc::select<DDims>(idx_range))...);
-    std::tuple<CoefficientField1D<ExecSpace, DDims>...> current_dim_coeffs(get_field(
-            std::get<CoefficientFieldMem1D<ExecSpace, DDims>>(current_dim_coeffs_alloc))...);
+    std::tuple<CoefficientField1D<ExecSpace, DDims, DataType>...> current_dim_coeffs(
+            get_field(std::get<CoefficientFieldMem1D<ExecSpace, DDims, DataType>>(
+                    current_dim_coeffs_alloc))...);
 
     const std::source_location location = std::source_location::current();
     ddc::parallel_for_each(
@@ -52,8 +54,8 @@ DFieldMem<IdxRange<DDims...>, typename ExecSpace::memory_space> quadrature_coeff
                 // multiply the 1D coefficients by one another
 
                 coefficients(idim)
-                        = (std::get<CoefficientField1D<ExecSpace, DDims>>(current_dim_coeffs)(
-                                   ddc::select<DDims>(idim))
+                        = (std::get<CoefficientField1D<ExecSpace, DDims, DataType>>(
+                                   current_dim_coeffs)(ddc::select<DDims>(idim))
                            * ... * 1);
             });
     return coefficients_alloc;

--- a/src/quadrature/quadrature_coeffs_nd.hpp
+++ b/src/quadrature/quadrature_coeffs_nd.hpp
@@ -11,10 +11,10 @@
 
 
 namespace {
-template <class ExecSpace, class Grid1D, class DataType>
+template <class ExecSpace, class Grid1D, std::floating_point DataType>
 using CoefficientFieldMem1D
         = FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
-template <class ExecSpace, class Grid1D, class DataType>
+template <class ExecSpace, class Grid1D, std::floating_point DataType>
 using CoefficientField1D = Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>;
 } // namespace
 

--- a/src/quadrature/simpson_quadrature.hpp
+++ b/src/quadrature/simpson_quadrature.hpp
@@ -196,5 +196,6 @@ simpson_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
     return quadrature_coeffs_nd<ExecSpace, DataType, ODims...>(
             idx_range,
             (std::function<FieldMem<DataType, IdxRange<ODims>, typename ExecSpace::memory_space>(
-                     IdxRange<ODims>)>(simpson_quadrature_coefficients_1d<ExecSpace, DataType, ODims>))...);
+                     IdxRange<ODims>)>(
+                    simpson_quadrature_coefficients_1d<ExecSpace, DataType, ODims>))...);
 }

--- a/src/quadrature/simpson_quadrature.hpp
+++ b/src/quadrature/simpson_quadrature.hpp
@@ -105,7 +105,7 @@ void fill_simpson_quadrature_coefficients_1d(
  *
  * @return The quadrature coefficients for the Simpson method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D, class DataType = double>
+template <class ExecSpace, class DataType = double, class Grid1D>
 FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 simpson_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
@@ -139,7 +139,7 @@ simpson_trapezoid_quadrature_coefficients_1d(
             !Grid1D::continuous_dimension_type::PERIODIC,
             "The extremity is non-sensical in a Periodic dimension");
     try {
-        return simpson_quadrature_coefficients_1d<ExecSpace, Grid1D, DataType>(idx_range);
+        return simpson_quadrature_coefficients_1d<ExecSpace, DataType, Grid1D>(idx_range);
     } catch (const std::runtime_error& error) {
         FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients_alloc(
                 "coefficients (simplson_trapezoid_quadrature_coefficients_1d)",
@@ -196,5 +196,5 @@ simpson_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
     return quadrature_coeffs_nd<ExecSpace, DataType, ODims...>(
             idx_range,
             (std::function<FieldMem<DataType, IdxRange<ODims>, typename ExecSpace::memory_space>(
-                     IdxRange<ODims>)>(simpson_quadrature_coefficients_1d<ExecSpace, ODims>))...);
+                     IdxRange<ODims>)>(simpson_quadrature_coefficients_1d<ExecSpace, DataType, ODims>))...);
 }

--- a/src/quadrature/simpson_quadrature.hpp
+++ b/src/quadrature/simpson_quadrature.hpp
@@ -19,7 +19,7 @@
  * @param[in] coefficients
  * 	The field where the quadrature coefficients should be saved.
  */
-template <class ExecSpace, class Grid1D, class DataType = double>
+template <class ExecSpace, class Grid1D, std::floating_point DataType = double>
 void fill_simpson_quadrature_coefficients_1d(
         Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients)
 {
@@ -105,7 +105,7 @@ void fill_simpson_quadrature_coefficients_1d(
  *
  * @return The quadrature coefficients for the Simpson method defined on the provided index range.
  */
-template <class ExecSpace, class DataType = double, class Grid1D>
+template <class ExecSpace, std::floating_point DataType = double, class Grid1D>
 FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 simpson_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
@@ -129,7 +129,7 @@ simpson_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
  *
  * @return The quadrature coefficients for the Simpson method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D, class DataType = double>
+template <class ExecSpace, class Grid1D, std::floating_point DataType = double>
 FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 simpson_trapezoid_quadrature_coefficients_1d(
         IdxRange<Grid1D> const& idx_range,
@@ -189,7 +189,7 @@ simpson_trapezoid_quadrature_coefficients_1d(
  * @return The quadrature coefficients for the trapezoid method defined on the provided idx_range.
  *         The allocation place (host or device ) will depend on the ExecSpace.
  */
-template <class ExecSpace, class DataType = double, class... ODims>
+template <class ExecSpace, std::floating_point DataType = double, class... ODims>
 FieldMem<DataType, IdxRange<ODims...>, typename ExecSpace::memory_space>
 simpson_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
 {

--- a/src/quadrature/simpson_quadrature.hpp
+++ b/src/quadrature/simpson_quadrature.hpp
@@ -19,9 +19,9 @@
  * @param[in] coefficients
  * 	The field where the quadrature coefficients should be saved.
  */
-template <class ExecSpace, class Grid1D>
+template <class ExecSpace, class Grid1D, class DataType = double>
 void fill_simpson_quadrature_coefficients_1d(
-        DField<IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients)
+        Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients)
 {
     IdxRange<Grid1D> idx_range = get_idx_range(coefficients);
     if constexpr (Grid1D::continuous_dimension_type::PERIODIC) {
@@ -43,9 +43,9 @@ void fill_simpson_quadrature_coefficients_1d(
                     idx_range.size() / 2 - int(Grid1D::continuous_dimension_type::PERIODIC)),
             KOKKOS_LAMBDA(const int i) {
                 Idx<Grid1D> idx_c = idx_range.front() + i * 2 + 1;
-                double const dx_l = distance_at_left(idx_c);
-                double const dx_r = distance_at_right(idx_c);
-                double const dx_sum = dx_l + dx_r;
+                DataType const dx_l = distance_at_left(idx_c);
+                DataType const dx_r = distance_at_right(idx_c);
+                DataType const dx_sum = dx_l + dx_r;
                 coefficients(idx_c - 1) = dx_sum * (2. * dx_l - dx_r) / (6. * dx_l);
                 coefficients(idx_c) = dx_sum * dx_sum * dx_sum / (6. * dx_l * dx_r);
             });
@@ -58,9 +58,9 @@ void fill_simpson_quadrature_coefficients_1d(
                     idx_range.size() / 2 - int(Grid1D::continuous_dimension_type::PERIODIC) - 1),
             KOKKOS_LAMBDA(const int i) {
                 Idx<Grid1D> idx_c = idx_range.front() + i * 2 + 1;
-                double const dx_l = distance_at_left(idx_c);
-                double const dx_r = distance_at_right(idx_c);
-                double const dx_sum = dx_l + dx_r;
+                DataType const dx_l = distance_at_left(idx_c);
+                DataType const dx_r = distance_at_right(idx_c);
+                DataType const dx_sum = dx_l + dx_r;
                 coefficients(idx_c + 1) += dx_sum * (2. * dx_r - dx_l) / (6. * dx_r);
             });
 
@@ -70,9 +70,9 @@ void fill_simpson_quadrature_coefficients_1d(
             KOKKOS_LAMBDA(const int i) {
                 Idx<Grid1D> idx_c
                         = idx_range.back() - 1 - int(Grid1D::continuous_dimension_type::PERIODIC);
-                double const dx_l = distance_at_left(idx_c);
-                double const dx_r = distance_at_right(idx_c);
-                double const dx_sum = dx_l + dx_r;
+                DataType const dx_l = distance_at_left(idx_c);
+                DataType const dx_r = distance_at_right(idx_c);
+                DataType const dx_sum = dx_l + dx_r;
                 coefficients(idx_c + 1) = dx_sum * (2. * dx_r - dx_l) / (6. * dx_r);
             });
 
@@ -82,9 +82,9 @@ void fill_simpson_quadrature_coefficients_1d(
                 Kokkos::RangePolicy<ExecSpace>(0, 1),
                 KOKKOS_LAMBDA(const int i) {
                     Idx<Grid1D> idx_c = idx_range.back();
-                    double const dx_l = distance_at_left(idx_c);
-                    double const dx_r = distance_at_right(idx_c);
-                    double const dx_sum = dx_l + dx_r;
+                    DataType const dx_l = distance_at_left(idx_c);
+                    DataType const dx_r = distance_at_right(idx_c);
+                    DataType const dx_sum = dx_l + dx_r;
                     coefficients(idx_c - 1) += dx_sum * (2. * dx_l - dx_r) / (6. * dx_l);
                     coefficients(idx_c) = dx_sum * dx_sum * dx_sum / (6. * dx_l * dx_r);
                     coefficients(idx_range.front()) += dx_sum * (2. * dx_r - dx_l) / (6. * dx_r);
@@ -105,11 +105,11 @@ void fill_simpson_quadrature_coefficients_1d(
  *
  * @return The quadrature coefficients for the Simpson method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D>
-DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> simpson_quadrature_coefficients_1d(
-        IdxRange<Grid1D> const& idx_range)
+template <class ExecSpace, class Grid1D, class DataType = double>
+FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
+simpson_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
-    DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients_alloc(
+    FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients_alloc(
             "current_dim_coeffs (simplson_quadrature_coefficients_1d)",
             idx_range);
     fill_simpson_quadrature_coefficients_1d<ExecSpace>(get_field(coefficients_alloc));
@@ -129,8 +129,8 @@ DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> simpson_quadrature
  *
  * @return The quadrature coefficients for the Simpson method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D>
-DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space>
+template <class ExecSpace, class Grid1D, class DataType = double>
+FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 simpson_trapezoid_quadrature_coefficients_1d(
         IdxRange<Grid1D> const& idx_range,
         Extremity trapezoid_extremity)
@@ -139,35 +139,35 @@ simpson_trapezoid_quadrature_coefficients_1d(
             !Grid1D::continuous_dimension_type::PERIODIC,
             "The extremity is non-sensical in a Periodic dimension");
     try {
-        return simpson_quadrature_coefficients_1d<ExecSpace>(idx_range);
+        return simpson_quadrature_coefficients_1d<ExecSpace, Grid1D, DataType>(idx_range);
     } catch (const std::runtime_error& error) {
-        DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients_alloc(
+        FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients_alloc(
                 "coefficients (simplson_trapezoid_quadrature_coefficients_1d)",
                 idx_range);
-        DField<IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients(
+        Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> coefficients(
                 get_field(coefficients_alloc));
         IdxStep<Grid1D> npts_to_remove(1);
         if (trapezoid_extremity == Extremity::FRONT) {
-            fill_simpson_quadrature_coefficients_1d<ExecSpace>(
+            fill_simpson_quadrature_coefficients_1d<ExecSpace, Grid1D, DataType>(
                     coefficients_alloc[idx_range.remove_first(npts_to_remove)]);
             Kokkos::parallel_for(
                     "trapezoid_region",
                     Kokkos::RangePolicy<ExecSpace>(0, 1),
                     KOKKOS_LAMBDA(const int i) {
                         Idx<Grid1D> idx_l = idx_range.front();
-                        double dx_cell = 0.5 * distance_at_right(idx_l);
+                        DataType dx_cell = 0.5 * distance_at_right(idx_l);
                         coefficients(idx_l) = dx_cell;
                         coefficients(idx_l + 1) += dx_cell;
                     });
         } else {
-            fill_simpson_quadrature_coefficients_1d<ExecSpace>(
+            fill_simpson_quadrature_coefficients_1d<ExecSpace, Grid1D, DataType>(
                     coefficients_alloc[idx_range.remove_last(npts_to_remove)]);
             Kokkos::parallel_for(
                     "trapezoid_region",
                     Kokkos::RangePolicy<ExecSpace>(0, 1),
                     KOKKOS_LAMBDA(const int i) {
                         Idx<Grid1D> idx_r = idx_range.back();
-                        double dx_cell = 0.5 * distance_at_left(idx_r);
+                        DataType dx_cell = 0.5 * distance_at_left(idx_r);
                         coefficients(idx_r) = dx_cell;
                         coefficients(idx_r - 1) += dx_cell;
                     });
@@ -189,12 +189,12 @@ simpson_trapezoid_quadrature_coefficients_1d(
  * @return The quadrature coefficients for the trapezoid method defined on the provided idx_range.
  *         The allocation place (host or device ) will depend on the ExecSpace.
  */
-template <class ExecSpace, class... ODims>
-DFieldMem<IdxRange<ODims...>, typename ExecSpace::memory_space> simpson_quadrature_coefficients(
-        IdxRange<ODims...> const& idx_range)
+template <class ExecSpace, class DataType = double, class... ODims>
+FieldMem<DataType, IdxRange<ODims...>, typename ExecSpace::memory_space>
+simpson_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
 {
-    return quadrature_coeffs_nd<ExecSpace, ODims...>(
+    return quadrature_coeffs_nd<ExecSpace, DataType, ODims...>(
             idx_range,
-            (std::function<DFieldMem<IdxRange<ODims>, typename ExecSpace::memory_space>(
+            (std::function<FieldMem<DataType, IdxRange<ODims>, typename ExecSpace::memory_space>(
                      IdxRange<ODims>)>(simpson_quadrature_coefficients_1d<ExecSpace, ODims>))...);
 }

--- a/src/quadrature/trapezoid_quadrature.hpp
+++ b/src/quadrature/trapezoid_quadrature.hpp
@@ -20,13 +20,13 @@
  *
  * @return The quadrature coefficients for the trapezoid method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D>
-DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> trapezoid_quadrature_coefficients_1d(
-        IdxRange<Grid1D> const& idx_range)
+template <class ExecSpace, class Grid1D, class DataType = double>
+FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
+trapezoid_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
-    DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space>
+    FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
             coefficients_alloc("coefficients (trapezoid_quadrature_coefficients_1d)", idx_range);
-    DField<IdxRange<Grid1D>, typename ExecSpace::memory_space> const coefficients
+    Field<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space> const coefficients
             = get_field(coefficients_alloc);
 
     IdxRange<Grid1D> middle_idx_range
@@ -78,12 +78,13 @@ DFieldMem<IdxRange<Grid1D>, typename ExecSpace::memory_space> trapezoid_quadratu
  * @return The quadrature coefficients for the trapezoid method defined on the provided idx_range.
  *         The allocation place (host or device ) will depend on the ExecSpace.
  */
-template <class ExecSpace, class... ODims>
-DFieldMem<IdxRange<ODims...>, typename ExecSpace::memory_space> trapezoid_quadrature_coefficients(
-        IdxRange<ODims...> const& idx_range)
+template <class ExecSpace, class DataType = double, class... ODims>
+FieldMem<DataType, IdxRange<ODims...>, typename ExecSpace::memory_space>
+trapezoid_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
 {
-    return quadrature_coeffs_nd<ExecSpace, ODims...>(
+    return quadrature_coeffs_nd<ExecSpace, DataType, ODims...>(
             idx_range,
             (std::function<DFieldMem<IdxRange<ODims>, typename ExecSpace::memory_space>(
-                     IdxRange<ODims>)>(trapezoid_quadrature_coefficients_1d<ExecSpace, ODims>))...);
+                     IdxRange<ODims>)>(
+                    trapezoid_quadrature_coefficients_1d<ExecSpace, ODims, DataType>))...);
 }

--- a/src/quadrature/trapezoid_quadrature.hpp
+++ b/src/quadrature/trapezoid_quadrature.hpp
@@ -20,7 +20,7 @@
  *
  * @return The quadrature coefficients for the trapezoid method defined on the provided index range.
  */
-template <class ExecSpace, class Grid1D, class DataType = double>
+template <class ExecSpace, class DataType = double, class Grid1D>
 FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 trapezoid_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
@@ -86,5 +86,5 @@ trapezoid_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
             idx_range,
             (std::function<DFieldMem<IdxRange<ODims>, typename ExecSpace::memory_space>(
                      IdxRange<ODims>)>(
-                    trapezoid_quadrature_coefficients_1d<ExecSpace, ODims, DataType>))...);
+                    trapezoid_quadrature_coefficients_1d<ExecSpace, DataType, ODims>))...);
 }

--- a/src/quadrature/trapezoid_quadrature.hpp
+++ b/src/quadrature/trapezoid_quadrature.hpp
@@ -20,7 +20,7 @@
  *
  * @return The quadrature coefficients for the trapezoid method defined on the provided index range.
  */
-template <class ExecSpace, class DataType = double, class Grid1D>
+template <class ExecSpace, std::floating_point DataType = double, class Grid1D>
 FieldMem<DataType, IdxRange<Grid1D>, typename ExecSpace::memory_space>
 trapezoid_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
 {
@@ -78,7 +78,7 @@ trapezoid_quadrature_coefficients_1d(IdxRange<Grid1D> const& idx_range)
  * @return The quadrature coefficients for the trapezoid method defined on the provided idx_range.
  *         The allocation place (host or device ) will depend on the ExecSpace.
  */
-template <class ExecSpace, class DataType = double, class... ODims>
+template <class ExecSpace, std::floating_point DataType = double, class... ODims>
 FieldMem<DataType, IdxRange<ODims...>, typename ExecSpace::memory_space>
 trapezoid_quadrature_coefficients(IdxRange<ODims...> const& idx_range)
 {

--- a/tests/quadrature/quadrature_1d.cpp
+++ b/tests/quadrature/quadrature_1d.cpp
@@ -12,7 +12,7 @@ namespace {
 
 enum Method { TRAPEZ, SIMPSON };
 
-template <bool Periodic>
+template <bool Periodic, class Real = double>
 struct ConstantFuncCheck
 {
     struct XPeriod
@@ -25,7 +25,7 @@ struct ConstantFuncCheck
     };
     using IdxRangeXPeriod = IdxRange<GridXPeriod>;
     using CoordXPeriod = Coord<XPeriod>;
-    using DFieldMemX = DFieldMem<IdxRangeXPeriod>;
+    using DFieldMemX = FieldMem<Real, IdxRangeXPeriod>;
 
     static double check_1d(Method quad_method)
     {
@@ -45,12 +45,13 @@ struct ConstantFuncCheck
         switch (quad_method) {
         case Method::TRAPEZ: {
             quadrature_coeffs_alloc
-                    = trapezoid_quadrature_coefficients<Kokkos::DefaultExecutionSpace>(gridx);
+                    = trapezoid_quadrature_coefficients<Kokkos::DefaultExecutionSpace, Real>(gridx);
             break;
         }
         case Method::SIMPSON: {
             quadrature_coeffs_alloc
-                    = simpson_quadrature_coefficients_1d<Kokkos::DefaultExecutionSpace>(gridx);
+                    = simpson_quadrature_coefficients_1d<Kokkos::DefaultExecutionSpace, Real>(
+                            gridx);
             break;
         }
         }
@@ -111,8 +112,8 @@ double compute_error(int n_cells, Method quad_method)
     using DimY = typename ComputeErrorTraits<N>::Y;
     using GridY = typename ComputeErrorTraits<N>::GridY;
     using IdxRangeY = IdxRange<GridY>;
-    using DFieldMemY = DFieldMem<IdxRangeY>;
-    using DFieldY = DField<IdxRangeY>;
+    using DFieldMemY = FieldMem<double, IdxRangeY>;
+    using DFieldY = Field<double, IdxRangeY>;
 
     Coord<DimY> const y_min(0.0);
     Coord<DimY> const y_max(M_PI);
@@ -129,12 +130,12 @@ double compute_error(int n_cells, Method quad_method)
     switch (quad_method) {
     case Method::TRAPEZ: {
         quadrature_coeffs_alloc
-                = trapezoid_quadrature_coefficients<Kokkos::DefaultExecutionSpace>(gridy);
+                = trapezoid_quadrature_coefficients<Kokkos::DefaultExecutionSpace, double>(gridy);
         break;
     }
     case Method::SIMPSON: {
         quadrature_coeffs_alloc
-                = simpson_quadrature_coefficients_1d<Kokkos::DefaultExecutionSpace>(gridy);
+                = simpson_quadrature_coefficients_1d<Kokkos::DefaultExecutionSpace, double>(gridy);
         break;
     }
     }
@@ -192,6 +193,36 @@ TEST(SimpsonTrapezoidFrontNonUniformNonPeriodicQuadrature1D, ExactForConstantFun
 TEST(SimpsonTrapezoidBackNonUniformNonPeriodicQuadrature1D, ExactForConstantFunc)
 {
     EXPECT_LE(ConstantFuncCheck<false>::check_simpson_trapezoid_1d(Extremity::BACK), 1e-11);
+}
+
+TEST(FloatTrapezoidNonUniformPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<true>::check_1d(Method::TRAPEZ), 1e-7);
+}
+
+TEST(FloatSimpsonNonUniformPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<true>::check_1d(Method::SIMPSON), 1e-7);
+}
+
+TEST(FloatTrapezoidNonUniformNonPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<false>::check_1d(Method::TRAPEZ), 1e-7);
+}
+
+TEST(FloatSimpsonNonUniformNonPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<false>::check_1d(Method::SIMPSON), 1e-7);
+}
+
+TEST(FloatSimpsonTrapezoidFrontNonUniformNonPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<false>::check_simpson_trapezoid_1d(Extremity::FRONT), 1e-7);
+}
+
+TEST(FloatSimpsonTrapezoidBackNonUniformNonPeriodicQuadrature1D, ExactForConstantFunc)
+{
+    EXPECT_LE(ConstantFuncCheck<false>::check_simpson_trapezoid_1d(Extremity::BACK), 1e-7);
 }
 
 TEST(TrapezoidUniformNonPeriodicQuadrature1D, Convergence)

--- a/tests/quadrature/quadrature_1d.cpp
+++ b/tests/quadrature/quadrature_1d.cpp
@@ -112,8 +112,8 @@ double compute_error(int n_cells, Method quad_method)
     using DimY = typename ComputeErrorTraits<N>::Y;
     using GridY = typename ComputeErrorTraits<N>::GridY;
     using IdxRangeY = IdxRange<GridY>;
-    using DFieldMemY = FieldMem<double, IdxRangeY>;
-    using DFieldY = Field<double, IdxRangeY>;
+    using DFieldMemY = DFieldMem<IdxRangeY>;
+    using DFieldY = DField<IdxRangeY>;
 
     Coord<DimY> const y_min(0.0);
     Coord<DimY> const y_max(M_PI);


### PR DESCRIPTION
Add support for arbitrary precision quadrature by adding a `DataType` template parameter.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
