### PR TITLE
Add a Spack build cache

### DIFF
--- a/.github/workflows/install_tests.yml
+++ b/.github/workflows/install_tests.yml
@@ -39,7 +39,7 @@ jobs:
   spack_test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     needs: pre_job
     name: Install Test
@@ -60,6 +60,15 @@ jobs:
           ../toolchains/cpu.spack.gyselalibxx_env/prepare.sh
         shell: bash
         timeout-minutes: 180
+      - name: Push packages and update index
+        shell: bash
+        env:
+          GITHUB_USER: ${{github.actor}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          source ${GITHUB_WORKSPACE}/toolchains/cpu.spack.gyselalibxx_env/environment.sh
+          spack buildcache push --update-index local-buildcache
+        if: ${{!cancelled()}}
       - name: Build code
         uses: ./.github/actions/build_code
         with:

--- a/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
+++ b/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
@@ -1,6 +1,17 @@
 spack:
   concretizer:
     unify: true
+  config:
+    install_tree:
+      padded_length: 128
+  mirrors:
+    local-buildcache:
+      url: oci://ghcr.io/gyselax/gyselalibxx-spack-buildcache
+      binary: true
+      signed: false
+      access_pair:
+        id_variable: GITHUB_USER
+        secret_variable: GITHUB_TOKEN
   definitions:
   - packages:
     - 'cmake@3.30'

--- a/toolchains/cpu.spack.gyselalibxx_env/prepare.sh
+++ b/toolchains/cpu.spack.gyselalibxx_env/prepare.sh
@@ -36,9 +36,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Activate spack
 . ${SPACK_PATH}/share/spack/setup-env.sh
 
-# Increase the time out that is by default too short for some packages (like PDI)
-spack config --scope site add 'config:connect_timeout:60'
-
 spack compiler find
 
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
This PR installs a binary cache located [here](https://github.com/gyselax/gyselalibxx/pkgs/container/gyselalibxx-spack-buildcache). The aim is to speed-up the test installing packages with Spack by downloading packages already available:
- before:
  - ubuntu: 2h14m
  - macos: 1h48m
- after:
  - ubuntu: 4m2s
  - macos: 5m2s
 
So a speedup of 20-30x.

The timeout in the prepare.sh script is removed, it is legacy of when PDI used to be on the MdlS gitlab.

I don't think a changelog entry is necessary as there is no user-facing change.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
