### PR TITLE
 Add data type parametrisation to `ConstantIdentityInterpolationExtrapolationRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add more labels to memory allocations.
 - Add a `NDIdentityInterpolationBuilder` class.
 - Add a new abstract class `IPolarPoissonLikeSolver`.
+- Add data type parametrisation to `ConstantIdentityInterpolationExtrapolationRule`.
 
 ### Fixed
 

--- a/src/interpolation/constant_identity_interpolation_extrapolation_rule.hpp
+++ b/src/interpolation/constant_identity_interpolation_extrapolation_rule.hpp
@@ -10,7 +10,7 @@
  * rather than extrapolating the polynomial. This is the Lagrange analog of
  * ddc::ConstantExtrapolationRule used with spline evaluators.
  *
- * It is intended to be constructed via get_extrapolation<CONSTANT, CoeffGrid, Basis>(),
+ * It is intended to be constructed via get_extrapolation<CONSTANT, CoeffGrid, DataType, Basis>(),
  * which supplies the appropriate boundary index automatically.
  *
  * @tparam CoeffGrid The discrete grid type of the interpolation coefficients.

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -6,57 +6,57 @@
 namespace details {
 
 // Get the class describing the interpolation rule
-template <ExtrapolationRule Rule, class CoeffGrid>
+template <ExtrapolationRule Rule, class CoeffGrid, class DataType>
 struct GetExtrapolationRuleClass;
 
-template <class CoeffGrid>
-struct GetExtrapolationRuleClass<PERIODIC, CoeffGrid>
+template <class CoeffGrid, class DataType>
+struct GetExtrapolationRuleClass<PERIODIC, CoeffGrid, DataType>
 {
     using type = ddc::PeriodicExtrapolationRule<typename CoeffGrid::continuous_dimension_type>;
 };
 
-template <class CoeffGrid>
-struct GetExtrapolationRuleClass<NULL_VALUE, CoeffGrid>
+template <class CoeffGrid, class DataType>
+struct GetExtrapolationRuleClass<NULL_VALUE, CoeffGrid, DataType>
 {
     using type = ddc::NullExtrapolationRule;
 };
 
-template <class CoeffGrid>
-struct GetExtrapolationRuleClass<CONSTANT, CoeffGrid>
+template <class CoeffGrid, class DataType>
+struct GetExtrapolationRuleClass<CONSTANT, CoeffGrid, DataType>
 {
     using type = std::conditional_t<
             is_spline_basis_v<CoeffGrid>,
             ddc::ConstantExtrapolationRule<typename CoeffGrid::continuous_dimension_type>,
-            ConstantIdentityInterpolationExtrapolationRule<CoeffGrid>>;
+            ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>;
 };
 
 } // namespace details
 
-template <ExtrapolationRule Rule, class CoeffGrid>
-using extrapolation_rule_t = details::GetExtrapolationRuleClass<Rule, CoeffGrid>::type;
+template <ExtrapolationRule Rule, class CoeffGrid, class DataType>
+using extrapolation_rule_t = details::GetExtrapolationRuleClass<Rule, CoeffGrid, DataType>::type;
 
-template <ExtrapolationRule Rule, class CoeffGrid, class Basis = CoeffGrid>
-extrapolation_rule_t<Rule, CoeffGrid> get_extrapolation(Extremity extremity)
+template <ExtrapolationRule Rule, class CoeffGrid, class DataType, class Basis = CoeffGrid>
+extrapolation_rule_t<Rule, CoeffGrid, DataType> get_extrapolation(Extremity extremity)
 {
     if constexpr (Rule == CONSTANT) {
         if constexpr (is_spline_basis_v<Basis>) {
             if (extremity == Extremity::FRONT) {
-                return extrapolation_rule_t<Rule, CoeffGrid>(
+                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
                         ddc::discrete_space<CoeffGrid>().rmin());
             } else {
-                return extrapolation_rule_t<Rule, CoeffGrid>(
+                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
                         ddc::discrete_space<CoeffGrid>().rmax());
             }
         } else {
             if (extremity == Extremity::FRONT) {
-                return extrapolation_rule_t<Rule, CoeffGrid>(
+                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
                         ddc::discrete_space<Basis>().full_domain().front());
             } else {
-                return extrapolation_rule_t<Rule, CoeffGrid>(
+                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
                         ddc::discrete_space<Basis>().full_domain().back());
             }
         }
     } else {
-        return extrapolation_rule_t<Rule, CoeffGrid>();
+        return extrapolation_rule_t<Rule, CoeffGrid, DataType>();
     }
 }

--- a/src/interpolation/identity_interpolation_builder.hpp
+++ b/src/interpolation/identity_interpolation_builder.hpp
@@ -111,9 +111,9 @@ public:
             IdxRange<basis_domain_type> extended_domain(
                     ddc::discrete_space<Basis>().full_domain().remove_first(
                             bp_idx_range.extents()));
-            typename BatchedInterpolationIdxRange::discrete_vector_type nrepeat(
-                    extended_domain.size());
-            BatchedInterpolationIdxRange repeat_domain(get_idx_range(vals).take_first(nrepeat));
+            IdxStep<InterpolationGrid> nrepeat(extended_domain.size());
+            IdxRange<InterpolationGrid> repeat_domain(
+                    get_idx_range<InterpolationGrid>(vals).take_first(nrepeat));
             Kokkos::deep_copy(
                     coeffs[extended_domain].allocation_kokkos_view(),
                     vals[repeat_domain].allocation_kokkos_view());

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -52,8 +52,6 @@ class LagrangeInterpolator
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
-    static_assert(is_periodic == (MinBound == ddc::BoundCond::PERIODIC));
-    static_assert(is_periodic == (MaxBound == ddc::BoundCond::PERIODIC));
     static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
     static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
 
@@ -78,8 +76,8 @@ public:
             DataType,
             Basis,
             InterpGrid,
-            extrapolation_rule_t<MinExtrapRule, CoeffGridType>,
-            extrapolation_rule_t<MaxExtrapRule, CoeffGridType>>;
+            extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>,
+            extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType>>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -88,8 +86,8 @@ public:
     }
 
 private:
-    extrapolation_rule_t<MinExtrapRule, CoeffGridType> m_min_extrapolation;
-    extrapolation_rule_t<MaxExtrapRule, CoeffGridType> m_max_extrapolation;
+    extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType> m_min_extrapolation;
+    extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType> m_max_extrapolation;
     BuilderType m_builder;
     EvaluatorType m_evaluator;
 
@@ -100,12 +98,15 @@ public:
      * The extrapolation rules are initialised from the discrete space of @c Basis,
      * so the corresponding ddc discrete space must be initialised before construction.
      * No index range is required because the identity builder needs none.
+     *
+     * @param idx_range The index range on which the interpolator will act. This is
+     *                  unused but is included to match the SplineInterpolator interface.
      */
-    LagrangeInterpolator()
+    LagrangeInterpolator(IdxRange<InterpGrid> idx_range)
         : m_min_extrapolation(
-                get_extrapolation<MinExtrapRule, CoeffGridType, Basis>(Extremity::FRONT))
+                get_extrapolation<MinExtrapRule, CoeffGridType, DataType, Basis>(Extremity::FRONT))
         , m_max_extrapolation(
-                  get_extrapolation<MaxExtrapRule, CoeffGridType, Basis>(Extremity::BACK))
+                  get_extrapolation<MaxExtrapRule, CoeffGridType, DataType, Basis>(Extremity::BACK))
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
     }

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -52,6 +52,8 @@ class LagrangeInterpolator
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
+    static_assert(is_periodic == (MinBound == ddc::BoundCond::PERIODIC));
+    static_assert(is_periodic == (MaxBound == ddc::BoundCond::PERIODIC));
     static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
     static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
 
@@ -98,11 +100,8 @@ public:
      * The extrapolation rules are initialised from the discrete space of @c Basis,
      * so the corresponding ddc discrete space must be initialised before construction.
      * No index range is required because the identity builder needs none.
-     *
-     * @param idx_range The index range on which the interpolator will act. This is
-     *                  unused but is included to match the SplineInterpolator interface.
      */
-    LagrangeInterpolator(IdxRange<InterpGrid> idx_range)
+    LagrangeInterpolator()
         : m_min_extrapolation(
                 get_extrapolation<MinExtrapRule, CoeffGridType, DataType, Basis>(Extremity::FRONT))
         , m_max_extrapolation(

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -66,8 +66,8 @@ public:
             typename ExecSpace::memory_space,
             Basis,
             InterpGrid,
-            extrapolation_rule_t<MinExtrapRule, Basis>,
-            extrapolation_rule_t<MaxExtrapRule, Basis>>;
+            extrapolation_rule_t<MinExtrapRule, Basis, double>,
+            extrapolation_rule_t<MaxExtrapRule, Basis, double>>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -76,8 +76,8 @@ public:
     }
 
 private:
-    extrapolation_rule_t<MinExtrapRule, Basis> m_min_extrapolation;
-    extrapolation_rule_t<MaxExtrapRule, Basis> m_max_extrapolation;
+    extrapolation_rule_t<MinExtrapRule, Basis, double> m_min_extrapolation;
+    extrapolation_rule_t<MaxExtrapRule, Basis, double> m_max_extrapolation;
     BuilderType m_builder;
     EvaluatorType m_evaluator;
 
@@ -92,8 +92,8 @@ public:
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
     explicit SplineInterpolator(std::string const& label, IdxRange<InterpGrid> idx_range)
-        : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis>(Extremity::FRONT))
-        , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis>(Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
         , m_builder(label, idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
@@ -107,8 +107,8 @@ public:
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
     explicit SplineInterpolator(IdxRange<InterpGrid> idx_range)
-        : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis>(Extremity::FRONT))
-        , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis>(Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
         , m_builder(idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {


### PR DESCRIPTION
Add data type parametrisation to `ConstantIdentityInterpolationExtrapolationRule` to ensure it is compatible with a float-based Lagrange interpolator.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
