### PR TITLE
Update to DDC v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed the name of class `SplineBuliderDerivField2D` to fix typo (->`SplineBuilderDerivField2D`).
-- Update DDC to [v0.14.0](https://github.com/CExA-project/ddc/releases/tag/v0.14.0) (see also [v0.13.0](https://github.com/CExA-project/ddc/releases/tag/v0.13.0)).
+- Update DDC to [v0.15.0](https://github.com/CExA-project/ddc/releases/tag/v0.15.0) (see also [v0.14.0](https://github.com/CExA-project/ddc/releases/tag/v0.14.0) and [v0.13.0](https://github.com/CExA-project/ddc/releases/tag/v0.13.0)).
 - Changed FindLAPACKE CMake module to the version in DDC.
 - Renamed `DiscreteToCartesian` -> `DiscretePoloidalCSSplineMapping`.
 - Renamed `DiscreteToCartesianBuilder` -> `DiscretePoloidalCSSplineMappingBuilder`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(Kokkos 4.4.1...<5 REQUIRED)
 
 find_package(KokkosKernels 4.5.1...<5 REQUIRED)
 
-find_package(DDC 0.14.0 REQUIRED COMPONENTS fft pdi splines)
+find_package(DDC 0.15.0 REQUIRED COMPONENTS fft pdi splines)
 
 find_package(koliop 0.1.2 REQUIRED)
 

--- a/docker/gyselalibxx_env/Dockerfile
+++ b/docker/gyselalibxx_env/Dockerfile
@@ -58,7 +58,7 @@ RUN chmod +x /bin/bash_run \
  && git clone --branch 4.7.01 --depth 1 https://github.com/kokkos/kokkos-kernels.git \
  && git clone --branch develop --depth 1 https://github.com/kokkos/kokkos-tools.git \
  && git clone --branch v0.1.2 --depth 1 https://gitlab.com/cines/code.gysela/libkoliop \
- && git clone --branch v0.14.0 --depth 1 https://github.com/CExA-project/ddc.git \
+ && git clone --branch v0.15.0 --depth 1 https://github.com/CExA-project/ddc.git \
  && git clone --branch v2.3.1 --depth 1 https://github.com/SciCompMod/GMGPolar.git \
  && export Kokkos_ROOT=/opt/serial/Kokkos \
  && export KokkosFFT_ROOT=/opt/serial/KokkosFFT \

--- a/docs/first_steps/landau_damping_tutorial.md
+++ b/docs/first_steps/landau_damping_tutorial.md
@@ -260,8 +260,8 @@ The function `ddc::init_discrete_space` calls the [constructor of `ddc::UniformB
 The grid is constructed from the Greville abscissae of the b-splines using DDC as follows:
 
 ```cpp
-auto constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-auto constexpr SplineVxBoundary = ddc::BoundCond::HERMITE;
+auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;

--- a/docs/first_steps/landau_damping_tutorial.md
+++ b/docs/first_steps/landau_damping_tutorial.md
@@ -260,13 +260,13 @@ The function `ddc::init_discrete_space` calls the [constructor of `ddc::UniformB
 The grid is constructed from the Greville abscissae of the b-splines using DDC as follows:
 
 ```cpp
-auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
+auto constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+auto constexpr SplineVxClosure = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {
@@ -335,8 +335,8 @@ using SplineXBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesX,
         GridX,
-        SplineXBoundary,
-        SplineXBoundary,
+        SplineXClosure,
+        SplineXClosure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineVxBuilder = ddc::SplineBuilder<
@@ -344,8 +344,8 @@ using SplineVxBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesVx,
         GridVx,
-        SplineVxBoundary,
-        SplineVxBoundary,
+        SplineVxClosure,
+        SplineVxClosure,
         ddc::SplineSolver::LAPACK>;
 ```
 

--- a/simulations/geometryVparMu/spline_definitions_vpar_mu.hpp
+++ b/simulations/geometryVparMu/spline_definitions_vpar_mu.hpp
@@ -26,8 +26,8 @@ struct BSplinesMu
               ddc::NonUniformBSplines<Mu, BSDegreeMu>>
 {
 };
-ddc::BoundCond constexpr SplineVparBoundary = ddc::BoundCond::HERMITE;
-ddc::BoundCond constexpr SplineMuBoundary = ddc::BoundCond::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineVparBoundary = ddc::SplineBuilderClosure::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineMuBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsVpar
         = ddc::GrevilleInterpolationPoints<BSplinesVpar, SplineVparBoundary, SplineVparBoundary>;

--- a/simulations/geometryVparMu/spline_definitions_vpar_mu.hpp
+++ b/simulations/geometryVparMu/spline_definitions_vpar_mu.hpp
@@ -26,21 +26,21 @@ struct BSplinesMu
               ddc::NonUniformBSplines<Mu, BSDegreeMu>>
 {
 };
-ddc::SplineBuilderClosure constexpr SplineVparBoundary = ddc::SplineBuilderClosure::HERMITE;
-ddc::SplineBuilderClosure constexpr SplineMuBoundary = ddc::SplineBuilderClosure::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineVparClosure = ddc::SplineBuilderClosure::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineMuClosure = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsVpar
-        = ddc::GrevilleInterpolationPoints<BSplinesVpar, SplineVparBoundary, SplineVparBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVpar, SplineVparClosure, SplineVparClosure>;
 using SplineInterpPointsMu
-        = ddc::GrevilleInterpolationPoints<BSplinesMu, SplineMuBoundary, SplineMuBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesMu, SplineMuClosure, SplineMuClosure>;
 
 using SplineVparBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace,
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesVpar,
         GridVpar,
-        SplineVparBoundary,
-        SplineVparBoundary,
+        SplineVparClosure,
+        SplineVparClosure,
         ddc::SplineSolver::LAPACK>;
 using SplineVparEvaluator = ddc::SplineEvaluator<
         Kokkos::DefaultExecutionSpace,
@@ -55,8 +55,8 @@ using SplineMuBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesMu,
         GridMu,
-        SplineMuBoundary,
-        SplineMuBoundary,
+        SplineMuClosure,
+        SplineMuClosure,
         ddc::SplineSolver::LAPACK>;
 using SplineMuEvaluator = ddc::SplineEvaluator<
         Kokkos::DefaultExecutionSpace,

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -31,7 +31,8 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineXBoundary
+        = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 using SplineInterpPointsX

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -31,14 +31,14 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary
+auto constexpr SplineXClosure
         = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
-auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
+auto constexpr SplineVxClosure = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 ExtrapolationRule constexpr XExtrapRule = X::PERIODIC ? PERIODIC : CONSTANT;
 
@@ -48,8 +48,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         XExtrapRule,
         XExtrapRule,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -57,8 +57,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         GridVx,
         CONSTANT,
         CONSTANT,
-        SplineVxBoundary,
-        SplineVxBoundary>;
+        SplineVxClosure,
+        SplineVxClosure>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -31,8 +31,8 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::BoundCond::PERIODIC : ddc::BoundCond::GREVILLE;
-auto constexpr SplineVxBoundary = ddc::BoundCond::HOMOGENEOUS_HERMITE;
+auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;

--- a/simulations/geometryXY/spline_definitions_xy.hpp
+++ b/simulations/geometryXY/spline_definitions_xy.hpp
@@ -27,8 +27,8 @@ struct BSplinesY
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineYBoundary = ddc::BoundCond::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 ExtrapolationRule constexpr SplineXExtrapolation = ExtrapolationRule::PERIODIC;
 ExtrapolationRule constexpr SplineYExtrapolation = ExtrapolationRule::PERIODIC;

--- a/simulations/geometryXY/spline_definitions_xy.hpp
+++ b/simulations/geometryXY/spline_definitions_xy.hpp
@@ -27,17 +27,17 @@ struct BSplinesY
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineYClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 ExtrapolationRule constexpr SplineXExtrapolation = ExtrapolationRule::PERIODIC;
 ExtrapolationRule constexpr SplineYExtrapolation = ExtrapolationRule::PERIODIC;
 
 // IDim initialisers
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsY
-        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYBoundary, SplineYBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYClosure, SplineYClosure>;
 
 
 // SplineBuilder and SplineEvaluator definitions
@@ -47,8 +47,8 @@ using SplineXInterpolator = SplineInterpolator<
         GridX,
         SplineXExtrapolation,
         SplineXExtrapolation,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 using SplineYInterpolator = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -56,8 +56,8 @@ using SplineYInterpolator = SplineInterpolator<
         GridY,
         SplineYExtrapolation,
         SplineYExtrapolation,
-        SplineYBoundary,
-        SplineYBoundary>;
+        SplineYClosure,
+        SplineYClosure>;
 
 // Spline index range
 using IdxRangeBSX = IdxRange<BSplinesX>;

--- a/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
@@ -49,8 +49,8 @@ struct LagrangeVy
 {
 };
 
-ddc::SplineBuilderClosure constexpr LagrangeYBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr LagrangeVyBoundary
+ddc::SplineBuilderClosure constexpr LagrangeYClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr LagrangeVyClosure
         = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // SplineBuilder and SplineEvaluator definition

--- a/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
@@ -50,7 +50,8 @@ struct LagrangeVy
 };
 
 ddc::SplineBuilderClosure constexpr LagrangeYBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr LagrangeVyBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr LagrangeVyBoundary
+        = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // SplineBuilder and SplineEvaluator definition
 using LagrangeInterpolatorX = LagrangeInterpolator<

--- a/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
@@ -49,8 +49,8 @@ struct LagrangeVy
 {
 };
 
-ddc::BoundCond constexpr LagrangeYBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr LagrangeVyBoundary = ddc::BoundCond::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr LagrangeYBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr LagrangeVyBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // SplineBuilder and SplineEvaluator definition
 using LagrangeInterpolatorX = LagrangeInterpolator<

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -32,8 +32,8 @@ struct BSplinesVy
 {
 };
 
-ddc::BoundCond constexpr SplineYBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineVyBoundary = ddc::BoundCond::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVyBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // IDim initialisers
 using SplineInterpPointsY

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -33,7 +33,8 @@ struct BSplinesVy
 };
 
 ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVyBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr SplineVyBoundary
+        = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // IDim initialisers
 using SplineInterpPointsY

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -32,15 +32,15 @@ struct BSplinesVy
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVyBoundary
+ddc::SplineBuilderClosure constexpr SplineYClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVyClosure
         = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 // IDim initialisers
 using SplineInterpPointsY
-        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYBoundary, SplineYBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYClosure, SplineYClosure>;
 using SplineInterpPointsVy
-        = ddc::GrevilleInterpolationPoints<BSplinesVy, SplineVyBoundary, SplineVyBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVy, SplineVyClosure, SplineVyClosure>;
 
 // SplineBuilder and SplineEvaluator definition
 using SplineInterpolatorY = SplineInterpolator<
@@ -49,8 +49,8 @@ using SplineInterpolatorY = SplineInterpolator<
         GridY,
         PERIODIC,
         PERIODIC,
-        SplineYBoundary,
-        SplineYBoundary>;
+        SplineYClosure,
+        SplineYClosure>;
 
 using SplineInterpolatorVy = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -58,8 +58,8 @@ using SplineInterpolatorVy = SplineInterpolator<
         GridVy,
         CONSTANT,
         CONSTANT,
-        SplineVyBoundary,
-        SplineVyBoundary>;
+        SplineVyClosure,
+        SplineVyClosure>;
 
 using IdxRangeBSY = IdxRange<BSplinesY>;
 using IdxRangeBSXY = IdxRange<BSplinesX, BSplinesY>;

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -422,16 +422,16 @@ class SplinePolarFootFinder
             "information about the derivatives and therefore will not work with this class. Please "
             "check the choice of boundary conditions).");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type1::s_bc_xmin != ddc::BoundCond::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmin != ddc::SplineBuilderClosure::PERIODIC,
             "Periodic boundary conditions in the radial direction are nonsensical.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type1::s_bc_xmax != ddc::BoundCond::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmax != ddc::SplineBuilderClosure::PERIODIC,
             "Periodic boundary conditions in the radial direction are nonsensical.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type2::s_bc_xmin == ddc::BoundCond::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmin == ddc::SplineBuilderClosure::PERIODIC,
             "Expected periodic boundary conditions in the poloidal direction.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type2::s_bc_xmax == ddc::BoundCond::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmax == ddc::SplineBuilderClosure::PERIODIC,
             "Expected periodic boundary conditions in the poloidal direction.");
 
 public:

--- a/src/advection/spline_polar_foot_finder.hpp
+++ b/src/advection/spline_polar_foot_finder.hpp
@@ -422,16 +422,20 @@ class SplinePolarFootFinder
             "information about the derivatives and therefore will not work with this class. Please "
             "check the choice of boundary conditions).");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmin != ddc::SplineBuilderClosure::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmin
+                    != ddc::SplineBuilderClosure::PERIODIC,
             "Periodic boundary conditions in the radial direction are nonsensical.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmax != ddc::SplineBuilderClosure::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type1::s_sbc_xmax
+                    != ddc::SplineBuilderClosure::PERIODIC,
             "Periodic boundary conditions in the radial direction are nonsensical.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmin == ddc::SplineBuilderClosure::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmin
+                    == ddc::SplineBuilderClosure::PERIODIC,
             "Expected periodic boundary conditions in the poloidal direction.");
     static_assert(
-            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmax == ddc::SplineBuilderClosure::PERIODIC,
+            SplineRThetaBuilderAdvection::builder_type2::s_sbc_xmax
+                    == ddc::SplineBuilderClosure::PERIODIC,
             "Expected periodic boundary conditions in the poloidal direction.");
 
 public:

--- a/src/coord_transformations/discrete_poloidal_cs_spline_mapping_builder.hpp
+++ b/src/coord_transformations/discrete_poloidal_cs_spline_mapping_builder.hpp
@@ -228,13 +228,13 @@ public:
 private:
     using GrevillePointsR = ddc::GrevilleInterpolationPoints<
             BSplinesRRefined,
-            SplineBuilder::builder_type1::s_bc_xmin,
-            SplineBuilder::builder_type1::s_bc_xmax>;
+            SplineBuilder::builder_type1::s_sbc_xmin,
+            SplineBuilder::builder_type1::s_sbc_xmax>;
 
     using GrevillePointsTheta = ddc::GrevilleInterpolationPoints<
             BSplinesThetaRefined,
-            SplineBuilder::builder_type2::s_bc_xmin,
-            SplineBuilder::builder_type2::s_bc_xmax>;
+            SplineBuilder::builder_type2::s_sbc_xmin,
+            SplineBuilder::builder_type2::s_sbc_xmax>;
 
 public:
     /// @brief The type of the grid of radial points on which the new mapping will be defined.
@@ -255,10 +255,10 @@ private:
     struct Build_BuilderType;
 
     template <
-            ddc::BoundCond BcLower1,
-            ddc::BoundCond BcUpper1,
-            ddc::BoundCond BcLower2,
-            ddc::BoundCond BcUpper2,
+            ddc::SplineBuilderClosure BcLower1,
+            ddc::SplineBuilderClosure BcUpper1,
+            ddc::SplineBuilderClosure BcLower2,
+            ddc::SplineBuilderClosure BcUpper2,
             ddc::SplineSolver Solver>
     struct Build_BuilderType<ddc::SplineBuilder2D<
             ExecSpace,

--- a/src/coord_transformations/discrete_poloidal_cs_spline_mapping_builder.hpp
+++ b/src/coord_transformations/discrete_poloidal_cs_spline_mapping_builder.hpp
@@ -255,10 +255,10 @@ private:
     struct Build_BuilderType;
 
     template <
-            ddc::SplineBuilderClosure BcLower1,
-            ddc::SplineBuilderClosure BcUpper1,
-            ddc::SplineBuilderClosure BcLower2,
-            ddc::SplineBuilderClosure BcUpper2,
+            ddc::SplineBuilderClosure SBCLower1,
+            ddc::SplineBuilderClosure SBCUpper1,
+            ddc::SplineBuilderClosure SBCLower2,
+            ddc::SplineBuilderClosure SBCUpper2,
             ddc::SplineSolver Solver>
     struct Build_BuilderType<ddc::SplineBuilder2D<
             ExecSpace,
@@ -267,10 +267,10 @@ private:
             BSplinesThetaOriginal,
             GridROriginal,
             GridThetaOriginal,
-            BcLower1,
-            BcUpper1,
-            BcLower2,
-            BcUpper2,
+            SBCLower1,
+            SBCUpper1,
+            SBCLower2,
+            SBCUpper2,
             Solver>>
     {
         using type = ddc::SplineBuilder2D<
@@ -280,10 +280,10 @@ private:
                 BSplinesThetaRefined,
                 GridRRefined,
                 GridThetaRefined,
-                BcLower1,
-                BcUpper1,
-                BcLower2,
-                BcUpper2,
+                SBCLower1,
+                SBCUpper1,
+                SBCLower2,
+                SBCUpper2,
                 Solver>;
     };
 

--- a/src/geometryRTheta/geometry/spline_definitions_r_theta.hpp
+++ b/src/geometryRTheta/geometry/spline_definitions_r_theta.hpp
@@ -29,8 +29,8 @@ struct PolarBSplinesRTheta : PolarBSplines<BSplinesR, BSplinesTheta, 1>
 {
 };
 
-ddc::BoundCond constexpr SplineRBoundary = ddc::BoundCond::GREVILLE;
-ddc::BoundCond constexpr SplineThetaBoundary = ddc::BoundCond::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 using SplineInterpPointsR
         = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;

--- a/src/geometryRTheta/geometry/spline_definitions_r_theta.hpp
+++ b/src/geometryRTheta/geometry/spline_definitions_r_theta.hpp
@@ -29,13 +29,13 @@ struct PolarBSplinesRTheta : PolarBSplines<BSplinesR, BSplinesTheta, 1>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-ddc::SplineBuilderClosure constexpr SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineRClosure = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineThetaClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 using SplineInterpPointsR
-        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRClosure, SplineRClosure>;
 using SplineInterpPointsTheta
-        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaBoundary, SplineThetaBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaClosure, SplineThetaClosure>;
 
 // --- Operators
 using SplineRThetaBuilder_host = ddc::SplineBuilder2D<
@@ -45,10 +45,10 @@ using SplineRThetaBuilder_host = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        SplineRBoundary, // boundary at r=0
-        SplineRBoundary, // boundary at rmax
-        SplineThetaBoundary,
-        SplineThetaBoundary,
+        SplineRClosure, // boundary at r=0
+        SplineRClosure, // boundary at rmax
+        SplineThetaClosure,
+        SplineThetaClosure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineRThetaEvaluatorConstBound_host = ddc::SplineEvaluator2D<
@@ -82,10 +82,10 @@ using SplineRThetaBuilder = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        SplineRBoundary, // boundary at r=0
-        SplineRBoundary, // boundary at rmax
-        SplineThetaBoundary,
-        SplineThetaBoundary,
+        SplineRClosure, // boundary at r=0
+        SplineRClosure, // boundary at rmax
+        SplineThetaClosure,
+        SplineThetaClosure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineRThetaEvaluatorConstBound = ddc::SplineEvaluator2D<

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -78,16 +78,16 @@ template <
         class MemorySpace,
         class BSplines,
         class InterpolationDDim,
-        ddc::SplineBuilderClosure BcLower,
-        ddc::SplineBuilderClosure BcUpper,
+        ddc::SplineBuilderClosure SBCLower,
+        ddc::SplineBuilderClosure SBCUpper,
         ddc::SplineSolver Solver>
 struct InterpolationBuilderTraits<ddc::SplineBuilder<
         ExecSpace,
         MemorySpace,
         BSplines,
         InterpolationDDim,
-        BcLower,
-        BcUpper,
+        SBCLower,
+        SBCUpper,
         Solver>>
 {
 private:
@@ -96,8 +96,8 @@ private:
             MemorySpace,
             BSplines,
             InterpolationDDim,
-            BcLower,
-            BcUpper,
+            SBCLower,
+            SBCUpper,
             Solver>;
 
 public:

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -78,8 +78,8 @@ template <
         class MemorySpace,
         class BSplines,
         class InterpolationDDim,
-        ddc::BoundCond BcLower,
-        ddc::BoundCond BcUpper,
+        ddc::SplineBuilderClosure BcLower,
+        ddc::SplineBuilderClosure BcUpper,
         ddc::SplineSolver Solver>
 struct InterpolationBuilderTraits<ddc::SplineBuilder<
         ExecSpace,

--- a/src/interpolation/identity_interpolation_builder.hpp
+++ b/src/interpolation/identity_interpolation_builder.hpp
@@ -123,7 +123,7 @@ public:
     /**
      * @brief Get the whole domain on which derivatives on lower boundary are defined.
      *
-     * This is only used with BoundCond::HERMITE boundary conditions.
+     * This is only used with SplineBuilderClosure::HERMITE boundary conditions.
      *
      * @param batched_interpolation_domain The whole domain on which the interpolation points are defined.
      *
@@ -141,7 +141,7 @@ public:
     /**
      * @brief Get the whole domain on which derivatives on upper boundary are defined.
      *
-     * This is only used with BoundCond::HERMITE boundary conditions.
+     * This is only used with SplineBuilderClosure::HERMITE boundary conditions.
      *
      * @param batched_interpolation_domain The whole domain on which the interpolation points are defined.
      *

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -22,8 +22,8 @@
  * @tparam InterpGrid    The discrete grid on which function values are provided.
  * @tparam MinExtrapRule The ExtrapolationRule applied below the lower boundary.
  * @tparam MaxExtrapRule The ExtrapolationRule applied above the upper boundary.
- * @tparam MinBound      The ddc::BoundCond at the lower boundary of the spline builder.
- * @tparam MaxBound      The ddc::BoundCond at the upper boundary of the spline builder.
+ * @tparam MinBound      The ddc::SplineBuilderClosure at the lower boundary of the spline builder.
+ * @tparam MaxBound      The ddc::SplineBuilderClosure at the upper boundary of the spline builder.
  * @tparam Solver        The spline solver backend (default: LAPACK).
  */
 template <
@@ -32,8 +32,8 @@ template <
         class InterpGrid,
         ExtrapolationRule MinExtrapRule,
         ExtrapolationRule MaxExtrapRule,
-        ddc::BoundCond MinBound,
-        ddc::BoundCond MaxBound,
+        ddc::SplineBuilderClosure MinBound,
+        ddc::SplineBuilderClosure MaxBound,
         ddc::SplineSolver Solver = ddc::SplineSolver::LAPACK>
 class SplineInterpolator
 {
@@ -42,8 +42,8 @@ private:
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
-    static_assert(is_periodic == (MinBound == ddc::BoundCond::PERIODIC));
-    static_assert(is_periodic == (MaxBound == ddc::BoundCond::PERIODIC));
+    static_assert(is_periodic == (MinBound == ddc::SplineBuilderClosure::PERIODIC));
+    static_assert(is_periodic == (MaxBound == ddc::SplineBuilderClosure::PERIODIC));
     static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
     static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
 

--- a/src/multipatch/interface_derivatives/README.md
+++ b/src/multipatch/interface_derivatives/README.md
@@ -103,11 +103,11 @@ SingleInterfaceDerivativesCalculator<Interface_12> derivatives_calculator (idx_r
 
 ```cpp
 // If we want to apply the treatment on Patch 1 and Patch 2
-SingleInterfaceDerivativesCalculator<Interface_12, ddc::BoundCond::GREVILLE, ddc::BoundCond::GREVILLE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
+SingleInterfaceDerivativesCalculator<Interface_12, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
 // or if we want to apply the treatment only on Patch 1
-SingleInterfaceDerivativesCalculator<Interface_12, ddc::BoundCond::GREVILLE, ddc::BoundCond::HERMITE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
+SingleInterfaceDerivativesCalculator<Interface_12, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::HERMITE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
 // or if we want to apply the treatment only on Patch 2
-SingleInterfaceDerivativesCalculator<Interface_12, ddc::BoundCond::HERMITE, ddc::BoundCond::GREVILLE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
+SingleInterfaceDerivativesCalculator<Interface_12, ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::GREVILLE> derivatives_calculator (idx_range_patch_1, idx_range_patch_2);
 ```
 
 > If we want to use an approximation where the boundary cells are not involved (even for interpolation points as closure condition on the global domain),

--- a/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
+++ b/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
@@ -155,11 +155,11 @@ public:
      * on the patch 1. 
      * @param idx_range_1d_2 1D index range perpendicular to the Interface, 
      * on the patch 2. 
-     * @param Bound1 The boundary condition type on the opposite edge of the interface on 
+     * @param Closure1 The spline closure type on the opposite edge of the interface on 
      * the patch 1. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. If 
      * ddc::SplineBuilderClosure::GREVILLE is given, a treatment will be applied to consider the 
      * additional interpolation point. Giving ddc::SplineBuilderClosure::PERIODIC does not make sense. 
-     * @param Bound2 The boundary condition type on the opposite edge of the interface on 
+     * @param Closure2 The spline closure type on the opposite edge of the interface on 
      * the patch 2. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. If 
      * ddc::SplineBuilderClosure::GREVILLE is given, a treatment will be applied to consider the 
      * additional interpolation point. Giving ddc::SplineBuilderClosure::PERIODIC does not make sense.  
@@ -167,10 +167,10 @@ public:
     SingleInterfaceDerivativesCalculator(
             IdxRange1DPerp_1 const& idx_range_1d_1,
             IdxRange1DPerp_2 const& idx_range_1d_2,
-            ddc::SplineBuilderClosure const& Bound1 = ddc::SplineBuilderClosure::HERMITE,
-            ddc::SplineBuilderClosure const& Bound2 = ddc::SplineBuilderClosure::HERMITE)
-        : m_is_cell_bound_1_with_extra_interpol_pt(Bound1 == ddc::SplineBuilderClosure::GREVILLE)
-        , m_is_cell_bound_2_with_extra_interpol_pt(Bound2 == ddc::SplineBuilderClosure::GREVILLE)
+            ddc::SplineBuilderClosure const& Closure1 = ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure const& Closure2 = ddc::SplineBuilderClosure::HERMITE)
+        : m_is_cell_bound_1_with_extra_interpol_pt(Closure1 == ddc::SplineBuilderClosure::GREVILLE)
+        , m_is_cell_bound_2_with_extra_interpol_pt(Closure2 == ddc::SplineBuilderClosure::GREVILLE)
         , m_idx_range_perp_1(idx_range_1d_1)
         , m_idx_range_perp_2(idx_range_1d_2)
         , m_weights_patch_1_alloc(
@@ -184,8 +184,8 @@ public:
         , m_weights_patch_1(m_weights_patch_1_alloc)
         , m_weights_patch_2(m_weights_patch_2_alloc)
     {
-        assert(Bound1 != ddc::SplineBuilderClosure::PERIODIC);
-        assert(Bound2 != ddc::SplineBuilderClosure::PERIODIC);
+        assert(Closure1 != ddc::SplineBuilderClosure::PERIODIC);
+        assert(Closure2 != ddc::SplineBuilderClosure::PERIODIC);
 
         // Two interpolation points have to be added if the derivatives are not closure condition.
         if (m_is_cell_bound_1_with_extra_interpol_pt) {
@@ -236,22 +236,22 @@ public:
      * See @ref SingleInterfaceDerivativesCalculatorInstantiator.
      * @param idx_range_a Index range on one patch. 
      * @param idx_range_b Index range on the other patch. 
-     * @param Bound1 The boundary condition type on the opposite edge of the interface on 
+     * @param Closure1 The spline closure type on the opposite edge of the interface on 
      * the patch 1. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. 
-     * @param Bound2 The boundary condition type on the opposite edge of the interface on 
+     * @param Closure2 The spline closure type on the opposite edge of the interface on 
      * the patch 2. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. 
      */
     template <class IdxRangeA, class IdxRangeB>
     SingleInterfaceDerivativesCalculator(
             IdxRangeA const& idx_range_a,
             IdxRangeB const& idx_range_b,
-            ddc::SplineBuilderClosure const& Bound1 = ddc::SplineBuilderClosure::HERMITE,
-            ddc::SplineBuilderClosure const& Bound2 = ddc::SplineBuilderClosure::HERMITE)
+            ddc::SplineBuilderClosure const& Closure1 = ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure const& Closure2 = ddc::SplineBuilderClosure::HERMITE)
         : SingleInterfaceDerivativesCalculator(
                 IdxRange1DPerp_1(idx_range_a, idx_range_b),
                 IdxRange1DPerp_2(idx_range_a, idx_range_b),
-                Bound1,
-                Bound2)
+                Closure1,
+                Closure2)
     {
         static_assert(ddc::is_discrete_domain_v<IdxRangeA>);
         static_assert(ddc::is_discrete_domain_v<IdxRangeB>);

--- a/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
+++ b/src/multipatch/interface_derivatives/single_interface_derivatives_calculator.hpp
@@ -57,7 +57,7 @@ inline constexpr bool is_single_derivative_calculator_v
  * to compute the derivatives.  
  * 
  * @warning The applied method only works for interpolation points located on 
- * the break points. In the case where "ddc::BoundCond::GREVILLE" is specified,
+ * the break points. In the case where "ddc::SplineBuilderClosure::GREVILLE" is specified,
  * additional interpolation points are also placed in the first or last cell
  * of the patch.
  * Please be sure to initialise the discrete space of your Grid on the break points
@@ -156,21 +156,21 @@ public:
      * @param idx_range_1d_2 1D index range perpendicular to the Interface, 
      * on the patch 2. 
      * @param Bound1 The boundary condition type on the opposite edge of the interface on 
-     * the patch 1. By default, the value is set to ddc::BoundCond::HERMITE. If 
-     * ddc::BoundCond::GREVILLE is given, a treatment will be applied to consider the 
-     * additional interpolation point. Giving ddc::BoundCond::PERIODIC does not make sense. 
+     * the patch 1. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. If 
+     * ddc::SplineBuilderClosure::GREVILLE is given, a treatment will be applied to consider the 
+     * additional interpolation point. Giving ddc::SplineBuilderClosure::PERIODIC does not make sense. 
      * @param Bound2 The boundary condition type on the opposite edge of the interface on 
-     * the patch 2. By default, the value is set to ddc::BoundCond::HERMITE. If 
-     * ddc::BoundCond::GREVILLE is given, a treatment will be applied to consider the 
-     * additional interpolation point. Giving ddc::BoundCond::PERIODIC does not make sense.  
+     * the patch 2. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. If 
+     * ddc::SplineBuilderClosure::GREVILLE is given, a treatment will be applied to consider the 
+     * additional interpolation point. Giving ddc::SplineBuilderClosure::PERIODIC does not make sense.  
      */
     SingleInterfaceDerivativesCalculator(
             IdxRange1DPerp_1 const& idx_range_1d_1,
             IdxRange1DPerp_2 const& idx_range_1d_2,
-            ddc::BoundCond const& Bound1 = ddc::BoundCond::HERMITE,
-            ddc::BoundCond const& Bound2 = ddc::BoundCond::HERMITE)
-        : m_is_cell_bound_1_with_extra_interpol_pt(Bound1 == ddc::BoundCond::GREVILLE)
-        , m_is_cell_bound_2_with_extra_interpol_pt(Bound2 == ddc::BoundCond::GREVILLE)
+            ddc::SplineBuilderClosure const& Bound1 = ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure const& Bound2 = ddc::SplineBuilderClosure::HERMITE)
+        : m_is_cell_bound_1_with_extra_interpol_pt(Bound1 == ddc::SplineBuilderClosure::GREVILLE)
+        , m_is_cell_bound_2_with_extra_interpol_pt(Bound2 == ddc::SplineBuilderClosure::GREVILLE)
         , m_idx_range_perp_1(idx_range_1d_1)
         , m_idx_range_perp_2(idx_range_1d_2)
         , m_weights_patch_1_alloc(
@@ -184,8 +184,8 @@ public:
         , m_weights_patch_1(m_weights_patch_1_alloc)
         , m_weights_patch_2(m_weights_patch_2_alloc)
     {
-        assert(Bound1 != ddc::BoundCond::PERIODIC);
-        assert(Bound2 != ddc::BoundCond::PERIODIC);
+        assert(Bound1 != ddc::SplineBuilderClosure::PERIODIC);
+        assert(Bound2 != ddc::SplineBuilderClosure::PERIODIC);
 
         // Two interpolation points have to be added if the derivatives are not closure condition.
         if (m_is_cell_bound_1_with_extra_interpol_pt) {
@@ -237,16 +237,16 @@ public:
      * @param idx_range_a Index range on one patch. 
      * @param idx_range_b Index range on the other patch. 
      * @param Bound1 The boundary condition type on the opposite edge of the interface on 
-     * the patch 1. By default, the value is set to ddc::BoundCond::HERMITE. 
+     * the patch 1. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. 
      * @param Bound2 The boundary condition type on the opposite edge of the interface on 
-     * the patch 2. By default, the value is set to ddc::BoundCond::HERMITE. 
+     * the patch 2. By default, the value is set to ddc::SplineBuilderClosure::HERMITE. 
      */
     template <class IdxRangeA, class IdxRangeB>
     SingleInterfaceDerivativesCalculator(
             IdxRangeA const& idx_range_a,
             IdxRangeB const& idx_range_b,
-            ddc::BoundCond const& Bound1 = ddc::BoundCond::HERMITE,
-            ddc::BoundCond const& Bound2 = ddc::BoundCond::HERMITE)
+            ddc::SplineBuilderClosure const& Bound1 = ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure const& Bound2 = ddc::SplineBuilderClosure::HERMITE)
         : SingleInterfaceDerivativesCalculator(
                 IdxRange1DPerp_1(idx_range_a, idx_range_b),
                 IdxRange1DPerp_2(idx_range_a, idx_range_b),
@@ -285,8 +285,8 @@ public:
                                 Kokkos::min(number_chosen_cells + 1, idx_range_1d_2.size())))
                         : idx_range_1d_2.take_last(IdxStep<EdgePerpGrid2>(
                                 Kokkos::min(number_chosen_cells + 1, idx_range_1d_2.size()))),
-                ddc::BoundCond::HERMITE,
-                ddc::BoundCond::HERMITE)
+                ddc::SplineBuilderClosure::HERMITE,
+                ddc::SplineBuilderClosure::HERMITE)
     {
     }
 

--- a/src/multipatch/spline/multipatch_spline_builder.hpp
+++ b/src/multipatch/spline/multipatch_spline_builder.hpp
@@ -29,8 +29,8 @@
  * @tparam MemorySpace The space (CPU/GPU) where the coefficients and values are stored.
  * @tparam BSplineOnPatch A type alias which provides the BSpline type along which the splines are built.
  * @tparam GridOnPatch A type alias which provides the Grid type along which the interpolation points of the splines are found.
- * @tparam BcLower The lower boundary condition.
- * @tparam BcUpper The upper boundary condition.
+ * @tparam SBCLower The lower spline closure.
+ * @tparam SBCUpper The upper spline closure.
  * @tparam BcTransition The boundary condition used at the interface between 2 patches.
  * @tparam Connectivity A MultipatchConnectivity object describing the interfaces between patches.
  * @tparam Solver The SplineSolver giving the backend used to perform the spline approximation. See DDC for more details.
@@ -44,8 +44,8 @@ template <
         typename BSplineOnPatch,
         template <typename P>
         typename GridOnPatch,
-        ddc::SplineBuilderClosure BcLower,
-        ddc::SplineBuilderClosure BcUpper,
+        ddc::SplineBuilderClosure SBCLower,
+        ddc::SplineBuilderClosure SBCUpper,
         ddc::SplineBuilderClosure BcTransition,
         class Connectivity,
         ddc::SplineSolver Solver,
@@ -87,8 +87,8 @@ class MultipatchSplineBuilder
                 MemorySpace,
                 BSplineOnPatch<Patch>,
                 GridOnPatch<Patch>,
-                std::is_same_v<lower_matching_edge, OutsideEdge> ? BcLower : BcTransition,
-                std::is_same_v<upper_matching_edge, OutsideEdge> ? BcUpper : BcTransition,
+                std::is_same_v<lower_matching_edge, OutsideEdge> ? SBCLower : BcTransition,
+                std::is_same_v<upper_matching_edge, OutsideEdge> ? SBCUpper : BcTransition,
                 Solver>;
     };
 

--- a/src/multipatch/spline/multipatch_spline_builder.hpp
+++ b/src/multipatch/spline/multipatch_spline_builder.hpp
@@ -44,9 +44,9 @@ template <
         typename BSplineOnPatch,
         template <typename P>
         typename GridOnPatch,
-        ddc::BoundCond BcLower,
-        ddc::BoundCond BcUpper,
-        ddc::BoundCond BcTransition,
+        ddc::SplineBuilderClosure BcLower,
+        ddc::SplineBuilderClosure BcUpper,
+        ddc::SplineBuilderClosure BcTransition,
         class Connectivity,
         ddc::SplineSolver Solver,
         template <typename P>

--- a/src/multipatch/spline/multipatch_spline_builder_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_builder_2d.hpp
@@ -31,10 +31,10 @@
  * @tparam BSpline2OnPatch A type alias which provides the second BSpline type along which the splines are built.
  * @tparam Grid1OnPatch A type alias which provides the first Grid type along which the interpolation points of the splines are found.
  * @tparam Grid2OnPatch A type alias which provides the second Grid type along which the interpolation points of the splines are found.
- * @tparam BcLower1 The lower boundary condition on the first dimension.
- * @tparam BcUpper1 The upper boundary condition on the first dimension.
- * @tparam BcLower2 The lower boundary condition on the second dimension.
- * @tparam BcUpper2 The upper boundary condition on the second dimension.
+ * @tparam SBCLower1 The lower spline closure on the first dimension.
+ * @tparam SBCUpper1 The upper spline closure on the first dimension.
+ * @tparam SBCLower2 The lower spline closure on the second dimension.
+ * @tparam SBCUpper2 The upper spline closure on the second dimension.
  * @tparam BcTransition The boundary condition used at the interface between 2 patches.
  * @tparam Connectivity A MultipatchConnectivity object describing the interfaces between patches.
  * @tparam Solver The SplineSolver giving the backend used to perform the spline approximation. See DDC for more details.
@@ -52,10 +52,10 @@ template <
         typename Grid1OnPatch,
         template <typename P>
         typename Grid2OnPatch,
-        ddc::SplineBuilderClosure BcLower1,
-        ddc::SplineBuilderClosure BcUpper1,
-        ddc::SplineBuilderClosure BcLower2,
-        ddc::SplineBuilderClosure BcUpper2,
+        ddc::SplineBuilderClosure SBCLower1,
+        ddc::SplineBuilderClosure SBCUpper1,
+        ddc::SplineBuilderClosure SBCLower2,
+        ddc::SplineBuilderClosure SBCUpper2,
         ddc::SplineBuilderClosure BcTransition,
         class Connectivity,
         ddc::SplineSolver Solver,
@@ -131,10 +131,10 @@ class MultipatchSplineBuilder2D
                 BSpline2OnPatch<Patch>,
                 Grid1OnPatch<Patch>,
                 Grid2OnPatch<Patch>,
-                std::is_same_v<lower_matching_edge1, OutsideEdge> ? BcLower1 : BcTransition,
-                std::is_same_v<upper_matching_edge1, OutsideEdge> ? BcUpper1 : BcTransition,
-                std::is_same_v<lower_matching_edge2, OutsideEdge> ? BcLower2 : BcTransition,
-                std::is_same_v<upper_matching_edge2, OutsideEdge> ? BcUpper2 : BcTransition,
+                std::is_same_v<lower_matching_edge1, OutsideEdge> ? SBCLower1 : BcTransition,
+                std::is_same_v<upper_matching_edge1, OutsideEdge> ? SBCUpper1 : BcTransition,
+                std::is_same_v<lower_matching_edge2, OutsideEdge> ? SBCLower2 : BcTransition,
+                std::is_same_v<upper_matching_edge2, OutsideEdge> ? SBCUpper2 : BcTransition,
                 Solver>;
     };
 

--- a/src/multipatch/spline/multipatch_spline_builder_2d.hpp
+++ b/src/multipatch/spline/multipatch_spline_builder_2d.hpp
@@ -52,11 +52,11 @@ template <
         typename Grid1OnPatch,
         template <typename P>
         typename Grid2OnPatch,
-        ddc::BoundCond BcLower1,
-        ddc::BoundCond BcUpper1,
-        ddc::BoundCond BcLower2,
-        ddc::BoundCond BcUpper2,
-        ddc::BoundCond BcTransition,
+        ddc::SplineBuilderClosure BcLower1,
+        ddc::SplineBuilderClosure BcUpper1,
+        ddc::SplineBuilderClosure BcLower2,
+        ddc::SplineBuilderClosure BcUpper2,
+        ddc::SplineBuilderClosure BcTransition,
         class Connectivity,
         ddc::SplineSolver Solver,
         template <typename P>

--- a/src/quadrature/neumann_spline_quadrature.hpp
+++ b/src/quadrature/neumann_spline_quadrature.hpp
@@ -54,13 +54,13 @@ neumann_spline_quadrature_coefficients_1d(
     constexpr int nbc_xmin = SplineBuilder::s_nbe_xmin;
     constexpr int nbc_xmax = SplineBuilder::s_nbe_xmax;
     static_assert(
-            SplineBuilder::s_bc_xmin == ddc::BoundCond::HERMITE
-                    || SplineBuilder::s_bc_xmin == ddc::BoundCond::HOMOGENEOUS_HERMITE,
+            SplineBuilder::s_sbc_xmin == ddc::SplineBuilderClosure::HERMITE
+                    || SplineBuilder::s_sbc_xmin == ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
             "The neumann spline quadrature requires a builder which uses Hermite boundary "
             "conditions.");
     static_assert(
-            SplineBuilder::s_bc_xmax == ddc::BoundCond::HERMITE
-                    || SplineBuilder::s_bc_xmax == ddc::BoundCond::HOMOGENEOUS_HERMITE,
+            SplineBuilder::s_sbc_xmax == ddc::SplineBuilderClosure::HERMITE
+                    || SplineBuilder::s_sbc_xmax == ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
             "The neumann spline quadrature requires a builder which uses Hermite boundary "
             "conditions.");
     static_assert(

--- a/src/utils/non_uniform_interpolation_points.hpp
+++ b/src/utils/non_uniform_interpolation_points.hpp
@@ -12,7 +12,7 @@
 
 namespace ddcHelper {
 
-template <class BSplines, ddc::BoundCond BcXmin, ddc::BoundCond BcXmax>
+template <class BSplines, ddc::SplineBuilderClosure BcXmin, ddc::SplineBuilderClosure BcXmax>
 class NonUniformInterpolationPoints;
 
 template <class T>
@@ -20,7 +20,7 @@ struct is_non_uniform_interpolation_points : std::false_type
 {
 };
 
-template <class BSplines, ddc::BoundCond BcXmin, ddc::BoundCond BcXmax>
+template <class BSplines, ddc::SplineBuilderClosure BcXmin, ddc::SplineBuilderClosure BcXmax>
 struct is_non_uniform_interpolation_points<NonUniformInterpolationPoints<BSplines, BcXmin, BcXmax>>
     : std::true_type
 {
@@ -39,7 +39,7 @@ inline constexpr bool is_non_uniform_interpolation_points_v
  * boundary conditions, the second and second to last interpolation points 
  * should be the Greville points. 
  */
-template <class BSplines, ddc::BoundCond BcXmin, ddc::BoundCond BcXmax>
+template <class BSplines, ddc::SplineBuilderClosure BcXmin, ddc::SplineBuilderClosure BcXmax>
 class NonUniformInterpolationPoints
 {
     using Dim = typename BSplines::continuous_dimension_type;

--- a/src/utils/spline_builder_deriv_field_2d.hpp
+++ b/src/utils/spline_builder_deriv_field_2d.hpp
@@ -26,10 +26,10 @@ template <
         class BSplines2,
         class Grid1,
         class Grid2,
-        ddc::BoundCond BoundCond1min,
-        ddc::BoundCond BoundCond1max,
-        ddc::BoundCond BoundCond2min,
-        ddc::BoundCond BoundCond2max>
+        ddc::SplineBuilderClosure SplineBuilderClosure1min,
+        ddc::SplineBuilderClosure SplineBuilderClosure1max,
+        ddc::SplineBuilderClosure SplineBuilderClosure2min,
+        ddc::SplineBuilderClosure SplineBuilderClosure2max>
 class SplineBuilderDerivField2D
 {
     using MemorySpace = typename ExecSpace::memory_space;
@@ -46,10 +46,10 @@ class SplineBuilderDerivField2D
             BSplines2,
             Grid1,
             Grid2,
-            BoundCond1min,
-            BoundCond1max,
-            BoundCond2min,
-            BoundCond2max,
+            SplineBuilderClosure1min,
+            SplineBuilderClosure1max,
+            SplineBuilderClosure2min,
+            SplineBuilderClosure2max,
             ddc::SplineSolver::LAPACK>;
 
     using SplineType = DField<IdxRange<BSplines1, BSplines2>, MemorySpace>;

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -32,7 +32,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 
 // Discrete dimension

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -32,7 +32,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 
 // Discrete dimension
@@ -41,7 +41,7 @@ struct GridX : UniformGridBase<X>
 };
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 
 using IdxRangeX = IdxRange<GridX>;
 using IdxX = Idx<GridX>;
@@ -63,8 +63,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         PERIODIC,
         PERIODIC,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 // Lagrange basis for the advection field interpolation
 struct LagBasisX : UniformLagrangeBasis<X, 3, double>

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -43,8 +43,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineVxBoundary = ddc::BoundCond::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 
 // Discrete dimension

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -43,8 +43,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxClosure = ddc::SplineBuilderClosure::HERMITE;
 
 
 // Discrete dimension
@@ -57,9 +57,9 @@ struct GridVx : UniformGridBase<Vx>
 
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 
 using IdxRangeX = IdxRange<GridX>;
@@ -106,8 +106,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         PERIODIC,
         PERIODIC,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 
 class XVxAdvection1DTest : public ::testing::Test

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -56,8 +56,8 @@ struct BSplinesY : ddc::UniformBSplines<Y, 3>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineYClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 // Discrete dimensions
 struct GridX : UniformGridBase<X>
@@ -75,9 +75,9 @@ struct GridVy : UniformGridBase<Vy>
 
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsY
-        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYBoundary, SplineYBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYClosure, SplineYClosure>;
 
 
 using IdxXY = Idx<GridX, GridY>;
@@ -127,8 +127,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         PERIODIC,
         PERIODIC,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 using SplineInterpolatorY = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -136,8 +136,8 @@ using SplineInterpolatorY = SplineInterpolator<
         GridY,
         PERIODIC,
         PERIODIC,
-        SplineYBoundary,
-        SplineYBoundary>;
+        SplineYClosure,
+        SplineYClosure>;
 
 
 

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -56,8 +56,8 @@ struct BSplinesY : ddc::UniformBSplines<Y, 3>
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineYBoundary = ddc::BoundCond::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 // Discrete dimensions
 struct GridX : UniformGridBase<X>

--- a/tests/advection/logical_foot_finder.cpp
+++ b/tests/advection/logical_foot_finder.cpp
@@ -52,7 +52,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 
 static constexpr int BSDegree = 3;
 static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-static constexpr ddc::SplineBuilderClosure SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineThetaBoundary
+        = ddc::SplineBuilderClosure::PERIODIC;
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>
 {

--- a/tests/advection/logical_foot_finder.cpp
+++ b/tests/advection/logical_foot_finder.cpp
@@ -51,8 +51,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 };
 
 static constexpr int BSDegree = 3;
-static constexpr ddc::BoundCond SplineRBoundary = ddc::BoundCond::GREVILLE;
-static constexpr ddc::BoundCond SplineThetaBoundary = ddc::BoundCond::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
+static constexpr ddc::SplineBuilderClosure SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>
 {

--- a/tests/advection/logical_foot_finder.cpp
+++ b/tests/advection/logical_foot_finder.cpp
@@ -51,9 +51,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 };
 
 static constexpr int BSDegree = 3;
-static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-static constexpr ddc::SplineBuilderClosure SplineThetaBoundary
-        = ddc::SplineBuilderClosure::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineRClosure = ddc::SplineBuilderClosure::GREVILLE;
+static constexpr ddc::SplineBuilderClosure SplineThetaClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>
 {
@@ -69,10 +68,10 @@ using SplineRThetaBuilder = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        SplineRBoundary,
-        SplineRBoundary,
-        SplineThetaBoundary,
-        SplineThetaBoundary,
+        SplineRClosure,
+        SplineRClosure,
+        SplineThetaClosure,
+        SplineThetaClosure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineRThetaEvaluator = ddc::SplineEvaluator2D<
@@ -88,9 +87,9 @@ using SplineRThetaEvaluator = ddc::SplineEvaluator2D<
         ddc::PeriodicExtrapolationRule<Theta>>;
 
 using SplineInterpPointsR
-        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRClosure, SplineRClosure>;
 using SplineInterpPointsTheta
-        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaBoundary, SplineThetaBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaClosure, SplineThetaClosure>;
 
 using IdxRangeR = IdxRange<GridR>;
 using IdxRangeTheta = IdxRange<GridTheta>;

--- a/tests/advection/polar_foot_finder.cpp
+++ b/tests/advection/polar_foot_finder.cpp
@@ -72,7 +72,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 
 static constexpr int BSDegree = 3;
 static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-static constexpr ddc::SplineBuilderClosure SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineThetaBoundary
+        = ddc::SplineBuilderClosure::PERIODIC;
 
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>

--- a/tests/advection/polar_foot_finder.cpp
+++ b/tests/advection/polar_foot_finder.cpp
@@ -71,9 +71,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 };
 
 static constexpr int BSDegree = 3;
-static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-static constexpr ddc::SplineBuilderClosure SplineThetaBoundary
-        = ddc::SplineBuilderClosure::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineRClosure = ddc::SplineBuilderClosure::GREVILLE;
+static constexpr ddc::SplineBuilderClosure SplineThetaClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>
@@ -90,10 +89,10 @@ using SplineRThetaBuilder = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        SplineRBoundary, // boundary at r=0
-        SplineRBoundary, // boundary at rmax
-        SplineThetaBoundary,
-        SplineThetaBoundary,
+        SplineRClosure, // boundary at r=0
+        SplineRClosure, // boundary at rmax
+        SplineThetaClosure,
+        SplineThetaClosure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineRThetaEvaluator = ddc::SplineEvaluator2D<
@@ -109,9 +108,9 @@ using SplineRThetaEvaluator = ddc::SplineEvaluator2D<
         ddc::PeriodicExtrapolationRule<Theta>>;
 
 using SplineInterpPointsR
-        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRClosure, SplineRClosure>;
 using SplineInterpPointsTheta
-        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaBoundary, SplineThetaBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaClosure, SplineThetaClosure>;
 
 using IdxRangeR = IdxRange<GridR>;
 using IdxRangeTheta = IdxRange<GridTheta>;

--- a/tests/advection/polar_foot_finder.cpp
+++ b/tests/advection/polar_foot_finder.cpp
@@ -71,8 +71,8 @@ struct GridTheta : NonUniformGridBase<Theta>
 };
 
 static constexpr int BSDegree = 3;
-static constexpr ddc::BoundCond SplineRBoundary = ddc::BoundCond::GREVILLE;
-static constexpr ddc::BoundCond SplineThetaBoundary = ddc::BoundCond::PERIODIC;
+static constexpr ddc::SplineBuilderClosure SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
+static constexpr ddc::SplineBuilderClosure SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 
 struct BSplinesR : ddc::NonUniformBSplines<R, BSDegree>

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -42,8 +42,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineVxBoundary = ddc::BoundCond::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 
 // Discrete dimensions

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -42,8 +42,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxClosure = ddc::SplineBuilderClosure::HERMITE;
 
 
 // Discrete dimensions
@@ -56,9 +56,9 @@ struct GridVx : UniformGridBase<Vx>
 
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 
 using IdxRangeX = IdxRange<GridX>;
@@ -107,8 +107,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         PERIODIC,
         PERIODIC,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 
 class Spatial1DAdvectionTest : public ::testing::Test

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -45,8 +45,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::PERIODIC;
-ddc::BoundCond constexpr SplineVxBoundary = ddc::BoundCond::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 
 // Discrete dimensions

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -45,8 +45,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVxBoundary
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineVxClosure
         = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 
@@ -60,9 +60,9 @@ struct GridVx : UniformGridBase<Vx>
 
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 
 using IdxRangeX = IdxRange<GridX>;
@@ -131,8 +131,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         GridVx,
         ExtrapolationRule::CONSTANT,
         ExtrapolationRule::CONSTANT,
-        SplineVxBoundary,
-        SplineVxBoundary>;
+        SplineVxClosure,
+        SplineVxClosure>;
 
 
 class Velocity1DAdvectionTest : public ::testing::Test

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -46,7 +46,8 @@ struct BSplinesVx : ddc::UniformBSplines<Vx, 3>
 };
 
 ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::PERIODIC;
-ddc::SplineBuilderClosure constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
+ddc::SplineBuilderClosure constexpr SplineVxBoundary
+        = ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE;
 
 
 // Discrete dimensions

--- a/tests/coord_transformations/geometry_coord_transformations_tests.hpp
+++ b/tests/coord_transformations/geometry_coord_transformations_tests.hpp
@@ -149,8 +149,10 @@ struct BSplinesTheta : ddc::NonUniformBSplines<Theta, BSDegree>
 {
 };
 
-using InterpPointsR = ddc::
-        GrevilleInterpolationPoints<BSplinesR, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
+using InterpPointsR = ddc::GrevilleInterpolationPoints<
+        BSplinesR,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 using InterpPointsTheta = ddc::GrevilleInterpolationPoints<
         BSplinesTheta,
         ddc::SplineBuilderClosure::PERIODIC,

--- a/tests/coord_transformations/geometry_coord_transformations_tests.hpp
+++ b/tests/coord_transformations/geometry_coord_transformations_tests.hpp
@@ -150,11 +150,11 @@ struct BSplinesTheta : ddc::NonUniformBSplines<Theta, BSDegree>
 };
 
 using InterpPointsR = ddc::
-        GrevilleInterpolationPoints<BSplinesR, ddc::BoundCond::GREVILLE, ddc::BoundCond::GREVILLE>;
+        GrevilleInterpolationPoints<BSplinesR, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
 using InterpPointsTheta = ddc::GrevilleInterpolationPoints<
         BSplinesTheta,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 struct GridR : InterpPointsR::interpolation_discrete_dimension_type
 {
@@ -183,10 +183,10 @@ using SplineRThetaBuilder = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC,
         ddc::SplineSolver::LAPACK>;
 using SplineRThetaBuilder_host = SplineRThetaBuilder<Kokkos::DefaultHostExecutionSpace>;
 

--- a/tests/coord_transformations/pseudo_cartesian_jacobian_matrix.cpp
+++ b/tests/coord_transformations/pseudo_cartesian_jacobian_matrix.cpp
@@ -79,12 +79,12 @@ public:
 
     using InterpPointsR = ddc::GrevilleInterpolationPoints<
             BSplinesR,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>;
     using InterpPointsTheta = ddc::GrevilleInterpolationPoints<
             BSplinesTheta,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
 
 
     struct GridR : InterpPointsR::interpolation_discrete_dimension_type
@@ -117,10 +117,10 @@ public:
             BSplinesTheta,
             GridR,
             GridTheta,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
 
     using SplineRThetaEvaluator = ddc::SplineEvaluator2D<

--- a/tests/geometryRTheta/quadrature/tests_L1_and_L2_norms.cpp
+++ b/tests/geometryRTheta/quadrature/tests_L1_and_L2_norms.cpp
@@ -112,16 +112,16 @@ void launch_tests(
             Kokkos::HostSpace,
             BSplinesR,
             GridR,
-            ddc::BoundCond::GREVILLE, // boundary at r=0
-            ddc::BoundCond::GREVILLE, // boundary at rmax
+            ddc::SplineBuilderClosure::GREVILLE, // boundary at r=0
+            ddc::SplineBuilderClosure::GREVILLE, // boundary at rmax
             ddc::SplineSolver::LAPACK>;
     using SplinePBuilder = ddc::SplineBuilder<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::HostSpace,
             BSplinesTheta,
             GridTheta,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
 
     SplineRBuilder r_builder(ddc::select<GridR>(grid));

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -31,22 +31,22 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary
+auto constexpr SplineXClosure
         = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
-auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
+auto constexpr SplineVxClosure = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsVx
-        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxBoundary, SplineVxBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
 using SplineXBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace,
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesX,
         GridX,
-        SplineXBoundary,
-        SplineXBoundary,
+        SplineXClosure,
+        SplineXClosure,
         ddc::SplineSolver::LAPACK>;
 using SplineXEvaluator = ddc::SplineEvaluator<
         Kokkos::DefaultExecutionSpace,
@@ -66,8 +66,8 @@ using SplineVxBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesVx,
         GridVx,
-        SplineVxBoundary,
-        SplineVxBoundary,
+        SplineVxClosure,
+        SplineVxClosure,
         ddc::SplineSolver::LAPACK>;
 using SplineVxEvaluator = ddc::SplineEvaluator<
         Kokkos::DefaultExecutionSpace,
@@ -85,8 +85,8 @@ using SplineInterpolatorX = SplineInterpolator<
         GridX,
         XExtrapRule,
         XExtrapRule,
-        SplineXBoundary,
-        SplineXBoundary>;
+        SplineXClosure,
+        SplineXClosure>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -94,8 +94,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         GridVx,
         CONSTANT,
         CONSTANT,
-        SplineVxBoundary,
-        SplineVxBoundary>;
+        SplineVxClosure,
+        SplineVxClosure>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -31,7 +31,8 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineXBoundary
+        = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -31,8 +31,8 @@ struct BSplinesVx
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::BoundCond::PERIODIC : ddc::BoundCond::GREVILLE;
-auto constexpr SplineVxBoundary = ddc::BoundCond::HERMITE;
+auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineVxBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;

--- a/tests/gyroaverage/gyroaverage_circular.cpp
+++ b/tests/gyroaverage/gyroaverage_circular.cpp
@@ -47,8 +47,8 @@ struct BSplinesTheta : ddc::UniformBSplines<Theta, BSDegreeTheta>
 {
 };
 
-ddc::BoundCond constexpr SplineRBoundary = ddc::BoundCond::GREVILLE;
-ddc::BoundCond constexpr SplineThetaBoundary = ddc::BoundCond::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
 
 using SplineInterpPointsR
         = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;

--- a/tests/gyroaverage/gyroaverage_circular.cpp
+++ b/tests/gyroaverage/gyroaverage_circular.cpp
@@ -47,13 +47,13 @@ struct BSplinesTheta : ddc::UniformBSplines<Theta, BSDegreeTheta>
 {
 };
 
-ddc::SplineBuilderClosure constexpr SplineRBoundary = ddc::SplineBuilderClosure::GREVILLE;
-ddc::SplineBuilderClosure constexpr SplineThetaBoundary = ddc::SplineBuilderClosure::PERIODIC;
+ddc::SplineBuilderClosure constexpr SplineRClosure = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineThetaClosure = ddc::SplineBuilderClosure::PERIODIC;
 
 using SplineInterpPointsR
-        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRBoundary, SplineRBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesR, SplineRClosure, SplineRClosure>;
 using SplineInterpPointsTheta
-        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaBoundary, SplineThetaBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesTheta, SplineThetaClosure, SplineThetaClosure>;
 
 struct GridR : SplineInterpPointsR::interpolation_discrete_dimension_type
 {
@@ -73,10 +73,10 @@ using SplineRThetaBuilderType = ddc::SplineBuilder2D<
         BSplinesTheta,
         GridR,
         GridTheta,
-        SplineRBoundary, // boundary at r=0
-        SplineRBoundary, // boundary at rmax
-        SplineThetaBoundary,
-        SplineThetaBoundary,
+        SplineRClosure, // boundary at r=0
+        SplineRClosure, // boundary at rmax
+        SplineThetaClosure,
+        SplineThetaClosure,
         ddc::SplineSolver::LAPACK>;
 
 template <class ExecutionSpace>

--- a/tests/interpolation/polar_bsplines.cpp
+++ b/tests/interpolation/polar_bsplines.cpp
@@ -81,12 +81,12 @@ struct PolarBsplineFixture<std::tuple<
 
     using GrevillePointsR = ddc::GrevilleInterpolationPoints<
             BSplinesR,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>;
     using GrevillePointsTheta = ddc::GrevilleInterpolationPoints<
             BSplinesTheta,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
 
     struct GridR : GrevillePointsR::interpolation_discrete_dimension_type
     {
@@ -128,10 +128,10 @@ TYPED_TEST(PolarBsplineFixture, PartitionOfUnity)
             BSplinesTheta,
             GridR,
             GridTheta,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
     using SplineRThetaEvaluator = ddc::SplineEvaluator2D<
             Kokkos::DefaultHostExecutionSpace,

--- a/tests/interpolation/polar_splines.cpp
+++ b/tests/interpolation/polar_splines.cpp
@@ -63,11 +63,11 @@ struct BSplinesTheta : ddc::NonUniformBSplines<Theta, spline_theta_degree>
 #endif
 
 using GrevillePointsR = ddc::
-        GrevilleInterpolationPoints<BSplinesR, ddc::BoundCond::GREVILLE, ddc::BoundCond::GREVILLE>;
+        GrevilleInterpolationPoints<BSplinesR, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
 using GrevillePointsTheta = ddc::GrevilleInterpolationPoints<
         BSplinesTheta,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 struct GridR : GrevillePointsR::interpolation_discrete_dimension_type
 {
@@ -103,10 +103,10 @@ TEST(PolarSplineTest, ConstantEval)
             BSplinesTheta,
             GridR,
             GridTheta,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
 
     using EvaluatorRTheta = ddc::SplineEvaluator2D<
@@ -224,10 +224,10 @@ void test_polar_spline_eval_gpu()
             BSplinesTheta,
             GridR,
             GridTheta,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
 
     using EvaluatorRTheta = ddc::SplineEvaluator2D<
@@ -343,10 +343,10 @@ void test_polar_integrals()
             BSplinesTheta,
             GridR,
             GridTheta,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC,
             ddc::SplineSolver::LAPACK>;
 
     using EvaluatorRTheta = ddc::SplineEvaluator2D<

--- a/tests/interpolation/polar_splines.cpp
+++ b/tests/interpolation/polar_splines.cpp
@@ -62,8 +62,10 @@ struct BSplinesTheta : ddc::NonUniformBSplines<Theta, spline_theta_degree>
 };
 #endif
 
-using GrevillePointsR = ddc::
-        GrevilleInterpolationPoints<BSplinesR, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
+using GrevillePointsR = ddc::GrevilleInterpolationPoints<
+        BSplinesR,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 using GrevillePointsTheta = ddc::GrevilleInterpolationPoints<
         BSplinesTheta,
         ddc::SplineBuilderClosure::PERIODIC,

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -243,8 +243,8 @@ public:
     using typename base_type::IdxRangeXY;
     using typename base_type::IdxRangeY;
 
-    static constexpr ddc::BoundCond SplineBoundary
-            = X::PERIODIC ? ddc::BoundCond::PERIODIC : ddc::BoundCond::GREVILLE;
+    static constexpr ddc::SplineBuilderClosure SplineBoundary
+            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 
     struct BSplinesX : ddc::NonUniformBSplines<X, spline_degree>
     {
@@ -365,8 +365,8 @@ public:
     using typename base_type::IdxRangeXY;
     using typename base_type::IdxRangeY;
 
-    static constexpr ddc::BoundCond SplineBoundary
-            = X::PERIODIC ? ddc::BoundCond::PERIODIC : ddc::BoundCond::GREVILLE;
+    static constexpr ddc::SplineBuilderClosure SplineBoundary
+            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 
     struct BSplinesX : ddc::NonUniformBSplines<X, spline_degree>
     {

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -243,7 +243,7 @@ public:
     using typename base_type::IdxRangeXY;
     using typename base_type::IdxRangeY;
 
-    static constexpr ddc::SplineBuilderClosure SplineBoundary
+    static constexpr ddc::SplineBuilderClosure SplineClosure
             = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC
                           : ddc::SplineBuilderClosure::GREVILLE;
 
@@ -251,14 +251,14 @@ public:
     {
     };
     using SplineInterpPointsX
-            = ddc::GrevilleInterpolationPoints<BSplinesX, SplineBoundary, SplineBoundary>;
+            = ddc::GrevilleInterpolationPoints<BSplinesX, SplineClosure, SplineClosure>;
 
 
     struct BSplinesY : ddc::NonUniformBSplines<Y, spline_degree>
     {
     };
     using SplineInterpPointsY
-            = ddc::GrevilleInterpolationPoints<BSplinesY, SplineBoundary, SplineBoundary>;
+            = ddc::GrevilleInterpolationPoints<BSplinesY, SplineClosure, SplineClosure>;
 
     using BSplinesDDim = find_grid_t<DDim, ddc::detail::TypeSeq<BSplinesX, BSplinesY>>;
 
@@ -276,8 +276,8 @@ public:
             GridDDim,
             SplineExtrapolation,
             SplineExtrapolation,
-            SplineBoundary,
-            SplineBoundary>;
+            SplineClosure,
+            SplineClosure>;
 
 public:
     PartialDerivativeTestSpline1D(
@@ -366,7 +366,7 @@ public:
     using typename base_type::IdxRangeXY;
     using typename base_type::IdxRangeY;
 
-    static constexpr ddc::SplineBuilderClosure SplineBoundary
+    static constexpr ddc::SplineBuilderClosure SplineClosure
             = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC
                           : ddc::SplineBuilderClosure::GREVILLE;
 
@@ -374,13 +374,13 @@ public:
     {
     };
     using SplineInterpPointsX
-            = ddc::GrevilleInterpolationPoints<BSplinesX, SplineBoundary, SplineBoundary>;
+            = ddc::GrevilleInterpolationPoints<BSplinesX, SplineClosure, SplineClosure>;
 
     struct BSplinesY : ddc::NonUniformBSplines<Y, spline_degree>
     {
     };
     using SplineInterpPointsY
-            = ddc::GrevilleInterpolationPoints<BSplinesY, SplineBoundary, SplineBoundary>;
+            = ddc::GrevilleInterpolationPoints<BSplinesY, SplineClosure, SplineClosure>;
 
     using SplineBuilder2D = ddc::SplineBuilder2D<
             Kokkos::DefaultExecutionSpace,
@@ -389,10 +389,10 @@ public:
             BSplinesY,
             GridX,
             GridY,
-            SplineBoundary,
-            SplineBoundary,
-            SplineBoundary,
-            SplineBoundary,
+            SplineClosure,
+            SplineClosure,
+            SplineClosure,
+            SplineClosure,
             ddc::SplineSolver::LAPACK>;
 
     using XExtrapolationRule = std::conditional_t<

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -244,7 +244,8 @@ public:
     using typename base_type::IdxRangeY;
 
     static constexpr ddc::SplineBuilderClosure SplineBoundary
-            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC
+                          : ddc::SplineBuilderClosure::GREVILLE;
 
     struct BSplinesX : ddc::NonUniformBSplines<X, spline_degree>
     {
@@ -366,7 +367,8 @@ public:
     using typename base_type::IdxRangeY;
 
     static constexpr ddc::SplineBuilderClosure SplineBoundary
-            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC
+                          : ddc::SplineBuilderClosure::GREVILLE;
 
     struct BSplinesX : ddc::NonUniformBSplines<X, spline_degree>
     {

--- a/tests/math_tools/test_spline_2d_cache.cpp
+++ b/tests/math_tools/test_spline_2d_cache.cpp
@@ -30,13 +30,13 @@ struct BSplinesY : ddc::UniformBSplines<Y, 3>
 {
 };
 
-auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::GREVILLE;
-auto constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineXClosure = ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineYClosure = ddc::SplineBuilderClosure::GREVILLE;
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 using SplineInterpPointsY
-        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYBoundary, SplineYBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY, SplineYClosure, SplineYClosure>;
 
 struct GridX : NonUniformGridBase<X>
 {
@@ -60,10 +60,10 @@ using SplineXYBuilder = ddc::SplineBuilder2D<
         BSplinesY,
         GridX,
         GridY,
-        SplineXBoundary,
-        SplineXBoundary,
-        SplineYBoundary,
-        SplineYBoundary,
+        SplineXClosure,
+        SplineXClosure,
+        SplineYClosure,
+        SplineYClosure,
         ddc::SplineSolver::LAPACK>;
 
 using IdxRangeBSXY = SplineXYBuilder::batched_spline_domain_type<IdxRangeXY>;

--- a/tests/math_tools/test_spline_2d_cache.cpp
+++ b/tests/math_tools/test_spline_2d_cache.cpp
@@ -30,8 +30,8 @@ struct BSplinesY : ddc::UniformBSplines<Y, 3>
 {
 };
 
-auto constexpr SplineXBoundary = ddc::BoundCond::GREVILLE;
-auto constexpr SplineYBoundary = ddc::BoundCond::GREVILLE;
+auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;

--- a/tests/multipatch/connectivity/coord_transformation_periodic.cpp
+++ b/tests/multipatch/connectivity/coord_transformation_periodic.cpp
@@ -18,12 +18,12 @@ class CoordinateTransformationPeriodicTest : public ::testing::Test
 private:
     using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<1>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
     using SplineInterpPointsTheta2 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<2>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
 
     static constexpr Patch1::IdxStep1 r1_npoints = Patch1::IdxStep1(10);
     static constexpr Patch1::IdxStep2 theta1_npoints = Patch1::IdxStep2(10);

--- a/tests/multipatch/connectivity/index_transformation_non_uniform_periodic.cpp
+++ b/tests/multipatch/connectivity/index_transformation_non_uniform_periodic.cpp
@@ -19,12 +19,12 @@ class IndexTransformationNonUniformPeriodicTest : public ::testing::Test
 private:
     using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<1>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
     using SplineInterpPointsTheta2 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<2>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
 
     static constexpr Patch1::IdxStep1 r1_npoints = Patch1::IdxStep1(16 + 1);
     static constexpr Patch1::IdxStep2 theta1_npoints = Patch1::IdxStep2(8);

--- a/tests/multipatch/connectivity/index_transformation_uniform_periodic.cpp
+++ b/tests/multipatch/connectivity/index_transformation_uniform_periodic.cpp
@@ -18,12 +18,12 @@ class IndexTransformationUniformPeriodicTest : public ::testing::Test
 private:
     using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<1>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
     using SplineInterpPointsTheta2 = ddc::KnotsAsInterpolationPoints<
             BSplinesTheta<2>,
-            ddc::BoundCond::PERIODIC,
-            ddc::BoundCond::PERIODIC>;
+            ddc::SplineBuilderClosure::PERIODIC,
+            ddc::SplineBuilderClosure::PERIODIC>;
 
     static constexpr Patch1::IdxStep1 r1_npoints = Patch1::IdxStep1(16 + 1);
     static constexpr Patch1::IdxStep2 theta1_npoints = Patch1::IdxStep2(8);

--- a/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_collection_test.cpp
+++ b/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_collection_test.cpp
@@ -22,7 +22,7 @@
         |  1  |  2  |  3  |
 
         with the global X dimension with additional points as closure condition
-        (ddc::BoundCond::GREVILLE) and the global Y with Hermite boundary conditions.
+        (ddc::SplineBuilderClosure::GREVILLE) and the global Y with Hermite boundary conditions.
 
 */
 
@@ -39,15 +39,15 @@ using HostExecSpace = Kokkos::DefaultHostExecutionSpace;
 
 
 // Interpolation points type for the patches.
-template <std::size_t PatchIdx, ddc::BoundCond BC1, ddc::BoundCond BC2>
+template <std::size_t PatchIdx, ddc::SplineBuilderClosure BC1, ddc::SplineBuilderClosure BC2>
 using SplineInterpPointsX = ddcHelper::NonUniformInterpolationPoints<BSplinesX<PatchIdx>, BC1, BC2>;
 
-template <std::size_t PatchIdx, ddc::BoundCond BC1, ddc::BoundCond BC2>
+template <std::size_t PatchIdx, ddc::SplineBuilderClosure BC1, ddc::SplineBuilderClosure BC2>
 using SplineInterpPointsY = ddcHelper::NonUniformInterpolationPoints<BSplinesY<PatchIdx>, BC1, BC2>;
 
 
-static constexpr ddc::BoundCond BCH = ddc::BoundCond::HERMITE;
-static constexpr ddc::BoundCond BCG = ddc::BoundCond::GREVILLE;
+static constexpr ddc::SplineBuilderClosure BCH = ddc::SplineBuilderClosure::HERMITE;
+static constexpr ddc::SplineBuilderClosure BCG = ddc::SplineBuilderClosure::GREVILLE;
 
 
 // USEFUL FUNCTIONS ==============================================================================
@@ -133,12 +133,12 @@ public:
         , idx_range_xy1(idx_range_x1, idx_range_y1)
         , idx_range_xy2(idx_range_x2, idx_range_y2)
         , idx_range_xy3(idx_range_x3, idx_range_y3)
-        , derivatives_calculator_1_2(idx_range_xy1, idx_range_xy2, ddc::BoundCond::GREVILLE)
+        , derivatives_calculator_1_2(idx_range_xy1, idx_range_xy2, ddc::SplineBuilderClosure::GREVILLE)
         , derivatives_calculator_2_3(
                   idx_range_xy2,
                   idx_range_xy3,
-                  ddc::BoundCond::HERMITE,
-                  ddc::BoundCond::GREVILLE)
+                  ddc::SplineBuilderClosure::HERMITE,
+                  ddc::SplineBuilderClosure::GREVILLE)
     {
     }
 

--- a/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_collection_test.cpp
+++ b/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_collection_test.cpp
@@ -133,7 +133,10 @@ public:
         , idx_range_xy1(idx_range_x1, idx_range_y1)
         , idx_range_xy2(idx_range_x2, idx_range_y2)
         , idx_range_xy3(idx_range_x3, idx_range_y3)
-        , derivatives_calculator_1_2(idx_range_xy1, idx_range_xy2, ddc::SplineBuilderClosure::GREVILLE)
+        , derivatives_calculator_1_2(
+                  idx_range_xy1,
+                  idx_range_xy2,
+                  ddc::SplineBuilderClosure::GREVILLE)
         , derivatives_calculator_2_3(
                   idx_range_xy2,
                   idx_range_xy3,

--- a/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_test.cpp
+++ b/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_test.cpp
@@ -78,8 +78,10 @@ using Xi = Theta;
 // Interpolation points type for the 2 patches
 // --- patch 1
 template <ddc::SplineBuilderClosure SplineBuilderClosureR>
-using SplineInterpPointsR1 = ddcHelper::
-        NonUniformInterpolationPoints<BSplinesR<1>, SplineBuilderClosureR, ddc::SplineBuilderClosure::HERMITE>;
+using SplineInterpPointsR1 = ddcHelper::NonUniformInterpolationPoints<
+        BSplinesR<1>,
+        SplineBuilderClosureR,
+        ddc::SplineBuilderClosure::HERMITE>;
 using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
         BSplinesTheta<1>,
         ddc::SplineBuilderClosure::PERIODIC,
@@ -87,8 +89,10 @@ using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
 
 // --- patch 2
 template <ddc::SplineBuilderClosure SplineBuilderClosureR>
-using SplineInterpPointsEta2 = ddcHelper::
-        NonUniformInterpolationPoints<BSplinesR<2>, ddc::SplineBuilderClosure::HERMITE, SplineBuilderClosureR>;
+using SplineInterpPointsEta2 = ddcHelper::NonUniformInterpolationPoints<
+        BSplinesR<2>,
+        ddc::SplineBuilderClosure::HERMITE,
+        SplineBuilderClosureR>;
 using SplineInterpPointsXi2 = ddc::KnotsAsInterpolationPoints<
         BSplinesTheta<2>,
         ddc::SplineBuilderClosure::PERIODIC,
@@ -97,8 +101,8 @@ using SplineInterpPointsXi2 = ddc::KnotsAsInterpolationPoints<
 
 // Interpolation points type for the equivalent global spline.
 template <ddc::SplineBuilderClosure SplineBuilderClosureR>
-using SplineInterpPointsRg
-        = ddcHelper::NonUniformInterpolationPoints<BSplinesRg, SplineBuilderClosureR, SplineBuilderClosureR>;
+using SplineInterpPointsRg = ddcHelper::
+        NonUniformInterpolationPoints<BSplinesRg, SplineBuilderClosureR, SplineBuilderClosureR>;
 using SplineInterpPointsThetag = ddcHelper::NonUniformInterpolationPoints<
         BSplinesThetag,
         ddc::SplineBuilderClosure::PERIODIC,
@@ -167,9 +171,9 @@ struct SingleInterfaceDerivativesCalculatorFixture<
     static constexpr Coord<R> r1_min = Coord<R>(0.0);
     static constexpr Coord<R> r1_max = Coord<R>(1.0);
     // Select less cells for ddc::SplineBuilderClosure::GREVILLE to test the boundary.
-    static constexpr IdxStep<GridR<1>> r1_ncells = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE)
-                                                           ? IdxStep<GridR<1>>(5)
-                                                           : IdxStep<GridR<1>>(30);
+    static constexpr IdxStep<GridR<1>> r1_ncells
+            = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) ? IdxStep<GridR<1>>(5)
+                                                                       : IdxStep<GridR<1>>(30);
 
     static constexpr Coord<Theta> theta1_min = Coord<Theta>(0.0);
     static constexpr Coord<Theta> theta1_max = Coord<Theta>(2 * M_PI);
@@ -182,9 +186,9 @@ struct SingleInterfaceDerivativesCalculatorFixture<
     static constexpr Coord<R> eta2_max
             = (std::is_same_v<Edge2, SouthEdge2>) ? Coord<Eta>(2.0 * 2 * M_PI) : Coord<Eta>(2.0);
     // Select less cells for ddc::SplineBuilderClosure::GREVILLE to test the boundary.
-    static constexpr IdxStep<GridR<2>> eta2_ncells = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE)
-                                                             ? IdxStep<GridR<2>>(5)
-                                                             : IdxStep<GridR<2>>(30);
+    static constexpr IdxStep<GridR<2>> eta2_ncells
+            = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) ? IdxStep<GridR<2>>(5)
+                                                                       : IdxStep<GridR<2>>(30);
 
     // Exchange R and Theta values for a connection with SouthEdge2.
     static constexpr Coord<Theta> xi2_min = Coord<Xi>(0.0);
@@ -567,7 +571,9 @@ using tuple_cat_t = decltype(std::tuple_cat(std::declval<input_t>()...));
 using Cases = tuple_to_types_t<tuple_cat_t<
         cartesian_product_t<
                 std::tuple<
-                        std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>
+                        std::integral_constant<
+                                ddc::SplineBuilderClosure,
+                                ddc::SplineBuilderClosure::HERMITE>
 #if defined(NON_UNIFORM_MESH)
                         /*
                             Test with additional interpolation points as closure.
@@ -576,13 +582,17 @@ using Cases = tuple_to_types_t<tuple_cat_t<
                             points as closure. 
                         */
                         ,
-                        std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>
+                        std::integral_constant<
+                                ddc::SplineBuilderClosure,
+                                ddc::SplineBuilderClosure::GREVILLE>
 #endif
                         >,
                 std::tuple<EastEdge1, WestEdge1>,
                 std::tuple<EastEdge2, WestEdge2>>,
         std::tuple<std::tuple<
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::HERMITE>,
                 EastEdge1,
                 SouthEdge2>>>>;
 

--- a/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_test.cpp
+++ b/tests/multipatch/interface_derivatives/single_interface_derivatives_calculator_test.cpp
@@ -77,36 +77,36 @@ using Xi = Theta;
 
 // Interpolation points type for the 2 patches
 // --- patch 1
-template <ddc::BoundCond BoundCondR>
+template <ddc::SplineBuilderClosure SplineBuilderClosureR>
 using SplineInterpPointsR1 = ddcHelper::
-        NonUniformInterpolationPoints<BSplinesR<1>, BoundCondR, ddc::BoundCond::HERMITE>;
+        NonUniformInterpolationPoints<BSplinesR<1>, SplineBuilderClosureR, ddc::SplineBuilderClosure::HERMITE>;
 using SplineInterpPointsTheta1 = ddc::KnotsAsInterpolationPoints<
         BSplinesTheta<1>,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 // --- patch 2
-template <ddc::BoundCond BoundCondR>
+template <ddc::SplineBuilderClosure SplineBuilderClosureR>
 using SplineInterpPointsEta2 = ddcHelper::
-        NonUniformInterpolationPoints<BSplinesR<2>, ddc::BoundCond::HERMITE, BoundCondR>;
+        NonUniformInterpolationPoints<BSplinesR<2>, ddc::SplineBuilderClosure::HERMITE, SplineBuilderClosureR>;
 using SplineInterpPointsXi2 = ddc::KnotsAsInterpolationPoints<
         BSplinesTheta<2>,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 
 // Interpolation points type for the equivalent global spline.
-template <ddc::BoundCond BoundCondR>
+template <ddc::SplineBuilderClosure SplineBuilderClosureR>
 using SplineInterpPointsRg
-        = ddcHelper::NonUniformInterpolationPoints<BSplinesRg, BoundCondR, BoundCondR>;
+        = ddcHelper::NonUniformInterpolationPoints<BSplinesRg, SplineBuilderClosureR, SplineBuilderClosureR>;
 using SplineInterpPointsThetag = ddcHelper::NonUniformInterpolationPoints<
         BSplinesThetag,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 
 // Operators on the equivalent global spline
-template <ddc::BoundCond BoundCondR>
+template <ddc::SplineBuilderClosure SplineBuilderClosureR>
 using SplineRThetagBuilder = ddc::SplineBuilder2D<
         HostExecSpace,
         typename HostExecSpace::memory_space,
@@ -114,10 +114,10 @@ using SplineRThetagBuilder = ddc::SplineBuilder2D<
         BSplinesThetag,
         GridRg,
         GridThetag,
-        BoundCondR,
-        BoundCondR,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC,
+        SplineBuilderClosureR,
+        SplineBuilderClosureR,
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC,
         ddc::SplineSolver::LAPACK>;
 
 using SplineRThetagEvaluator = ddc::SplineEvaluator2D<
@@ -157,7 +157,7 @@ struct SingleInterfaceDerivativesCalculatorFixture<
 {
     // Get the parameters of the test: patch connection and interpolation type.
     using Interpolation = InterpolationType;
-    static constexpr ddc::BoundCond Interpolation_v = InterpolationType::value;
+    static constexpr ddc::SplineBuilderClosure Interpolation_v = InterpolationType::value;
     using Edge1 = Edge_Patch1;
     using Edge2 = Edge_Patch2;
 
@@ -166,8 +166,8 @@ struct SingleInterfaceDerivativesCalculatorFixture<
     // patch 1 -----------------------------------
     static constexpr Coord<R> r1_min = Coord<R>(0.0);
     static constexpr Coord<R> r1_max = Coord<R>(1.0);
-    // Select less cells for ddc::BoundCond::GREVILLE to test the boundary.
-    static constexpr IdxStep<GridR<1>> r1_ncells = (Interpolation_v == ddc::BoundCond::GREVILLE)
+    // Select less cells for ddc::SplineBuilderClosure::GREVILLE to test the boundary.
+    static constexpr IdxStep<GridR<1>> r1_ncells = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE)
                                                            ? IdxStep<GridR<1>>(5)
                                                            : IdxStep<GridR<1>>(30);
 
@@ -181,8 +181,8 @@ struct SingleInterfaceDerivativesCalculatorFixture<
             = (std::is_same_v<Edge2, SouthEdge2>) ? Coord<Eta>(1.0 * 2 * M_PI) : Coord<Eta>(1.0);
     static constexpr Coord<R> eta2_max
             = (std::is_same_v<Edge2, SouthEdge2>) ? Coord<Eta>(2.0 * 2 * M_PI) : Coord<Eta>(2.0);
-    // Select less cells for ddc::BoundCond::GREVILLE to test the boundary.
-    static constexpr IdxStep<GridR<2>> eta2_ncells = (Interpolation_v == ddc::BoundCond::GREVILLE)
+    // Select less cells for ddc::SplineBuilderClosure::GREVILLE to test the boundary.
+    static constexpr IdxStep<GridR<2>> eta2_ncells = (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE)
                                                              ? IdxStep<GridR<2>>(5)
                                                              : IdxStep<GridR<2>>(30);
 
@@ -220,7 +220,7 @@ struct SingleInterfaceDerivativesCalculatorFixture<
 #endif
 
         std::vector<Coord<R>> interpolation_points_r1;
-        if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+        if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
             // Add an interpolation point in the cell on the boundary of the equivalent global domain.
             // The other interpolation points are the break points.
             if constexpr (std::is_same_v<Edge1, EastEdge1>) {
@@ -229,7 +229,7 @@ struct SingleInterfaceDerivativesCalculatorFixture<
                 interpolation_points_r1
                         = get_interpolation_points_add_one_on_right(break_points_r1);
             }
-        } else if (Interpolation_v == ddc::BoundCond::HERMITE) {
+        } else if (Interpolation_v == ddc::SplineBuilderClosure::HERMITE) {
             // Use the break points as interpolation points.
             interpolation_points_r1 = break_points_r1;
         }
@@ -264,7 +264,7 @@ struct SingleInterfaceDerivativesCalculatorFixture<
 
         std::vector<Coord<R>> interpolation_points_eta2;
         std::vector<Coord<Theta>> interpolation_points_xi2;
-        if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+        if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
             // Add an interpolation point in the cell on the boundary of the equivalent global domain.
             // The other interpolation points are the break points.
             if constexpr (std::is_same_v<Edge2, EastEdge2>) {
@@ -280,7 +280,7 @@ struct SingleInterfaceDerivativesCalculatorFixture<
                         = get_interpolation_points_add_one_on_right(break_points_xi2);
                 interpolation_points_eta2 = break_points_eta2;
             }
-        } else if (Interpolation_v == ddc::BoundCond::HERMITE) {
+        } else if (Interpolation_v == ddc::SplineBuilderClosure::HERMITE) {
             // Use the break points as interpolation points.
             interpolation_points_eta2 = break_points_eta2;
             interpolation_points_xi2 = break_points_xi2;
@@ -567,7 +567,7 @@ using tuple_cat_t = decltype(std::tuple_cat(std::declval<input_t>()...));
 using Cases = tuple_to_types_t<tuple_cat_t<
         cartesian_product_t<
                 std::tuple<
-                        std::integral_constant<ddc::BoundCond, ddc::BoundCond::HERMITE>
+                        std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>
 #if defined(NON_UNIFORM_MESH)
                         /*
                             Test with additional interpolation points as closure.
@@ -576,13 +576,13 @@ using Cases = tuple_to_types_t<tuple_cat_t<
                             points as closure. 
                         */
                         ,
-                        std::integral_constant<ddc::BoundCond, ddc::BoundCond::GREVILLE>
+                        std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>
 #endif
                         >,
                 std::tuple<EastEdge1, WestEdge1>,
                 std::tuple<EastEdge2, WestEdge2>>,
         std::tuple<std::tuple<
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::HERMITE>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
                 EastEdge1,
                 SouthEdge2>>>>;
 
@@ -595,7 +595,7 @@ TYPED_TEST_SUITE(SingleInterfaceDerivativesCalculatorFixture, Cases);
 TYPED_TEST(SingleInterfaceDerivativesCalculatorFixture, InterpolationPointsCheck)
 {
     // Get parameters of the test.
-    constexpr ddc::BoundCond Interpolation_v = TestFixture::Interpolation_v;
+    constexpr ddc::SplineBuilderClosure Interpolation_v = TestFixture::Interpolation_v;
     using Edge1 = typename TestFixture::Edge1;
     using Edge2 = typename TestFixture::Edge2;
 
@@ -623,7 +623,7 @@ TYPED_TEST(SingleInterfaceDerivativesCalculatorFixture, InterpolationPointsCheck
             Patch1::IdxStep1 idx_r(Patch1::Idx1(idx) - TestFixture::idx_range_r1.front());
             Patch1::IdxStep2 idx_theta(Patch1::Idx2(idx) - TestFixture::idx_range_theta1.front());
             Idx<GridRg, GridThetag> idx_g;
-            if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+            if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
                 idx_g = Idx<GridRg, GridThetag>(
                         TestFixture::r1_ncells.value() + 1 - idx_r.value(),
                         TestFixture::theta1_ncells.value() - 1 - idx_theta.value());
@@ -652,7 +652,7 @@ TYPED_TEST(SingleInterfaceDerivativesCalculatorFixture, InterpolationPointsCheck
             Patch2::IdxStep1 idx_eta(Patch2::Idx1(idx) - TestFixture::idx_range_eta2.front());
             Patch2::IdxStep2 idx_xi(Patch2::Idx2(idx) - TestFixture::idx_range_xi2.front());
             Idx<GridRg, GridThetag> idx_g;
-            if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+            if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
                 idx_g = Idx<GridRg, GridThetag>(
                         TestFixture::eta2_ncells.value() - idx_eta.value()
                                 + TestFixture::r1_ncells.value() + 2,
@@ -680,7 +680,7 @@ TYPED_TEST(SingleInterfaceDerivativesCalculatorFixture, InterpolationPointsCheck
             Patch2::IdxStep1 idx_eta(Patch2::Idx1(idx) - TestFixture::idx_range_eta2.front());
             Patch2::IdxStep2 idx_xi(Patch2::Idx2(idx) - TestFixture::idx_range_xi2.front());
             Idx<GridRg, GridThetag> idx_g;
-            if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+            if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
                 idx_g = Idx<GridRg, GridThetag>(
                         idx_eta.value() + TestFixture::r1_ncells.value() + 1,
                         idx_xi.value());
@@ -701,7 +701,7 @@ TYPED_TEST(SingleInterfaceDerivativesCalculatorFixture, InterpolationPointsCheck
     } else if (std ::is_same_v<Edge2, SouthEdge2>) {
         // Orientation second patch:  ↓→
         // Orientation global domain: ↑→
-        if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+        if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
             Kokkos::abort("Test case not implemented."
                           "We cannot make the Edge1 on Theta with N points to match with the "
                           "Edge2 on R with N+1 points.");
@@ -734,7 +734,7 @@ TYPED_TEST(
         InterfaceDerivativesExactAndApproximationFormulae)
 {
     // Get parameters of the test.
-    constexpr ddc::BoundCond Interpolation_v = TestFixture::Interpolation_v;
+    constexpr ddc::SplineBuilderClosure Interpolation_v = TestFixture::Interpolation_v;
     using Edge1 = typename TestFixture::Edge1;
     using Edge2 = typename TestFixture::Edge2;
     using Interface_1_2 = typename TestFixture::Interface_1_2;
@@ -821,7 +821,7 @@ TYPED_TEST(
     host_t<DField<IdxRange<BSplinesRg, BSplinesThetag>>> function_g_coef
             = get_field(function_g_coef_alloc);
 
-    if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+    if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
         // --- Spline builder
         builder_g(function_g_coef, get_const_field(function_g));
     } else {
@@ -864,14 +864,14 @@ TYPED_TEST(
 
 
     // Check the local derivatives with the global ones at the interfaces ========================
-    if constexpr (Interpolation_v == ddc::BoundCond::GREVILLE) {
+    if constexpr (Interpolation_v == ddc::SplineBuilderClosure::GREVILLE) {
         // We test if the boundaries are well treated => only work with 5 cells to better identify an error.
         // 5 cells -------------------------------------------------------------------------------
         SingleInterfaceDerivativesCalculator<Interface_1_2> const derivatives_calculator(
                 TestFixture::idx_range_rtheta1,
                 TestFixture::idx_range_etaxi2,
-                ddc::BoundCond::GREVILLE,
-                ddc::BoundCond::GREVILLE);
+                ddc::SplineBuilderClosure::GREVILLE,
+                ddc::SplineBuilderClosure::GREVILLE);
 
 
         ddc::host_for_each(TestFixture::idx_range_theta1, [&](Patch1::Idx2 const& idx2_1) {

--- a/tests/multipatch/spline/multipatch_spline_builder.cpp
+++ b/tests/multipatch/spline/multipatch_spline_builder.cpp
@@ -16,14 +16,14 @@
 
 namespace {
 using namespace non_periodic_non_uniform_2d_2patches;
-ddc::BoundCond constexpr SplineXBoundary = ddc::BoundCond::GREVILLE;
-ddc::BoundCond constexpr SplineYBoundary = ddc::BoundCond::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
 
-ddc::BoundCond constexpr SplineX1Boundary = SplineXBoundary;
-ddc::BoundCond constexpr SplineY1Boundary = SplineYBoundary;
+ddc::SplineBuilderClosure constexpr SplineX1Boundary = SplineXBoundary;
+ddc::SplineBuilderClosure constexpr SplineY1Boundary = SplineYBoundary;
 
-ddc::BoundCond constexpr SplineX2Boundary = SplineXBoundary;
-ddc::BoundCond constexpr SplineY2Boundary = SplineYBoundary;
+ddc::SplineBuilderClosure constexpr SplineX2Boundary = SplineXBoundary;
+ddc::SplineBuilderClosure constexpr SplineY2Boundary = SplineYBoundary;
 
 using SplineInterpPointsX1
         = ddc::GrevilleInterpolationPoints<BSplinesX<1>, SplineX1Boundary, SplineX1Boundary>;

--- a/tests/multipatch/spline/multipatch_spline_builder.cpp
+++ b/tests/multipatch/spline/multipatch_spline_builder.cpp
@@ -16,24 +16,24 @@
 
 namespace {
 using namespace non_periodic_non_uniform_2d_2patches;
-ddc::SplineBuilderClosure constexpr SplineXBoundary = ddc::SplineBuilderClosure::GREVILLE;
-ddc::SplineBuilderClosure constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::GREVILLE;
+ddc::SplineBuilderClosure constexpr SplineYClosure = ddc::SplineBuilderClosure::GREVILLE;
 
-ddc::SplineBuilderClosure constexpr SplineX1Boundary = SplineXBoundary;
-ddc::SplineBuilderClosure constexpr SplineY1Boundary = SplineYBoundary;
+ddc::SplineBuilderClosure constexpr SplineX1Closure = SplineXClosure;
+ddc::SplineBuilderClosure constexpr SplineY1Closure = SplineYClosure;
 
-ddc::SplineBuilderClosure constexpr SplineX2Boundary = SplineXBoundary;
-ddc::SplineBuilderClosure constexpr SplineY2Boundary = SplineYBoundary;
+ddc::SplineBuilderClosure constexpr SplineX2Closure = SplineXClosure;
+ddc::SplineBuilderClosure constexpr SplineY2Closure = SplineYClosure;
 
 using SplineInterpPointsX1
-        = ddc::GrevilleInterpolationPoints<BSplinesX<1>, SplineX1Boundary, SplineX1Boundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX<1>, SplineX1Closure, SplineX1Closure>;
 using SplineInterpPointsY1
-        = ddc::GrevilleInterpolationPoints<BSplinesY<1>, SplineY1Boundary, SplineY1Boundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY<1>, SplineY1Closure, SplineY1Closure>;
 using SplineInterpPointsX2
 
-        = ddc::GrevilleInterpolationPoints<BSplinesX<2>, SplineX2Boundary, SplineX2Boundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX<2>, SplineX2Closure, SplineX2Closure>;
 using SplineInterpPointsY2
-        = ddc::GrevilleInterpolationPoints<BSplinesY<2>, SplineY2Boundary, SplineY2Boundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesY<2>, SplineY2Closure, SplineY2Closure>;
 
 // Operators
 using SplineX1Builder = ddc::SplineBuilder<
@@ -41,8 +41,8 @@ using SplineX1Builder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesX<1>,
         GridX<1>,
-        SplineX1Boundary,
-        SplineX1Boundary,
+        SplineX1Closure,
+        SplineX1Closure,
         ddc::SplineSolver::LAPACK>;
 
 using SplineX2Builder = ddc::SplineBuilder<
@@ -50,8 +50,8 @@ using SplineX2Builder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesX<2>,
         GridX<2>,
-        SplineX2Boundary,
-        SplineX2Boundary,
+        SplineX2Closure,
+        SplineX2Closure,
         ddc::SplineSolver::LAPACK>;
 
 
@@ -60,9 +60,9 @@ using MultipatchSplineBuilderX_1d = MultipatchSplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplines1OnPatch,
         Grid1OnPatch,
-        SplineXBoundary,
-        SplineXBoundary,
-        SplineXBoundary,
+        SplineXClosure,
+        SplineXClosure,
+        SplineXClosure,
         Connectivity,
         ddc::SplineSolver::LAPACK,
         DConstField1OnPatch,
@@ -75,9 +75,9 @@ using MultipatchSplineBuilderX_2d = MultipatchSplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplines1OnPatch,
         Grid1OnPatch,
-        SplineXBoundary,
-        SplineXBoundary,
-        SplineXBoundary,
+        SplineXClosure,
+        SplineXClosure,
+        SplineXClosure,
         Connectivity,
         ddc::SplineSolver::LAPACK,
         DConstFieldOnPatch,

--- a/tests/multipatch/spline/multipatch_spline_builder_2d.cpp
+++ b/tests/multipatch/spline/multipatch_spline_builder_2d.cpp
@@ -17,13 +17,13 @@
 namespace {
 using namespace non_periodic_non_uniform_2d_2patches;
 
-template <int PatchIdx, ddc::BoundCond BC>
+template <int PatchIdx, ddc::SplineBuilderClosure BC>
 using SplineInterpPointsX = ddc::GrevilleInterpolationPoints<BSplinesX<PatchIdx>, BC, BC>;
-template <int PatchIdx, ddc::BoundCond BC>
+template <int PatchIdx, ddc::SplineBuilderClosure BC>
 using SplineInterpPointsY = ddc::GrevilleInterpolationPoints<BSplinesY<PatchIdx>, BC, BC>;
 
 // Operators
-template <int PatchIdx, ddc::BoundCond BC>
+template <int PatchIdx, ddc::SplineBuilderClosure BC>
 using SplineXYBuilder = ddc::SplineBuilder2D<
         Kokkos::DefaultExecutionSpace,
         Kokkos::DefaultExecutionSpace::memory_space,
@@ -37,7 +37,7 @@ using SplineXYBuilder = ddc::SplineBuilder2D<
         BC,
         ddc::SplineSolver::LAPACK>;
 
-template <ddc::BoundCond BC>
+template <ddc::SplineBuilderClosure BC>
 using MultipatchSplineBuilderXY = MultipatchSplineBuilder2D<
         Kokkos::DefaultExecutionSpace,
         Kokkos::DefaultExecutionSpace::memory_space,
@@ -187,34 +187,34 @@ public:
 TEST_F(MultipatchSplineBuilder2DTest, TwoPatches2D)
 {
     ddc::init_discrete_space<GridX<1>>(
-            SplineInterpPointsX<1, ddc::BoundCond::GREVILLE>::get_sampling<GridX<1>>());
+            SplineInterpPointsX<1, ddc::SplineBuilderClosure::GREVILLE>::get_sampling<GridX<1>>());
     ddc::init_discrete_space<GridY<1>>(
-            SplineInterpPointsY<1, ddc::BoundCond::GREVILLE>::get_sampling<GridY<1>>());
+            SplineInterpPointsY<1, ddc::SplineBuilderClosure::GREVILLE>::get_sampling<GridY<1>>());
 
     ddc::init_discrete_space<GridX<2>>(
-            SplineInterpPointsX<2, ddc::BoundCond::GREVILLE>::get_sampling<GridX<2>>());
+            SplineInterpPointsX<2, ddc::SplineBuilderClosure::GREVILLE>::get_sampling<GridX<2>>());
     ddc::init_discrete_space<GridY<2>>(
-            SplineInterpPointsY<2, ddc::BoundCond::GREVILLE>::get_sampling<GridY<2>>());
+            SplineInterpPointsY<2, ddc::SplineBuilderClosure::GREVILLE>::get_sampling<GridY<2>>());
 
     IdxRange<GridX<1>> const idx_range_x1
-            = SplineInterpPointsX<1, ddc::BoundCond::GREVILLE>::get_domain<GridX<1>>();
+            = SplineInterpPointsX<1, ddc::SplineBuilderClosure::GREVILLE>::get_domain<GridX<1>>();
     IdxRange<GridY<1>> const idx_range_y1
-            = SplineInterpPointsY<1, ddc::BoundCond::GREVILLE>::get_domain<GridY<1>>();
+            = SplineInterpPointsY<1, ddc::SplineBuilderClosure::GREVILLE>::get_domain<GridY<1>>();
 
     IdxRange<GridX<2>> const idx_range_x2
-            = SplineInterpPointsX<2, ddc::BoundCond::GREVILLE>::get_domain<GridX<2>>();
+            = SplineInterpPointsX<2, ddc::SplineBuilderClosure::GREVILLE>::get_domain<GridX<2>>();
     IdxRange<GridY<2>> const idx_range_y2
-            = SplineInterpPointsY<2, ddc::BoundCond::GREVILLE>::get_domain<GridY<2>>();
+            = SplineInterpPointsY<2, ddc::SplineBuilderClosure::GREVILLE>::get_domain<GridY<2>>();
 
     IdxRange<GridX<1>, GridY<1>> const idx_range_xy1(idx_range_x1, idx_range_y1);
     IdxRange<GridX<2>, GridY<2>> const idx_range_xy2(idx_range_x2, idx_range_y2);
 
     // List of spline builders
-    SplineXYBuilder<1, ddc::BoundCond::GREVILLE> builder1(idx_range_xy1);
-    SplineXYBuilder<2, ddc::BoundCond::GREVILLE> builder2(idx_range_xy2);
+    SplineXYBuilder<1, ddc::SplineBuilderClosure::GREVILLE> builder1(idx_range_xy1);
+    SplineXYBuilder<2, ddc::SplineBuilderClosure::GREVILLE> builder2(idx_range_xy2);
 
     // Collection of builders for each patch
-    MultipatchSplineBuilderXY<ddc::BoundCond::GREVILLE> builder(builder1, builder2);
+    MultipatchSplineBuilderXY<ddc::SplineBuilderClosure::GREVILLE> builder(builder1, builder2);
 
 
     // Function tests
@@ -275,34 +275,34 @@ TEST_F(MultipatchSplineBuilder2DTest, TwoPatches2D)
 TEST_F(MultipatchSplineBuilder2DTest, TwoPatches2DHermite)
 {
     ddc::init_discrete_space<GridX<1>>(
-            SplineInterpPointsX<1, ddc::BoundCond::HERMITE>::get_sampling<GridX<1>>());
+            SplineInterpPointsX<1, ddc::SplineBuilderClosure::HERMITE>::get_sampling<GridX<1>>());
     ddc::init_discrete_space<GridY<1>>(
-            SplineInterpPointsY<1, ddc::BoundCond::HERMITE>::get_sampling<GridY<1>>());
+            SplineInterpPointsY<1, ddc::SplineBuilderClosure::HERMITE>::get_sampling<GridY<1>>());
 
     ddc::init_discrete_space<GridX<2>>(
-            SplineInterpPointsX<2, ddc::BoundCond::HERMITE>::get_sampling<GridX<2>>());
+            SplineInterpPointsX<2, ddc::SplineBuilderClosure::HERMITE>::get_sampling<GridX<2>>());
     ddc::init_discrete_space<GridY<2>>(
-            SplineInterpPointsY<2, ddc::BoundCond::HERMITE>::get_sampling<GridY<2>>());
+            SplineInterpPointsY<2, ddc::SplineBuilderClosure::HERMITE>::get_sampling<GridY<2>>());
 
     IdxRange<GridX<1>> const idx_range_x1
-            = SplineInterpPointsX<1, ddc::BoundCond::HERMITE>::get_domain<GridX<1>>();
+            = SplineInterpPointsX<1, ddc::SplineBuilderClosure::HERMITE>::get_domain<GridX<1>>();
     IdxRange<GridY<1>> const idx_range_y1
-            = SplineInterpPointsY<1, ddc::BoundCond::HERMITE>::get_domain<GridY<1>>();
+            = SplineInterpPointsY<1, ddc::SplineBuilderClosure::HERMITE>::get_domain<GridY<1>>();
 
     IdxRange<GridX<2>> const idx_range_x2
-            = SplineInterpPointsX<2, ddc::BoundCond::HERMITE>::get_domain<GridX<2>>();
+            = SplineInterpPointsX<2, ddc::SplineBuilderClosure::HERMITE>::get_domain<GridX<2>>();
     IdxRange<GridY<2>> const idx_range_y2
-            = SplineInterpPointsY<2, ddc::BoundCond::HERMITE>::get_domain<GridY<2>>();
+            = SplineInterpPointsY<2, ddc::SplineBuilderClosure::HERMITE>::get_domain<GridY<2>>();
 
     IdxRange<GridX<1>, GridY<1>> const idx_range_xy1(idx_range_x1, idx_range_y1);
     IdxRange<GridX<2>, GridY<2>> const idx_range_xy2(idx_range_x2, idx_range_y2);
 
     // List of spline builders
-    SplineXYBuilder<1, ddc::BoundCond::HERMITE> builder1(idx_range_xy1);
-    SplineXYBuilder<2, ddc::BoundCond::HERMITE> builder2(idx_range_xy2);
+    SplineXYBuilder<1, ddc::SplineBuilderClosure::HERMITE> builder1(idx_range_xy1);
+    SplineXYBuilder<2, ddc::SplineBuilderClosure::HERMITE> builder2(idx_range_xy2);
 
     // Collection of builders for each patch
-    MultipatchSplineBuilderXY<ddc::BoundCond::HERMITE> builder(builder1, builder2);
+    MultipatchSplineBuilderXY<ddc::SplineBuilderClosure::HERMITE> builder(builder1, builder2);
 
 
     // Function tests

--- a/tests/multipatch/spline/spline_testing_tools.hpp
+++ b/tests/multipatch/spline/spline_testing_tools.hpp
@@ -28,13 +28,13 @@ using DeviceExecSpace = Kokkos::DefaultExecutionSpace;
 template <int PatchIdx>
 using SplineInterpPointsR = ddc::GrevilleInterpolationPoints<
         BSplinesR<PatchIdx>,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::GREVILLE>;
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 template <int PatchIdx>
 using SplineInterpPointsTheta = ddc::GrevilleInterpolationPoints<
         BSplinesTheta<PatchIdx>,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 
 template <int PatchIdx, class ExecSpace>
@@ -45,10 +45,10 @@ using SplineRThetaBuilder_host = ddc::SplineBuilder2D<
         BSplinesTheta<PatchIdx>,
         GridR<PatchIdx>,
         GridTheta<PatchIdx>,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC,
         ddc::SplineSolver::LAPACK>;
 
 

--- a/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
@@ -27,7 +27,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 };
 
 using SplineInterpPointsX = ddc::
-        GrevilleInterpolationPoints<BSplinesX, ddc::BoundCond::GREVILLE, ddc::BoundCond::GREVILLE>;
+        GrevilleInterpolationPoints<BSplinesX, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {
@@ -43,8 +43,8 @@ using SplineXInterpolator = SplineInterpolator<
         GridX,
         ExtrapolationRule::NULL_VALUE,
         ExtrapolationRule::NULL_VALUE,
-        ddc::BoundCond::GREVILLE,
-        ddc::BoundCond::GREVILLE>;
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 
 using DFieldMemX = DFieldMem<IdxRangeX>;
 

--- a/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
@@ -26,8 +26,10 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-using SplineInterpPointsX = ddc::
-        GrevilleInterpolationPoints<BSplinesX, ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE>;
+using SplineInterpPointsX = ddc::GrevilleInterpolationPoints<
+        BSplinesX,
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {

--- a/tests/pde_solvers/femperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femperiodicpoissonsolver.cpp
@@ -33,7 +33,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 };
 
 using SplineInterpPointsX = ddc::
-        GrevilleInterpolationPoints<BSplinesX, ddc::BoundCond::PERIODIC, ddc::BoundCond::PERIODIC>;
+        GrevilleInterpolationPoints<BSplinesX, ddc::SplineBuilderClosure::PERIODIC, ddc::SplineBuilderClosure::PERIODIC>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {
@@ -59,8 +59,8 @@ using SplineXInterpolator = SplineInterpolator<
         GridX,
         ExtrapolationRule::PERIODIC,
         ExtrapolationRule::PERIODIC,
-        ddc::BoundCond::PERIODIC,
-        ddc::BoundCond::PERIODIC>;
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 using DFieldMemX = DFieldMem<IdxRangeX>;
 using DFieldMemBatchX = DFieldMem<IdxRangeBatchX>;

--- a/tests/pde_solvers/femperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femperiodicpoissonsolver.cpp
@@ -32,8 +32,10 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-using SplineInterpPointsX = ddc::
-        GrevilleInterpolationPoints<BSplinesX, ddc::SplineBuilderClosure::PERIODIC, ddc::SplineBuilderClosure::PERIODIC>;
+using SplineInterpPointsX = ddc::GrevilleInterpolationPoints<
+        BSplinesX,
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {

--- a/tests/quadrature/neumann_quadrature_spline.cpp
+++ b/tests/quadrature/neumann_quadrature_spline.cpp
@@ -20,10 +20,10 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::HERMITE;
+auto constexpr SplineXClosure = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
-        = ddc::KnotsAsInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::KnotsAsInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {
@@ -34,8 +34,8 @@ using SplineXBuilder = ddc::SplineBuilder<
         Kokkos::DefaultExecutionSpace::memory_space,
         BSplinesX,
         GridX,
-        SplineXBoundary,
-        SplineXBoundary,
+        SplineXClosure,
+        SplineXClosure,
         ddc::SplineSolver::LAPACK>;
 
 using IdxStepX = IdxStep<GridX>;

--- a/tests/quadrature/neumann_quadrature_spline.cpp
+++ b/tests/quadrature/neumann_quadrature_spline.cpp
@@ -20,7 +20,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-auto constexpr SplineXBoundary = ddc::BoundCond::HERMITE;
+auto constexpr SplineXBoundary = ddc::SplineBuilderClosure::HERMITE;
 
 using SplineInterpPointsX
         = ddc::KnotsAsInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
@@ -107,7 +107,7 @@ struct ComputeErrorTraits
     {
     };
     using GrevillePointsY = ddc::
-            KnotsAsInterpolationPoints<BSplinesY, ddc::BoundCond::HERMITE, ddc::BoundCond::HERMITE>;
+            KnotsAsInterpolationPoints<BSplinesY, ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::HERMITE>;
     struct GridY : GrevillePointsY::interpolation_discrete_dimension_type
     {
     };
@@ -125,8 +125,8 @@ double compute_error(int n_elems)
             Kokkos::HostSpace,
             BSplinesY,
             GridY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
             ddc::SplineSolver::LAPACK>;
     using IdxRangeY = IdxRange<GridY>;
     using DFieldMemY = DFieldMem<IdxRangeY>;

--- a/tests/quadrature/neumann_quadrature_spline.cpp
+++ b/tests/quadrature/neumann_quadrature_spline.cpp
@@ -106,8 +106,10 @@ struct ComputeErrorTraits
     struct BSplinesY : ddc::UniformBSplines<Y, 3>
     {
     };
-    using GrevillePointsY = ddc::
-            KnotsAsInterpolationPoints<BSplinesY, ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::HERMITE>;
+    using GrevillePointsY = ddc::KnotsAsInterpolationPoints<
+            BSplinesY,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE>;
     struct GridY : GrevillePointsY::interpolation_discrete_dimension_type
     {
     };

--- a/tests/quadrature/quadrature_spline.cpp
+++ b/tests/quadrature/quadrature_spline.cpp
@@ -27,11 +27,11 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-auto constexpr SplineXBoundary
+auto constexpr SplineXClosure
         = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 
 using SplineInterpPointsX
-        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
+        = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXClosure, SplineXClosure>;
 
 struct GridX : SplineInterpPointsX::interpolation_discrete_dimension_type
 {
@@ -53,8 +53,8 @@ TEST(SplineUniformQuadrature, ExactForConstantFunc)
             Kokkos::HostSpace,
             BSplinesX,
             GridX,
-            SplineXBoundary,
-            SplineXBoundary,
+            SplineXClosure,
+            SplineXClosure,
             ddc::SplineSolver::LAPACK>;
 
     ddc::init_discrete_space<BSplinesX>(x_min, x_max, x_size);
@@ -102,14 +102,14 @@ double compute_error(int n_elems)
     using BSplinesY = typename ComputeErrorTraits<N>::BSplinesY;
     using GrevillePointsY = typename ComputeErrorTraits<N>::GrevillePointsY;
     using GridY = typename ComputeErrorTraits<N>::GridY;
-    auto constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
+    auto constexpr SplineYClosure = ddc::SplineBuilderClosure::GREVILLE;
     using SplineYBuilder = ddc::SplineBuilder<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::HostSpace,
             BSplinesY,
             GridY,
-            SplineYBoundary,
-            SplineYBoundary,
+            SplineYClosure,
+            SplineYClosure,
             ddc::SplineSolver::LAPACK>;
     using IdxRangeY = IdxRange<GridY>;
     using DFieldMemY = DFieldMem<IdxRangeY>;

--- a/tests/quadrature/quadrature_spline.cpp
+++ b/tests/quadrature/quadrature_spline.cpp
@@ -27,7 +27,7 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::BoundCond::PERIODIC : ddc::BoundCond::GREVILLE;
+auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;
@@ -87,8 +87,8 @@ struct ComputeErrorTraits
     };
     using GrevillePointsY = ddc::GrevilleInterpolationPoints<
             BSplinesY,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>;
     struct GridY : GrevillePointsY::interpolation_discrete_dimension_type
     {
     };
@@ -101,7 +101,7 @@ double compute_error(int n_elems)
     using BSplinesY = typename ComputeErrorTraits<N>::BSplinesY;
     using GrevillePointsY = typename ComputeErrorTraits<N>::GrevillePointsY;
     using GridY = typename ComputeErrorTraits<N>::GridY;
-    auto constexpr SplineYBoundary = ddc::BoundCond::GREVILLE;
+    auto constexpr SplineYBoundary = ddc::SplineBuilderClosure::GREVILLE;
     using SplineYBuilder = ddc::SplineBuilder<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::HostSpace,

--- a/tests/quadrature/quadrature_spline.cpp
+++ b/tests/quadrature/quadrature_spline.cpp
@@ -27,7 +27,8 @@ struct BSplinesX : ddc::UniformBSplines<X, 3>
 {
 };
 
-auto constexpr SplineXBoundary = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
+auto constexpr SplineXBoundary
+        = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC : ddc::SplineBuilderClosure::GREVILLE;
 
 using SplineInterpPointsX
         = ddc::GrevilleInterpolationPoints<BSplinesX, SplineXBoundary, SplineXBoundary>;

--- a/tests/utils/non_uniform_interpolation_points.cpp
+++ b/tests/utils/non_uniform_interpolation_points.cpp
@@ -13,14 +13,14 @@
 template <class T>
 struct NonUniformInterpolationPointsFixture;
 
-template <ddc::BoundCond BcMin, ddc::BoundCond BcMax>
+template <ddc::SplineBuilderClosure BcMin, ddc::SplineBuilderClosure BcMax>
 struct NonUniformInterpolationPointsFixture<std::tuple<
-        std::integral_constant<ddc::BoundCond, BcMin>,
-        std::integral_constant<ddc::BoundCond, BcMax>>> : public testing::Test
+        std::integral_constant<ddc::SplineBuilderClosure, BcMin>,
+        std::integral_constant<ddc::SplineBuilderClosure, BcMax>>> : public testing::Test
 {
     struct X
     {
-        static bool constexpr PERIODIC = (BcMin == ddc::BoundCond::PERIODIC);
+        static bool constexpr PERIODIC = (BcMin == ddc::SplineBuilderClosure::PERIODIC);
     };
     struct GridX : NonUniformGridBase<X>
     {
@@ -29,23 +29,23 @@ struct NonUniformInterpolationPointsFixture<std::tuple<
     {
     };
 
-    static constexpr ddc::BoundCond bc_min = BcMin;
-    static constexpr ddc::BoundCond bc_max = BcMax;
+    static constexpr ddc::SplineBuilderClosure bc_min = BcMin;
+    static constexpr ddc::SplineBuilderClosure bc_max = BcMax;
 };
 
 using Cases = tuple_to_types_t<std::tuple<
         std::tuple<
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::HERMITE>,
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::HERMITE>>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>>,
         std::tuple<
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::GREVILLE>,
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::GREVILLE>>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>>,
         std::tuple<
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::HERMITE>,
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::GREVILLE>>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>>,
         std::tuple<
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::PERIODIC>,
-                std::integral_constant<ddc::BoundCond, ddc::BoundCond::PERIODIC>>>>;
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::PERIODIC>,
+                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::PERIODIC>>>>;
 
 TYPED_TEST_SUITE(NonUniformInterpolationPointsFixture, Cases);
 
@@ -88,7 +88,7 @@ TYPED_TEST(NonUniformInterpolationPointsFixture, CoordinatesMatchAfterInit)
         EXPECT_DOUBLE_EQ(double(ddc::coordinate(idx_range.front() + i)), double(interp_points[i]));
     }
 
-    if constexpr (TestFixture::bc_min == ddc::BoundCond::PERIODIC) {
+    if constexpr (TestFixture::bc_min == ddc::SplineBuilderClosure::PERIODIC) {
         EXPECT_DOUBLE_EQ(ddcHelper::total_interval_length(idx_range), x_max - x_min);
     }
 }

--- a/tests/utils/non_uniform_interpolation_points.cpp
+++ b/tests/utils/non_uniform_interpolation_points.cpp
@@ -35,17 +35,33 @@ struct NonUniformInterpolationPointsFixture<std::tuple<
 
 using Cases = tuple_to_types_t<std::tuple<
         std::tuple<
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::HERMITE>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::HERMITE>>,
         std::tuple<
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>,
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::GREVILLE>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::GREVILLE>>,
         std::tuple<
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::HERMITE>,
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::GREVILLE>>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::HERMITE>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::GREVILLE>>,
         std::tuple<
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::PERIODIC>,
-                std::integral_constant<ddc::SplineBuilderClosure, ddc::SplineBuilderClosure::PERIODIC>>>>;
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::PERIODIC>,
+                std::integral_constant<
+                        ddc::SplineBuilderClosure,
+                        ddc::SplineBuilderClosure::PERIODIC>>>>;
 
 TYPED_TEST_SUITE(NonUniformInterpolationPointsFixture, Cases);
 

--- a/tests/utils/spline_builder_deriv_field_2d_test.cpp
+++ b/tests/utils/spline_builder_deriv_field_2d_test.cpp
@@ -210,16 +210,16 @@ void initialise_derivatives_hybrid_case(
 
 
 
-TEST(SplineBuilderDerivField2DTest, DDCBoundCondHermiteTest)
+TEST(SplineBuilderDerivField2DTest, DDCSplineBuilderClosureHermiteTest)
 {
     using SplineInterpPointsX = ddcHelper::NonUniformInterpolationPoints<
             BSplinesX,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE>;
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE>;
     using SplineInterpPointsY = ddcHelper::NonUniformInterpolationPoints<
             BSplinesY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE>;
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE>;
 
     // Initialise the mesh -----------------------------------------------------------------------
     const Coord<X> x_min(0.0);
@@ -312,10 +312,10 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondHermiteTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
             ddc::SplineSolver::LAPACK>
             builder(idx_range_xy);
 
@@ -325,10 +325,10 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondHermiteTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::HERMITE>
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE>
             apply_builder(builder);
 
     // Instantiate splines -----------------------------------------------------------------------
@@ -361,16 +361,16 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondHermiteTest)
 }
 
 
-TEST(SplineBuilderDerivField2DTest, DDCBoundCondGrevilleTest)
+TEST(SplineBuilderDerivField2DTest, DDCSplineBuilderClosureGrevilleTest)
 {
     using SplineInterpPointsX = ddc::GrevilleInterpolationPoints<
             BSplinesX,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>;
     using SplineInterpPointsY = ddc::GrevilleInterpolationPoints<
             BSplinesY,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>;
 
     // Initialise the mesh -----------------------------------------------------------------------
     const Coord<X> x_min(0.0);
@@ -423,10 +423,10 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondGrevilleTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
             ddc::SplineSolver::LAPACK>
             builder(idx_range_xy);
 
@@ -436,10 +436,10 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondGrevilleTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE>
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE>
             apply_builder(builder);
 
     // Instantiate splines -----------------------------------------------------------------------
@@ -464,16 +464,16 @@ TEST(SplineBuilderDerivField2DTest, DDCBoundCondGrevilleTest)
 
 
 
-TEST(SplineBuilderDerivField2DTest, HybridDDCBoundCondTest)
+TEST(SplineBuilderDerivField2DTest, HybridDDCSplineBuilderClosureTest)
 {
     using SplineInterpPointsX = ddcHelper::NonUniformInterpolationPoints<
             BSplinesX,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::GREVILLE>;
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::GREVILLE>;
     using SplineInterpPointsY = ddcHelper::NonUniformInterpolationPoints<
             BSplinesY,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::HERMITE>;
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::HERMITE>;
 
     // Initialise the mesh -----------------------------------------------------------------------
     const Coord<X> x_min(0.0);
@@ -564,10 +564,10 @@ TEST(SplineBuilderDerivField2DTest, HybridDDCBoundCondTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::HERMITE,
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::HERMITE,
             ddc::SplineSolver::LAPACK>
             builder(idx_range_xy);
 
@@ -577,10 +577,10 @@ TEST(SplineBuilderDerivField2DTest, HybridDDCBoundCondTest)
             BSplinesY,
             GridX,
             GridY,
-            ddc::BoundCond::HERMITE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::GREVILLE,
-            ddc::BoundCond::HERMITE>
+            ddc::SplineBuilderClosure::HERMITE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::GREVILLE,
+            ddc::SplineBuilderClosure::HERMITE>
             apply_builder(builder);
 
     // Instantiate splines -----------------------------------------------------------------------

--- a/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/a100.raven.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +cuda cuda_arch=80
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
+++ b/toolchains/cpu.spack.gyselalibxx_env/gyselalibxx-env-1.1.0.yaml
@@ -16,7 +16,7 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.30'
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - 'ginkgo@1.9'
     - 'gmgpolar@2.3'
     - 'googletest@1.14 +gmock'

--- a/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/genoa.gcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 +openmp
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/h100.jean-zay.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +cuda cuda_arch=90
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/h200.hpcc.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/h200.hpcc.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +cuda cuda_arch=90
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/mi250.hipcc.adastra.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +rocm amdgpu_target=gfx90a
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/mi250.hipcc.lumi.spack/gyselalibxx-spack-environment.yaml
+++ b/toolchains/mi250.hipcc.lumi.spack/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - cmake
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - ginkgo@1.9 ~openmp +rocm amdgpu_target=gfx90a
     - gmgpolar@2.3
     - googletest +gmock

--- a/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/v100/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.22:3'
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - 'ginkgo@1.9 +cuda cuda_arch=70 +openmp'
     - 'gmgpolar@2.3'
     - 'googletest +gmock'

--- a/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
+++ b/toolchains/persee/xeon/gyselalibxx-spack-environment.yaml
@@ -2,7 +2,7 @@ spack:
   definitions:
   - packages:
     - 'cmake@3.22:3'
-    - 'ddc@0.14 +fft +pdi +splines'
+    - 'ddc@0.15 +fft +pdi +splines'
     - 'ginkgo@1.9 +openmp'
     - 'gmgpolar@2.3'
     - 'googletest +gmock'


### PR DESCRIPTION
- Update to DDC 0.15.0 as a minimal requirement
- Remove deprecated `ddc::BoundCond` in favor of `ddc::SplineBuilderClosure`
- Remove deprecated `s_bc_xmin/xmax` in favor of `s_sbc_xmin/xmax`

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
