### PR TITLE
Allow run_cppcheck script to be run in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove version constraint on the indirect dependency Kokkos-FFT.
 - Use uppercase L suffix for long double literals.
 - Allow passing fields defined on strided domains to `BslAdvection1D`.
+- Allow `run_cppcheck` CI script to be run in parallel.
 
 ### Deprecated
 

--- a/bin/run_cppcheck
+++ b/bin/run_cppcheck
@@ -17,6 +17,7 @@ if __name__ == '__main__':
     parser.add_argument('--disable-style', help='Disable the style checks', action='store_true')
     parser.add_argument('--no-clean-up', help='Disable the clean-up of the generated folder.', action='store_true')
     parser.add_argument('--verbose', help='Run cppcheck in verbose mode', action='store_true')
+    parser.add_argument('-j', '--parallel', metavar='jobs', help='Start <jobs> threads to do the checking simultaneously.', type=int, default=1)
 
     args = parser.parse_args()
 
@@ -44,7 +45,7 @@ if __name__ == '__main__':
            '--library=googletest', '--max-ctu-depth=5', '--check-level=exhaustive',
            '--std=c++17', '--suppress=unusedStructMember', '--suppress=useStlAlgorithm',
            '--suppress=knownConditionTrueFalse', '--suppress=ctuOneDefinitionRuleViolation',
-           '--inline-suppr',
+           '--inline-suppr', '-j', args.jobs,
            f'--addon={GYSELALIB_ROOT}/bin/ci_tools/check_naming_conventions',
            f'--addon={GYSELALIB_ROOT}/bin/ci_tools/check_for_memory_misuse',
            f'--project={build_dir}/relevant_compile_commands.json']


### PR DESCRIPTION
Allow run_cppcheck script to be run in parallel. This could speed up the CI in Gysela-X.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
