### PR TITLE
Move rank > 1 out of the metadata section

### DIFF
--- a/simulations/geometryVparMu/collisions/pdi_out.yml.hpp
+++ b/simulations/geometryVparMu/collisions/pdi_out.yml.hpp
@@ -30,11 +30,6 @@ metadata:
     type: array
     subtype: double
     size: [ '$fdistribu_masses_extents[0]' ]
-  fdistribu_eq_extents : { type: array, subtype: int64, size: 3 }
-  fdistribu_eq:
-    type: array
-    subtype: double
-    size: [ '$fdistribu_eq_extents[0]', '$fdistribu_eq_extents[1]', '$fdistribu_eq_extents[2]' ]
 
 data:
   fdistribu_extents: { type: array, subtype: int64, size: 3 }

--- a/simulations/geometryXVx/pdi_out.yml.hpp
+++ b/simulations/geometryXVx/pdi_out.yml.hpp
@@ -31,13 +31,13 @@ metadata:
     type: array
     subtype: double
     size: [ '$fdistribu_masses_extents[0]' ]
+
+data:
   fdistribu_eq_extents : { type: array, subtype: int64, size: 2 }
   fdistribu_eq:
     type: array
     subtype: double
     size: [ '$fdistribu_eq_extents[0]', '$fdistribu_eq_extents[1]' ]
-
-data:
   fdistribu_extents: { type: array, subtype: int64, size: 3 }
   fdistribu:
     type: array

--- a/simulations/geometryXYVxVy/landau/pdi_out.yml.hpp
+++ b/simulations/geometryXYVxVy/landau/pdi_out.yml.hpp
@@ -42,11 +42,6 @@ metadata:
     type: array
     subtype: double
     size: [ '$fdistribu_masses_extents[0]' ]
-  fdistribu_eq_extents : { type: array, subtype: int64, size: 3 }
-  fdistribu_eq:
-    type: array
-    subtype: double
-    size: [ '$fdistribu_eq_extents[0]', '$fdistribu_eq_extents[1]', '$fdistribu_eq_extents[2]' ]
 
   #-- Parallel data
   local_fdistribu_starts: { type: array, subtype: size_t, size: 5 }
@@ -54,6 +49,11 @@ metadata:
 
 
 data:
+  fdistribu_eq_extents : { type: array, subtype: int64, size: 3 }
+  fdistribu_eq:
+    type: array
+    subtype: double
+    size: [ '$fdistribu_eq_extents[0]', '$fdistribu_eq_extents[1]', '$fdistribu_eq_extents[2]' ]
   fdistribu:
     type: array
     subtype: double


### PR DESCRIPTION
solves #640 

I only found 3 simulations that were declaring arrays rank > 1 in the metadata section:
- geometryVparMu/collisions: fdistribu_eq does not seem to be exposed so removed
- geometryXVx: fdistribu_eq moved to data section
- geometryXYVxVy/landau: fdistribu_eq moved to data section

Should be transparent for users so I suggest no changelog entry.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
