### PR TITLE
Use int64_t for species indentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable python for PDI and pdiplugin-pycall on macOS.
 - Enforce version of Kokkos Tools in all toolchains for reproducibility.
 - Remove default O1 optimisation flag.
+- Changed type of species identifier read in `read_species` PDI event (from `int` to `int64`).
 
 ### Deprecated
 

--- a/src/speciesinfo/species_init.cpp
+++ b/src/speciesinfo/species_init.cpp
@@ -141,7 +141,7 @@ void init_species_withfluid(
  */
 IdxRangeSp init_kinetic_species()
 {
-    std::vector<int> species;
+    std::vector<int64_t> species;
     std::vector<double> charges;
     std::vector<double> masses;
     PDI_get_arrays("read_species", "species", species, "charges", charges, "masses", masses);


### PR DESCRIPTION
Use int64_t for species indentifier to match Gysela-X which prefers to use int64 throughout.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
