### PR TITLE
Increase tolerance of coord transformation tests

### DIFF
--- a/tests/coord_transformations/jacobian.cpp
+++ b/tests/coord_transformations/jacobian.cpp
@@ -46,7 +46,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixCircMap)
         check_inverse_tensor(
                 mapping.jacobian_matrix(coords(irtheta)),
                 inv_jacobian(coords(irtheta)),
-                1e-14);
+                5e-14);
     });
 }
 
@@ -67,7 +67,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixCzarMap)
         check_inverse_tensor(
                 mapping.jacobian_matrix(coords(irtheta)),
                 mapping.inv_jacobian_matrix(coords(irtheta)),
-                1e-14);
+                5e-14);
     });
 }
 
@@ -130,7 +130,7 @@ TEST_P(InvJacobianMatrix, InverseMatrixDiscCzarMap)
             check_inverse_tensor(
                     mapping.jacobian_matrix(coord_rtheta),
                     inv_jacobian(coord_rtheta),
-                    1e-14);
+                    5e-14);
         }
     });
 }
@@ -210,7 +210,7 @@ TEST_P(InvJacobianMatrix3D, InverseMatrixToroidalDiscCzarMap)
         const CoordRThetaPhi coord(ddc::coordinate(idx));
         const double r = ddc::get<R>(coord);
         if (fabs(r) > 1e-15) {
-            check_inverse_tensor(mapping.jacobian_matrix(coord), inv_jacobian(coord), 1e-14);
+            check_inverse_tensor(mapping.jacobian_matrix(coord), inv_jacobian(coord), 5e-14);
         }
     });
 }


### PR DESCRIPTION
The tolerance is slightly too restrictive for Adastra.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
