### PR TITLE
Correct output datatypes for mesh descriptors

### DIFF
--- a/simulations/geometryXYVxVy/landau/pdi_out.yml.hpp
+++ b/simulations/geometryXYVxVy/landau/pdi_out.yml.hpp
@@ -24,33 +24,33 @@ constexpr char const* const PDI_CFG
   MeshX_extents: { type: array, subtype: int64, size: 1 }
   MeshX:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$MeshX_extents[0]' ]
   MeshY_extents: { type: array, subtype: int64, size: 1 }
   MeshY:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$MeshY_extents[0]' ]
   MeshVx_extents: { type: array, subtype: int64, size: 1 }
   MeshVx:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$MeshVx_extents[0]' ]
   MeshVy_extents: { type: array, subtype: int64, size: 1 }
   MeshVy:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$MeshVy_extents[0]' ]
   Nkinspecies: int
   fdistribu_charges_extents : { type: array, subtype: int64, size: 1 }
   fdistribu_charges:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$fdistribu_charges_extents[0]' ]
   fdistribu_masses_extents : { type: array, subtype: int64, size: 1 }
   fdistribu_masses:
     type: array
-    subtype: real_type
+    subtype: double
     size: [ '$fdistribu_masses_extents[0]' ]
 
   #-- Parallel data


### PR DESCRIPTION
Correct output datatypes for mesh descriptors in the Landau 4D simulation. The data is single precision, but the coordinates and species information is still stored in double precision

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
