### PR TITLE
Revert "Warnings as errors (#720)"

### DIFF
--- a/toolchains/common_toolchains/debug_toolchain.cmake
+++ b/toolchains/common_toolchains/debug_toolchain.cmake
@@ -5,8 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
-set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Werror=parentheses -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS ON)

--- a/toolchains/common_toolchains/release_toolchain.cmake
+++ b/toolchains/common_toolchains/release_toolchain.cmake
@@ -5,8 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
-set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS OFF)


### PR DESCRIPTION
Having `CMAKE_COMPILE_WARNING_AS_ERROR` in the toolchain is problematic for Gysela-X++.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
