### PR TITLE
Warnings as errors

### DIFF
--- a/toolchains/common_toolchains/debug_toolchain.cmake
+++ b/toolchains/common_toolchains/debug_toolchain.cmake
@@ -5,7 +5,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Werror=parentheses -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Wno-sign-compare")
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS ON)

--- a/toolchains/common_toolchains/debug_toolchain.cmake
+++ b/toolchains/common_toolchains/debug_toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Activate/deactivate parts of the code

--- a/toolchains/common_toolchains/release_toolchain.cmake
+++ b/toolchains/common_toolchains/release_toolchain.cmake
@@ -5,7 +5,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wno-sign-compare")
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS OFF)

--- a/toolchains/common_toolchains/release_toolchain.cmake
+++ b/toolchains/common_toolchains/release_toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Activate/deactivate parts of the code


### PR DESCRIPTION
This PR turns all enabled warnings into errors using [CMAKE_COMPILE_WARNING_AS_ERROR](https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILE_WARNING_AS_ERROR.html) for the common CPU toolchains.  Explicit warnings set as errors are removed, they are already warnings enabled by [-Wall](https://gcc.gnu.org/onlinedocs/gcc-11.5.0/gcc/Warning-Options.html). Warnings `-Wextra` are added without `-Wno-unused-but-set-parameter` and `-Wno-unused-parameter`.

See [logs](https://github.com/gyselax/gyselalibxx/actions/runs/30115644922)

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
