### PR TITLE
Fix strided use of BslAdvection1D

### DIFF
--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -326,7 +326,7 @@ public:
 
         TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
-        ConstField<DataType, IdxRangeBSAdvection> function_coefs_const
+        ConstField<DataType, IdxRangeFunctionBasis> function_coefs_const
                 = get_const_field(function_coefs_alloc);
         FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         AdvectionFieldEvaluator const& adv_field_evaluator_proxy = m_adv_field_evaluator;

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -297,6 +297,7 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
+        // Use Kokkos view constructor to ensure correct layout
         Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs(
                 function_coefs_alloc.allocation_kokkos_view(),
                 get_idx_range(function_coefs_alloc));

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -297,12 +297,9 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
-        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs;
-        if constexpr (std::is_same_v<FDistribLayout, Kokkos::layout_stride>) {
-            function_coefs = function_coefs_alloc[get_idx_range(function_coefs_alloc)];
-        } else {
-            function_coefs = get_field(function_coefs_alloc);
-        }
+        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs(
+                function_coefs_alloc.allocation_kokkos_view(),
+                get_idx_range(function_coefs_alloc));
 
         // Interpolate the function ..............................................................
         /*

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -298,7 +298,7 @@ public:
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
         // Use Kokkos view constructor to ensure correct layout
-        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs(
+        Field<DataType, IdxRangeFunctionBasis, MemSpace, FDistribLayout> function_coefs(
                 function_coefs_alloc.allocation_kokkos_view(),
                 get_idx_range(function_coefs_alloc));
 

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -103,7 +103,6 @@ private:
     using IdxRangeBSAdvection = typename InterpolationBuilderTraits<
             AdvectionFieldBuilder>::template batched_basis_idx_range_type<IdxRangeAdvection>;
     using AdvecFieldSplineMem = FieldMem<DataType, IdxRangeBSAdvection>;
-    using AdvecFieldSplineCoeffs = Field<DataType, IdxRangeBSAdvection>;
 
     // Type for the derivatives of the advection field
     using DerivDim = ddc::Deriv<DimInterest>;
@@ -285,7 +284,8 @@ public:
         AdvecFieldSplineMem advection_field_coefs_alloc(
                 "advection_field_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_adv_field_builder, get_idx_range(advection_field)));
-        AdvecFieldSplineCoeffs advection_field_coefs = get_field(advection_field_coefs_alloc);
+        Field<DataType, IdxRangeBSAdvection, MemSpace, AdvecLayout> advection_field_coefs
+                = get_field(advection_field_coefs_alloc);
 
         m_adv_field_builder(
                 advection_field_coefs,
@@ -297,6 +297,8 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
+        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs
+                = get_field(function_coefs_alloc);
 
         // Interpolate the function ..............................................................
         /*

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -109,7 +109,6 @@ private:
     using DerivDim = ddc::Deriv<DimInterest>;
     using IdxRangeAdvecFieldDeriv
             = ddc::replace_dim_of_t<IdxRangeAdvection, GridInterest, DerivDim>;
-    using AdvecFieldDerivConstField = Field<const DataType, IdxRangeAdvecFieldDeriv>;
 
     // Type for the spline representation of the function
     using IdxRangeFunctionBasis = typename InterpolationBuilderTraits<
@@ -120,7 +119,6 @@ private:
     // Type for the derivatives of the function
     using IdxRangeFunctionDeriv = typename InterpolationBuilderTraits<
             FunctionBuilder>::template batched_derivs_idx_range_type<IdxRangeFunction>;
-    using FunctionDerivConstField = ConstField<DataType, IdxRangeFunctionDeriv>;
 
     using TimeStepper =
             typename TimeStepperBuilder::template time_stepper_t<CoordInterest, DataType>;
@@ -256,12 +254,21 @@ public:
             Field<DataType, IdxRangeFunction, MemSpace, FDistribLayout> const allfdistribu,
             Field<DataType, IdxRangeAdvection, MemSpace, AdvecLayout> const advection_field,
             DataType const dt,
-            std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_min
+            std::optional<
+                    ConstField<DataType, IdxRangeAdvecFieldDeriv, MemSpace, AdvecLayout>> const
+                    advection_field_derivatives_min
             = std::nullopt,
-            std::optional<AdvecFieldDerivConstField> const advection_field_derivatives_max
+            std::optional<
+                    ConstField<DataType, IdxRangeAdvecFieldDeriv, MemSpace, AdvecLayout>> const
+                    advection_field_derivatives_max
             = std::nullopt,
-            std::optional<FunctionDerivConstField> const function_derivatives_min = std::nullopt,
-            std::optional<FunctionDerivConstField> const function_derivatives_max
+            std::optional<
+                    ConstField<DataType, IdxRangeFunctionDeriv, MemSpace, FDistribLayout>> const
+                    function_derivatives_min
+            = std::nullopt,
+            std::optional<
+                    ConstField<DataType, IdxRangeFunctionDeriv, MemSpace, FDistribLayout>> const
+                    function_derivatives_max
             = std::nullopt) const
     {
         using IdxRangeBatchFunction = ddc::remove_dims_of_t<IdxRangeFunction, GridInterest>;

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -324,8 +324,8 @@ public:
 
         TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
-        ConstField<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs_const
-                = get_field(function_coefs_alloc);
+        ConstField<DataType, IdxRangeBSAdvection> function_coefs_const
+                = get_const_field(function_coefs_alloc);
         FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         AdvectionFieldEvaluator const& adv_field_evaluator_proxy = m_adv_field_evaluator;
         // Evaluate the function at the characteristic feet

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -297,12 +297,12 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
-		Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs;
-		if constexpr (std::is_same_v<FDistribLayout, Kokkos::layout_stride>) {
-				function_coefs = function_coefs_alloc[get_idx_range(function_coefs_alloc)];
-		} else {
-				function_coefs = get_field(function_coefs_alloc);
-		}
+        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs;
+        if constexpr (std::is_same_v<FDistribLayout, Kokkos::layout_stride>) {
+            function_coefs = function_coefs_alloc[get_idx_range(function_coefs_alloc)];
+        } else {
+            function_coefs = get_field(function_coefs_alloc);
+        }
 
         // Interpolate the function ..............................................................
         /*

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -297,8 +297,12 @@ public:
         FunctionBasisFieldMem function_coefs_alloc(
                 "function_coefs (BslAdvection1D::operator())",
                 batched_basis_idx_range(m_function_builder, idx_range_function));
-        Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs
-                = get_field(function_coefs_alloc);
+		Field<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs;
+		if constexpr (std::is_same_v<FDistribLayout, Kokkos::layout_stride>) {
+				function_coefs = function_coefs_alloc[get_idx_range(function_coefs_alloc)];
+		} else {
+				function_coefs = get_field(function_coefs_alloc);
+		}
 
         // Interpolate the function ..............................................................
         /*
@@ -307,7 +311,7 @@ public:
         */
         // Build interpolation coefficients from the function values
         m_function_builder(
-                get_field(function_coefs_alloc),
+                function_coefs,
                 get_const_field(allfdistribu),
                 function_derivatives_min,
                 function_derivatives_max);

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -324,9 +324,6 @@ public:
 
         TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
-
-        FunctionBasisConstField function_coefs = get_const_field(function_coefs_alloc);
-
         FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         AdvectionFieldEvaluator const& adv_field_evaluator_proxy = m_adv_field_evaluator;
         // Evaluate the function at the characteristic feet

--- a/src/advection/bsl_advection_1d.hpp
+++ b/src/advection/bsl_advection_1d.hpp
@@ -324,6 +324,8 @@ public:
 
         TimeStepper time_stepper = m_time_stepper_builder.template preallocate<TimeStepper>();
 
+        ConstField<DataType, IdxRangeBSAdvection, MemSpace, FDistribLayout> function_coefs_const
+                = get_field(function_coefs_alloc);
         FunctionEvaluator const& function_evaluator_proxy = m_function_evaluator;
         AdvectionFieldEvaluator const& adv_field_evaluator_proxy = m_adv_field_evaluator;
         // Evaluate the function at the characteristic feet
@@ -347,8 +349,9 @@ public:
                                                         advection_field_coefs[IdxBatchAdvecField(
                                                                 idx)]));
                                     });
-                    allfdistribu(idx)
-                            = function_evaluator_proxy(foot, function_coefs[IdxBatchFunction(idx)]);
+                    allfdistribu(idx) = function_evaluator_proxy(
+                            foot,
+                            function_coefs_const[IdxBatchFunction(idx)]);
                 });
 
 

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -246,8 +246,8 @@ public:
                 allfdistribu,
                 advection_field,
                 timestep,
-                get_const_field(advection_field_derivatives_min),
-                get_const_field(advection_field_derivatives_max));
+                std::optional(get_const_field(advection_field_derivatives_min)),
+                std::optional(get_const_field(advection_field_derivatives_max)));
 
 
         double const max_advection_error = ddc::parallel_transform_reduce(


### PR DESCRIPTION
Fix strided use of `BslAdvection1D`. `ddc::SplineBuilder` only accepts arguments which all have the same layouts. This requires some changes to the first attempt at a strided version of `BslAdvection1D`.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
