### PR TITLE
Allow passing fields defined on strided domains to `BslAdvection1D`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed type of species identifier read in `read_species` PDI event (from `int` to `int64`).
 - Remove version constraint on the indirect dependency Kokkos-FFT.
 - Use uppercase L suffix for long double literals.
+- Allow passing fields defined on strided domains to `BslAdvection1D`.
 
 ### Deprecated
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -86,7 +86,7 @@ private:
     // Full index range element:
     using IdxFunction = typename IdxRangeFunction::discrete_element_type;
 
-    using MemSpace = typename FunctionBuilder::mem_space;
+    using MemSpace = typename FunctionBuilder::memory_space;
 
     // Advection dimension (or Interest dimension):
     using DimInterest = typename GridInterest::continuous_dimension_type;

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -75,12 +75,18 @@ public:
     /// The type of the spline evaluator for the advection field (see SplineEvaluator).
     using AdvectionFieldEvaluator = typename AdvectionFieldInterpolator::EvaluatorType;
 
+    static_assert(std::is_same_v<
+                  typename FunctionBuilder::mem_space,
+                  typename AdvectionFieldBuilder::mem_space>);
+
 private:
     // Advection index range element:
     using IdxAdvection = typename IdxRangeAdvection::discrete_element_type;
 
     // Full index range element:
     using IdxFunction = typename IdxRangeFunction::discrete_element_type;
+
+    using MemSpace = typename FunctionBuilder::mem_space;
 
     // Advection dimension (or Interest dimension):
     using DimInterest = typename GridInterest::continuous_dimension_type;
@@ -92,11 +98,6 @@ private:
     using FeetFieldMem = FieldMem<CoordInterest, IdxRangeAdvection>;
     using FeetField = typename FeetFieldMem::span_type;
     using FeetConstField = typename FeetFieldMem::view_type;
-
-    using AdvecFieldMem = FieldMem<DataType, IdxRangeAdvection>;
-    using AdvecField = typename AdvecFieldMem::span_type;
-
-    using FunctionField = Field<DataType, IdxRangeFunction>;
 
     // Type for spline representation of the advection field
     using IdxRangeBSAdvection = typename InterpolationBuilderTraits<
@@ -250,9 +251,10 @@ public:
      *
      * @return A reference to the allfdistribu array after advection on dt.
      */
-    FunctionField operator()(
-            FunctionField const allfdistribu,
-            AdvecField const advection_field,
+    template <class FDistribLayout, class AdvecLayout>
+    Field<DataType, IdxRangeFunction, MemSpace, FDistribLayout> operator()(
+            Field<DataType, IdxRangeFunction, MemSpace, FDistribLayout> const allfdistribu,
+            Field<DataType, IdxRangeAdvection, MemSpace, AdvecLayout> const advection_field,
             DataType const dt,
             std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_min
             = std::nullopt,

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -76,8 +76,8 @@ public:
     using AdvectionFieldEvaluator = typename AdvectionFieldInterpolator::EvaluatorType;
 
     static_assert(std::is_same_v<
-                  typename FunctionBuilder::mem_space,
-                  typename AdvectionFieldBuilder::mem_space>);
+                  typename FunctionBuilder::memory_space,
+                  typename AdvectionFieldBuilder::memory_space>);
 
 private:
     // Advection index range element:


### PR DESCRIPTION
Allow passing fields defined on strided domains to `BslAdvection1D`. This is ill-advised for the advection dimension, but is not necessarily problematic (e.g. iteration over 4 dims with 1 point removed from the outermost dimension).

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
