### PR TITLE
Enable custom extrapolation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a method `get_derivative` to `CentralFDMPartialDerivative` so it respects the `LocalPartialDerivativeCreator` concept.
 - Add class `GMGPolarPoissonLikeSolver` to allow the use of [GMGPolar](https://github.com/SciCompMod/GMGPolar) as a polar Poisson solver.
 - Add GMGPolar in the toolchains.
+- Allow `SplineInterpolator` and `LagrangeInterpolator` to specify custom extrapolation rules.
 
 ### Fixed
 
@@ -88,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `run_cppcheck` CI script to be run in parallel.
 - Simplify `restrict_to_idx_range` implementation.
 - Rename CMake options `POLAR_SPLINES_TEST_DEGREE_[MIN/MAX]` to `GYSELALIBXX_POLAR_SPLINES_TEST_DEGREE_[MIN/MAX]`.
+- Changed `ExtrapolationRule::RULENAME` from an enum to `ExtrapolationRule::RuleName`, a struct tag in a namespace.
 
 ### Deprecated
 

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -40,7 +40,8 @@ using SplineInterpPointsX
 using SplineInterpPointsVx
         = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
-ExtrapolationRule constexpr XExtrapRule = X::PERIODIC ? PERIODIC : CONSTANT;
+using XExtrapRule = std::
+        conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
 
 using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -55,8 +56,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
-        CONSTANT,
-        CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         SplineVxClosure,
         SplineVxClosure>;
 

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -40,8 +40,8 @@ using SplineInterpPointsX
 using SplineInterpPointsVx
         = ddc::GrevilleInterpolationPoints<BSplinesVx, SplineVxClosure, SplineVxClosure>;
 
-using XExtrapRule = std::
-        conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
+using XExtrapRule
+        = std::conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
 
 using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,

--- a/simulations/geometryXY/spline_definitions_xy.hpp
+++ b/simulations/geometryXY/spline_definitions_xy.hpp
@@ -30,8 +30,8 @@ struct BSplinesY
 ddc::SplineBuilderClosure constexpr SplineXClosure = ddc::SplineBuilderClosure::PERIODIC;
 ddc::SplineBuilderClosure constexpr SplineYClosure = ddc::SplineBuilderClosure::PERIODIC;
 
-ExtrapolationRule constexpr SplineXExtrapolation = ExtrapolationRule::PERIODIC;
-ExtrapolationRule constexpr SplineYExtrapolation = ExtrapolationRule::PERIODIC;
+using SplineXExtrapolation = ExtrapolationRule::Periodic;
+using SplineYExtrapolation = ExtrapolationRule::Periodic;
 
 // IDim initialisers
 using SplineInterpPointsX

--- a/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
@@ -58,30 +58,30 @@ using LagrangeInterpolatorX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagrangeX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         Real>;
 using LagrangeInterpolatorY = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagrangeY,
         GridY,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         Real>;
 
 using LagrangeInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagrangeVx,
         GridVx,
-        CONSTANT,
-        CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         Real>;
 using LagrangeInterpolatorVy = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagrangeVy,
         GridVy,
-        CONSTANT,
-        CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         Real>;
 
 using IdxRangeLY = IdxRange<LagrangeY>;

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -47,8 +47,8 @@ using SplineInterpolatorY = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineYClosure,
         SplineYClosure>;
 
@@ -56,8 +56,8 @@ using SplineInterpolatorVy = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVy,
         GridVy,
-        CONSTANT,
-        CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         SplineVyClosure,
         SplineVyClosure>;
 

--- a/src/interpolation/constant_identity_interpolation_extrapolation_rule.hpp
+++ b/src/interpolation/constant_identity_interpolation_extrapolation_rule.hpp
@@ -10,8 +10,9 @@
  * rather than extrapolating the polynomial. This is the Lagrange analog of
  * ddc::ConstantExtrapolationRule used with spline evaluators.
  *
- * It is intended to be constructed via get_extrapolation<CONSTANT, CoeffGrid, DataType, Basis>(),
- * which supplies the appropriate boundary index automatically.
+ * It is intended to be constructed via
+ * get_extrapolation<ExtrapolationRule::Constant, CoeffGrid, DataType, Basis>(), which
+ * supplies the appropriate boundary index automatically.
  *
  * @tparam CoeffGrid The discrete grid type of the interpolation coefficients.
  * @tparam DataType  The floating-point type of the function values (default: double).

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -5,58 +5,62 @@
 
 namespace details {
 
-// Get the class describing the interpolation rule
-template <ExtrapolationRule Rule, class CoeffGrid, class DataType>
-struct GetExtrapolationRuleClass;
-
-template <class CoeffGrid, class DataType>
-struct GetExtrapolationRuleClass<PERIODIC, CoeffGrid, DataType>
+/// Primary template: Rule has no nested `type` alias template, so it is assumed to
+/// already be a concrete, usable extrapolation rule class - use it as-is.
+template <class Rule, class CoeffGrid, class DataType, class = void>
+struct ExtrapolationRuleResolver
 {
-    using type = ddc::PeriodicExtrapolationRule<typename CoeffGrid::continuous_dimension_type>;
+    using type = Rule;
 };
 
-template <class CoeffGrid, class DataType>
-struct GetExtrapolationRuleClass<NULL_VALUE, CoeffGrid, DataType>
+/// Specialisation selected via SFINAE when Rule exposes `Rule::type<CoeffGrid, DataType>`
+/// (i.e. Rule is a self-describing tag such as ExtrapolationRule::Periodic) - resolve
+/// through it to obtain the concrete extrapolation rule class.
+template <class Rule, class CoeffGrid, class DataType>
+struct ExtrapolationRuleResolver<
+        Rule,
+        CoeffGrid,
+        DataType,
+        std::void_t<typename Rule::template type<CoeffGrid, DataType>>>
 {
-    using type = ddc::NullExtrapolationRule;
-};
-
-template <class CoeffGrid, class DataType>
-struct GetExtrapolationRuleClass<CONSTANT, CoeffGrid, DataType>
-{
-    using type = std::conditional_t<
-            is_spline_basis_v<CoeffGrid>,
-            ddc::ConstantExtrapolationRule<typename CoeffGrid::continuous_dimension_type>,
-            ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>;
+    using type = typename Rule::template type<CoeffGrid, DataType>;
 };
 
 } // namespace details
 
-template <ExtrapolationRule Rule, class CoeffGrid, class DataType>
-using extrapolation_rule_t = details::GetExtrapolationRuleClass<Rule, CoeffGrid, DataType>::type;
+/// @brief Resolve Rule (either a self-describing tag or a concrete extrapolation rule
+/// class) to the concrete extrapolation rule class to use for a given CoeffGrid/DataType.
+template <class Rule, class CoeffGrid, class DataType>
+using extrapolation_rule_t =
+        typename details::ExtrapolationRuleResolver<Rule, CoeffGrid, DataType>::type;
 
-template <ExtrapolationRule Rule, class CoeffGrid, class DataType, class Basis = CoeffGrid>
+/**
+ * @brief Initialise the extrapolation rule.
+ *
+ * Initialise the extrapolation rule using the default constructor if available. For a
+ * constant extrapolation, initialise the extrapolation from the selected extremity.
+ */
+template <class Rule, class CoeffGrid, class DataType, class Basis = CoeffGrid>
 extrapolation_rule_t<Rule, CoeffGrid, DataType> get_extrapolation(Extremity extremity)
 {
-    if constexpr (Rule == CONSTANT) {
+    using RuleType = extrapolation_rule_t<Rule, CoeffGrid, DataType>;
+    if constexpr (std::is_default_constructible_v<RuleType>) {
+        return RuleType();
+    } else if constexpr (std::is_same_v<Rule, ExtrapolationRule::Constant>) {
         if constexpr (is_spline_basis_v<Basis>) {
             if (extremity == Extremity::FRONT) {
-                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
-                        ddc::discrete_space<CoeffGrid>().rmin());
+                return RuleType(ddc::discrete_space<CoeffGrid>().rmin());
             } else {
-                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
-                        ddc::discrete_space<CoeffGrid>().rmax());
+                return RuleType(ddc::discrete_space<CoeffGrid>().rmax());
             }
         } else {
             if (extremity == Extremity::FRONT) {
-                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
-                        ddc::discrete_space<Basis>().full_domain().front());
+                return RuleType(ddc::discrete_space<Basis>().full_domain().front());
             } else {
-                return extrapolation_rule_t<Rule, CoeffGrid, DataType>(
-                        ddc::discrete_space<Basis>().full_domain().back());
+                return RuleType(ddc::discrete_space<Basis>().full_domain().back());
             }
         }
     } else {
-        return extrapolation_rule_t<Rule, CoeffGrid, DataType>();
+        static_assert("Extrapolation rule initialisation cannot be deduced from type.");
     }
 }

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -34,6 +34,15 @@ template <class Rule, class CoeffGrid, class DataType>
 using extrapolation_rule_t =
         typename details::ExtrapolationRuleResolver<Rule, CoeffGrid, DataType>::type;
 
+/// @brief True if get_extrapolation<Rule, CoeffGrid, DataType, ...> can build the rule
+/// with no extra information: the resolved rule type is default-constructible, or Rule
+/// is the ExtrapolationRule::Constant tag (which get_extrapolation knows how to build
+/// from the boundary of the discrete space).
+template <class Rule, class CoeffGrid, class DataType>
+constexpr bool is_extrapolation_rule_auto_constructible_v
+        = std::is_default_constructible_v<extrapolation_rule_t<Rule, CoeffGrid, DataType>>
+          || std::is_same_v<Rule, ExtrapolationRule::Constant>;
+
 /**
  * @brief Initialise the extrapolation rule.
  *

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -40,8 +40,10 @@ using extrapolation_rule_t =
 /// from the boundary of the discrete space).
 template <class Rule, class CoeffGrid, class DataType>
 constexpr bool is_extrapolation_rule_auto_constructible_v
-        = std::is_default_constructible_v<extrapolation_rule_t<Rule, CoeffGrid, DataType>>
-          || std::is_same_v<Rule, ExtrapolationRule::Constant>;
+        = std::is_default_constructible_v<extrapolation_rule_t<
+                  Rule,
+                  CoeffGrid,
+                  DataType>> || std::is_same_v<Rule, ExtrapolationRule::Constant>;
 
 /**
  * @brief Initialise the extrapolation rule.

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -2,22 +2,13 @@
 #pragma once
 #include <ddc/kernels/splines.hpp>
 
+#include "constant_identity_interpolation_extrapolation_rule.hpp"
 #include "geometry_descriptors.hpp"
 #include "i_interpolation_builder.hpp"
 #include "i_interpolation_evaluator.hpp"
 #include "lagrange_basis_non_uniform.hpp"
 #include "lagrange_basis_uniform.hpp"
 #include "type_seq_tools.hpp"
-
-/**
- * @brief An enum describing how a function is extrapolated outside the interpolation domain.
- *
- * - PERIODIC : the function is assumed to be periodic. The value at a point outside
- *   the domain is taken as the value at the equivalent point inside the domain.
- * - NULL_VALUE : the function evaluates to zero outside the domain.
- * - CONSTANT : the function is clamped to the value at the nearest boundary point.
- */
-enum ExtrapolationRule { PERIODIC, NULL_VALUE, CONSTANT };
 
 namespace concepts {
 
@@ -87,3 +78,55 @@ constexpr bool is_lagrange_basis_v
 template <class Basis>
 constexpr bool is_spline_basis_v
         = ddc::is_uniform_bsplines_v<Basis> || ddc::is_non_uniform_bsplines_v<Basis>;
+
+/**
+ * @brief A namespace containing tag types describing how a function is extrapolated
+ * outside the interpolation domain.
+ *
+ * Each tag exposes a type alias template that resolves, given the coefficient grid
+ * and data type of the interpolator, to the concrete extrapolation rule class to use.
+ * This keeps the set of extrapolation rules open for extension: user code may define
+ * its own tag following the same pattern, or bypass tags entirely and pass an
+ * already-concrete extrapolation rule class directly to SplineInterpolator or
+ * LagrangeInterpolator (see extrapolation_rule_choice.hpp for the generic resolution
+ * mechanism).
+ */
+namespace ExtrapolationRule {
+
+/**
+ * @brief Tag selecting periodic extrapolation.
+ *
+ * The value at a point outside the domain is taken as the value at the equivalent
+ * point inside the domain.
+ */
+struct Periodic
+{
+    /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
+    template <class CoeffGrid, class DataType>
+    using type = ddc::PeriodicExtrapolationRule<typename CoeffGrid::continuous_dimension_type>;
+};
+
+/// @brief Tag selecting null extrapolation: the function evaluates to zero outside the domain.
+struct NullValue
+{
+    /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
+    template <class CoeffGrid, class DataType>
+    using type = ddc::NullExtrapolationRule;
+};
+
+/**
+ * @brief Tag selecting constant extrapolation.
+ *
+ * The function is clamped to the value at the nearest boundary point.
+ */
+struct Constant
+{
+    /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
+    template <class CoeffGrid, class DataType>
+    using type = std::conditional_t<
+            is_spline_basis_v<CoeffGrid>,
+            ddc::ConstantExtrapolationRule<typename CoeffGrid::continuous_dimension_type>,
+            ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>;
+};
+
+} // namespace ExtrapolationRule

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -69,6 +69,9 @@ private:
                     extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType>,
                     ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
 
+    using MinExtrapolationRule = extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>;
+    using MaxExtrapolationRule = extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>;
+
 public:
     /// @brief The LagrangeEvaluator type built from the template parameters.
     using EvaluatorType = LagrangeEvaluator<
@@ -77,8 +80,8 @@ public:
             DataType,
             Basis,
             InterpGrid,
-            extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>,
-            extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType>>;
+            MinExtrapolationRule,
+            MaxExtrapolationRule>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -87,8 +90,8 @@ public:
     }
 
 private:
-    extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType> m_min_extrapolation;
-    extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType> m_max_extrapolation;
+    MinExtrapolationRule m_min_extrapolation;
+    MaxExtrapolationRule m_max_extrapolation;
     BuilderType m_builder;
     EvaluatorType m_evaluator;
 

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -111,13 +111,12 @@ public:
      * @param idx_range The index range on which the interpolator will act. This is
      *                  unused but is included to match the SplineInterpolator interface.
      */
-    explicit LagrangeInterpolator(IdxRange<InterpGrid> idx_range = IdxRange<InterpGrid> {})
-        requires(
-                is_extrapolation_rule_auto_constructible_v<
-                        MinExtrapRule,
-                        CoeffGridType,
-                        DataType> &&
-                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, CoeffGridType, DataType>)
+    explicit LagrangeInterpolator(IdxRange<InterpGrid> idx_range = IdxRange<InterpGrid> {}) requires(
+            is_extrapolation_rule_auto_constructible_v<MinExtrapRule, CoeffGridType, DataType>&&
+                    is_extrapolation_rule_auto_constructible_v<
+                            MaxExtrapRule,
+                            CoeffGridType,
+                            DataType>)
         : m_min_extrapolation(
                 get_extrapolation<MinExtrapRule, CoeffGridType, DataType, Basis>(Extremity::FRONT))
         , m_max_extrapolation(

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -22,25 +22,26 @@
  * @tparam ExecSpace     The Kokkos execution space used for computations.
  * @tparam Basis         The Lagrange basis type (uniform or non-uniform).
  * @tparam InterpGrid    The discrete grid on which function values are provided.
- * @tparam MinExtrapRule The ExtrapolationRule applied below the lower boundary.
- * @tparam MaxExtrapRule The ExtrapolationRule applied above the upper boundary.
+ * @tparam MinExtrapRule The extrapolation rule applied below the lower boundary. This
+ *                       may be one of the tags in the ExtrapolationRule namespace
+ *                       (e.g. ExtrapolationRule::Periodic) or a custom, already-concrete
+ *                       extrapolation rule class.
+ * @tparam MaxExtrapRule The extrapolation rule applied above the upper boundary. See
+ *                       MinExtrapRule for the accepted forms.
  * @tparam DataType      The floating-point type of the function values (default: double).
  */
 template <
         class ExecSpace,
         class Basis,
         class InterpGrid,
-        ExtrapolationRule MinExtrapRule,
-        ExtrapolationRule MaxExtrapRule,
+        class MinExtrapRule,
+        class MaxExtrapRule,
         class DataType = double>
 class LagrangeInterpolator
 {
     using continuous_dimension_type = typename InterpGrid::continuous_dimension_type;
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
-
-    static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
-    static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
 
     static_assert(is_lagrange_basis_v<Basis>);
 
@@ -56,6 +57,19 @@ public:
     /// @brief The discrete grid type used for the Lagrange coefficients (the Lagrange basis grid).
     using CoeffGridType = typename BuilderType::basis_domain_type;
 
+private:
+    static_assert(
+            is_periodic
+            == std::is_same_v<
+                    extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>,
+                    ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
+    static_assert(
+            is_periodic
+            == std::is_same_v<
+                    extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType>,
+                    ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
+
+public:
     /// @brief The LagrangeEvaluator type built from the template parameters.
     using EvaluatorType = LagrangeEvaluator<
             ExecSpace,

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <utility>
+
 #include "extrapolation_rule_choice.hpp"
 #include "identity_interpolation_builder.hpp"
 #include "lagrange_basis_non_uniform.hpp"
@@ -70,7 +72,7 @@ private:
                     ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
 
     using MinExtrapolationRule = extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>;
-    using MaxExtrapolationRule = extrapolation_rule_t<MinExtrapRule, CoeffGridType, DataType>;
+    using MaxExtrapolationRule = extrapolation_rule_t<MaxExtrapRule, CoeffGridType, DataType>;
 
 public:
     /// @brief The LagrangeEvaluator type built from the template parameters.
@@ -102,15 +104,46 @@ public:
      * The extrapolation rules are initialised from the discrete space of @c Basis,
      * so the corresponding ddc discrete space must be initialised before construction.
      * No index range is required because the identity builder needs none.
+     * This overload is only available when both extrapolation rules can be built
+     * automatically (they are default-constructible, or the tag ExtrapolationRule::Constant
+     * is used) - otherwise use the overload that takes the extrapolation rules explicitly.
      *
      * @param idx_range The index range on which the interpolator will act. This is
      *                  unused but is included to match the SplineInterpolator interface.
      */
     explicit LagrangeInterpolator(IdxRange<InterpGrid> idx_range = IdxRange<InterpGrid> {})
+        requires(
+                is_extrapolation_rule_auto_constructible_v<
+                        MinExtrapRule,
+                        CoeffGridType,
+                        DataType> &&
+                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, CoeffGridType, DataType>)
         : m_min_extrapolation(
                 get_extrapolation<MinExtrapRule, CoeffGridType, DataType, Basis>(Extremity::FRONT))
         , m_max_extrapolation(
                   get_extrapolation<MaxExtrapRule, CoeffGridType, DataType, Basis>(Extremity::BACK))
+        , m_evaluator(m_min_extrapolation, m_max_extrapolation)
+    {
+    }
+
+    /**
+     * @brief Construct a LagrangeInterpolator, specifying the extrapolation rules explicitly.
+     *
+     * Use this overload when the chosen extrapolation rule cannot be built automatically,
+     * e.g. a custom extrapolation rule that is not default-constructible and is not
+     * ExtrapolationRule::Constant.
+     *
+     * @param idx_range The index range on which the interpolator will act. This is
+     *                  unused but is included to match the SplineInterpolator interface.
+     * @param min_extrapolation_rule The extrapolation rule to use below the lower boundary.
+     * @param max_extrapolation_rule The extrapolation rule to use above the upper boundary.
+     */
+    explicit LagrangeInterpolator(
+            IdxRange<InterpGrid> idx_range,
+            MinExtrapolationRule min_extrapolation_rule,
+            MaxExtrapolationRule max_extrapolation_rule)
+        : m_min_extrapolation(std::move(min_extrapolation_rule))
+        , m_max_extrapolation(std::move(max_extrapolation_rule))
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
     }

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -61,6 +61,9 @@ private:
 
     static_assert(is_spline_basis_v<Basis>);
 
+    using MinExtrapolationRule = extrapolation_rule_t<MinExtrapRule, Basis, double>;
+    using MaxExtrapolationRule = extrapolation_rule_t<MaxExtrapRule, Basis, double>;
+
 public:
     /// @brief The ddc::SplineBuilder type built from the template parameters.
     using BuilderType = ddc::SplineBuilder<
@@ -78,8 +81,8 @@ public:
             typename ExecSpace::memory_space,
             Basis,
             InterpGrid,
-            extrapolation_rule_t<MinExtrapRule, Basis, double>,
-            extrapolation_rule_t<MaxExtrapRule, Basis, double>>;
+            MinExtrapolationRule,
+            MaxExtrapolationRule>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -88,8 +91,8 @@ public:
     }
 
 private:
-    extrapolation_rule_t<MinExtrapRule, Basis, double> m_min_extrapolation;
-    extrapolation_rule_t<MaxExtrapRule, Basis, double> m_max_extrapolation;
+    MinExtrapolationRule m_min_extrapolation;
+    MaxExtrapolationRule m_max_extrapolation;
     BuilderType m_builder;
     EvaluatorType m_evaluator;
 

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -20,8 +20,12 @@
  * @tparam ExecSpace     The Kokkos execution space used for computations.
  * @tparam Basis         The B-spline basis type (uniform or non-uniform).
  * @tparam InterpGrid    The discrete grid on which function values are provided.
- * @tparam MinExtrapRule The ExtrapolationRule applied below the lower boundary.
- * @tparam MaxExtrapRule The ExtrapolationRule applied above the upper boundary.
+ * @tparam MinExtrapRule The extrapolation rule applied below the lower boundary. This
+ *                       may be one of the tags in the ExtrapolationRule namespace
+ *                       (e.g. ExtrapolationRule::Periodic) or a custom, already-concrete
+ *                       extrapolation rule class.
+ * @tparam MaxExtrapRule The extrapolation rule applied above the upper boundary. See
+ *                       MinExtrapRule for the accepted forms.
  * @tparam MinBound      The ddc::SplineBuilderClosure at the lower boundary of the spline builder.
  * @tparam MaxBound      The ddc::SplineBuilderClosure at the upper boundary of the spline builder.
  * @tparam Solver        The spline solver backend (default: LAPACK).
@@ -30,8 +34,8 @@ template <
         class ExecSpace,
         class Basis,
         class InterpGrid,
-        ExtrapolationRule MinExtrapRule,
-        ExtrapolationRule MaxExtrapRule,
+        class MinExtrapRule,
+        class MaxExtrapRule,
         ddc::SplineBuilderClosure MinBound,
         ddc::SplineBuilderClosure MaxBound,
         ddc::SplineSolver Solver = ddc::SplineSolver::LAPACK>
@@ -44,8 +48,16 @@ private:
 
     static_assert(is_periodic == (MinBound == ddc::SplineBuilderClosure::PERIODIC));
     static_assert(is_periodic == (MaxBound == ddc::SplineBuilderClosure::PERIODIC));
-    static_assert(is_periodic == (MinExtrapRule == ExtrapolationRule::PERIODIC));
-    static_assert(is_periodic == (MaxExtrapRule == ExtrapolationRule::PERIODIC));
+    static_assert(
+            is_periodic
+            == std::is_same_v<
+                    extrapolation_rule_t<MinExtrapRule, Basis, double>,
+                    ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
+    static_assert(
+            is_periodic
+            == std::is_same_v<
+                    extrapolation_rule_t<MaxExtrapRule, Basis, double>,
+                    ddc::PeriodicExtrapolationRule<continuous_dimension_type>>);
 
     static_assert(is_spline_basis_v<Basis>);
 

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
+#include <utility>
+
 #include <ddc/kernels/splines.hpp>
 
 #include "ddc_aliases.hpp"
@@ -102,11 +104,17 @@ public:
      *
      * The extrapolation rules are initialised from the discrete space of @c Basis,
      * so the corresponding ddc discrete space must be initialised before construction.
+     * This overload is only available when both extrapolation rules can be built
+     * automatically (they are default-constructible, or the tag ExtrapolationRule::Constant
+     * is used) - otherwise use the overload that takes the extrapolation rules explicitly.
      *
      * @param label A label used to tag parallel regions and memory allocations for profiling.
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
     explicit SplineInterpolator(std::string const& label, IdxRange<InterpGrid> idx_range)
+        requires(
+                is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double> &&
+                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
         : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
         , m_builder(label, idx_range)
@@ -118,12 +126,66 @@ public:
      *
      * The extrapolation rules are initialised from the discrete space of @c Basis,
      * so the corresponding ddc discrete space must be initialised before construction.
+     * This overload is only available when both extrapolation rules can be built
+     * automatically (they are default-constructible, or the tag ExtrapolationRule::Constant
+     * is used) - otherwise use the overload that takes the extrapolation rules explicitly.
      *
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
     explicit SplineInterpolator(IdxRange<InterpGrid> idx_range)
+        requires(
+                is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double> &&
+                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
         : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
+        , m_builder(idx_range)
+        , m_evaluator(m_min_extrapolation, m_max_extrapolation)
+    {
+    }
+
+    /**
+     * @brief Construct a SplineInterpolator on the given interpolation index range,
+     * specifying the extrapolation rules explicitly.
+     *
+     * Use this overload when the chosen extrapolation rule cannot be built
+     * automatically, e.g. a custom extrapolation rule that is not default-constructible
+     * and is not ExtrapolationRule::Constant.
+     *
+     * @param label A label used to tag parallel regions and memory allocations for profiling.
+     * @param idx_range The 1D interpolation index range passed to the builder.
+     * @param min_extrapolation_rule The extrapolation rule to use below the lower boundary.
+     * @param max_extrapolation_rule The extrapolation rule to use above the upper boundary.
+     */
+    explicit SplineInterpolator(
+            std::string const& label,
+            IdxRange<InterpGrid> idx_range,
+            MinExtrapolationRule min_extrapolation_rule,
+            MaxExtrapolationRule max_extrapolation_rule)
+        : m_min_extrapolation(std::move(min_extrapolation_rule))
+        , m_max_extrapolation(std::move(max_extrapolation_rule))
+        , m_builder(label, idx_range)
+        , m_evaluator(m_min_extrapolation, m_max_extrapolation)
+    {
+    }
+
+    /**
+     * @brief Construct a SplineInterpolator on the given interpolation index range,
+     * specifying the extrapolation rules explicitly.
+     *
+     * Use this overload when the chosen extrapolation rule cannot be built
+     * automatically, e.g. a custom extrapolation rule that is not default-constructible
+     * and is not ExtrapolationRule::Constant.
+     *
+     * @param idx_range The 1D interpolation index range passed to the builder.
+     * @param min_extrapolation_rule The extrapolation rule to use below the lower boundary.
+     * @param max_extrapolation_rule The extrapolation rule to use above the upper boundary.
+     */
+    explicit SplineInterpolator(
+            IdxRange<InterpGrid> idx_range,
+            MinExtrapolationRule min_extrapolation_rule,
+            MaxExtrapolationRule max_extrapolation_rule)
+        : m_min_extrapolation(std::move(min_extrapolation_rule))
+        , m_max_extrapolation(std::move(max_extrapolation_rule))
         , m_builder(idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -111,10 +111,9 @@ public:
      * @param label A label used to tag parallel regions and memory allocations for profiling.
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
-    explicit SplineInterpolator(std::string const& label, IdxRange<InterpGrid> idx_range)
-        requires(
-                is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double> &&
-                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
+    explicit SplineInterpolator(std::string const& label, IdxRange<InterpGrid> idx_range) requires(
+            is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double>&&
+                    is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
         : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
         , m_builder(label, idx_range)
@@ -132,10 +131,9 @@ public:
      *
      * @param idx_range The 1D interpolation index range passed to the builder.
      */
-    explicit SplineInterpolator(IdxRange<InterpGrid> idx_range)
-        requires(
-                is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double> &&
-                is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
+    explicit SplineInterpolator(IdxRange<InterpGrid> idx_range) requires(
+            is_extrapolation_rule_auto_constructible_v<MinExtrapRule, Basis, double>&&
+                    is_extrapolation_rule_auto_constructible_v<MaxExtrapRule, Basis, double>)
         : m_min_extrapolation(get_extrapolation<MinExtrapRule, Basis, double>(Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<MaxExtrapRule, Basis, double>(Extremity::BACK))
         , m_builder(idx_range)

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -61,8 +61,8 @@ using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineXClosure,
         SplineXClosure>;
 
@@ -75,15 +75,19 @@ struct LagBasisFloatX : UniformLagrangeBasis<X, 3, float>
 {
 };
 
-using LagrangeInterpolatorX
-        = LagrangeInterpolator<Kokkos::DefaultExecutionSpace, LagBasisX, GridX, PERIODIC, PERIODIC>;
+using LagrangeInterpolatorX = LagrangeInterpolator<
+        Kokkos::DefaultExecutionSpace,
+        LagBasisX,
+        GridX,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic>;
 
 using LagrangeInterpolatorFloatX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagBasisFloatX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         float>;
 
 

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -104,8 +104,8 @@ using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineXClosure,
         SplineXClosure>;
 

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -125,8 +125,8 @@ using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineXClosure,
         SplineXClosure>;
 
@@ -134,8 +134,8 @@ using SplineInterpolatorY = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineYClosure,
         SplineYClosure>;
 

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -105,8 +105,8 @@ using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        PERIODIC,
-        PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         SplineXClosure,
         SplineXClosure>;
 

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -120,8 +120,8 @@ using LagrangeInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagBasisVx,
         GridVx,
-        ExtrapolationRule::CONSTANT,
-        ExtrapolationRule::CONSTANT>;
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant>;
 
 
 // Operators
@@ -129,8 +129,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
-        ExtrapolationRule::CONSTANT,
-        ExtrapolationRule::CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         SplineVxClosure,
         SplineVxClosure>;
 

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -77,8 +77,8 @@ using SplineVxEvaluator = ddc::SplineEvaluator<
         ddc::ConstantExtrapolationRule<Vx>,
         ddc::ConstantExtrapolationRule<Vx>>;
 
-using XExtrapRule = std::
-        conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
+using XExtrapRule
+        = std::conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
 
 using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -77,7 +77,8 @@ using SplineVxEvaluator = ddc::SplineEvaluator<
         ddc::ConstantExtrapolationRule<Vx>,
         ddc::ConstantExtrapolationRule<Vx>>;
 
-ExtrapolationRule constexpr XExtrapRule = X::PERIODIC ? PERIODIC : CONSTANT;
+using XExtrapRule = std::
+        conditional_t<X::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
 
 using SplineInterpolatorX = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
@@ -92,8 +93,8 @@ using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
-        CONSTANT,
-        CONSTANT,
+        ExtrapolationRule::Constant,
+        ExtrapolationRule::Constant,
         SplineVxClosure,
         SplineVxClosure>;
 

--- a/tests/geometryXVx/velocityadvection.cpp
+++ b/tests/geometryXVx/velocityadvection.cpp
@@ -27,8 +27,8 @@ using LagInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
         LagBasisVx,
         GridVx,
-        NULL_VALUE,
-        NULL_VALUE>;
+        ExtrapolationRule::NullValue,
+        ExtrapolationRule::NullValue>;
 
 std::pair<IdxRange<GridX>, IdxRange<GridVx>> Init_idx_range_velocity_adv()
 {

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -267,10 +267,8 @@ public:
     using SplineInterpPointsDDim
             = std::conditional_t<std::is_same_v<DDim, X>, SplineInterpPointsX, SplineInterpPointsY>;
 
-    using SplineExtrapolation = std::conditional_t<
-            DDim::PERIODIC,
-            ExtrapolationRule::Periodic,
-            ExtrapolationRule::Constant>;
+    using SplineExtrapolation = std::
+            conditional_t<DDim::PERIODIC, ExtrapolationRule::Periodic, ExtrapolationRule::Constant>;
 
     using SplineDDimInterpolation = SplineInterpolator<
             Kokkos::DefaultExecutionSpace,

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -466,7 +466,7 @@ public:
     }
 
 private:
-    XExtrapolationRule get_x_bv(Coord<X> xmin, Coord<Y> ymin, Coord<Y> ymax)
+    static XExtrapolationRule get_x_bv(Coord<X> xmin, Coord<Y> ymin, Coord<Y> ymax)
     {
         if constexpr (X::PERIODIC) {
             return XExtrapolationRule();
@@ -474,7 +474,7 @@ private:
             return XExtrapolationRule(xmin, ymin, ymax);
         }
     }
-    YExtrapolationRule get_y_bv(Coord<Y> ymin, Coord<X> xmin, Coord<X> xmax)
+    static YExtrapolationRule get_y_bv(Coord<Y> ymin, Coord<X> xmin, Coord<X> xmax)
     {
         if constexpr (Y::PERIODIC) {
             return YExtrapolationRule();

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -267,8 +267,10 @@ public:
     using SplineInterpPointsDDim
             = std::conditional_t<std::is_same_v<DDim, X>, SplineInterpPointsX, SplineInterpPointsY>;
 
-    static constexpr ExtrapolationRule SplineExtrapolation
-            = DDim::PERIODIC ? ExtrapolationRule::PERIODIC : ExtrapolationRule::CONSTANT;
+    using SplineExtrapolation = std::conditional_t<
+            DDim::PERIODIC,
+            ExtrapolationRule::Periodic,
+            ExtrapolationRule::Constant>;
 
     using SplineDDimInterpolation = SplineInterpolator<
             Kokkos::DefaultExecutionSpace,
@@ -332,16 +334,6 @@ public:
                         Y>>(idxrange, function_to_differentiate, derivative_creator, max_distance);
 
         return max_error;
-    }
-
-private:
-    ExtrapolationRule get_bv(Coord<DDim> dcoord) const
-    {
-        if constexpr (DDim::PERIODIC) {
-            return ExtrapolationRule();
-        } else {
-            return ExtrapolationRule(dcoord);
-        }
     }
 };
 

--- a/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
@@ -43,8 +43,8 @@ using SplineXInterpolator = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        ExtrapolationRule::NULL_VALUE,
-        ExtrapolationRule::NULL_VALUE,
+        ExtrapolationRule::NullValue,
+        ExtrapolationRule::NullValue,
         ddc::SplineBuilderClosure::GREVILLE,
         ddc::SplineBuilderClosure::GREVILLE>;
 

--- a/tests/pde_solvers/femperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femperiodicpoissonsolver.cpp
@@ -59,8 +59,8 @@ using SplineXInterpolator = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesX,
         GridX,
-        ExtrapolationRule::PERIODIC,
-        ExtrapolationRule::PERIODIC,
+        ExtrapolationRule::Periodic,
+        ExtrapolationRule::Periodic,
         ddc::SplineBuilderClosure::PERIODIC,
         ddc::SplineBuilderClosure::PERIODIC>;
 


### PR DESCRIPTION
PR #568 introduced the enum `ExtrapolationRule`. While this simplified the declarations of spline and Lagrange interpolators it made it impossible to use a custom extrapolation rule. This PR modifies the logic to use tag structs in a `ExtrapolationRule` namespace. This allows us to choose between a pre-defined extrapolation rule or a custom rule.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
