### PR TITLE
Add extrapolation to `GMGPolarPoissonLikeSolver` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a `extrapolation_rule` argument to `GMGPolarPoissonLikeSolver`. Default no extrapolation. 
+- Add a `extrapolation_rule` argument to `GMGPolarPoissonLikeSolver`. Default no extrapolation.
 - Add a new constructor for `GaussLegendre` from an index range describing the cell edges.
 - Add a `GradientCreator` operator to group derivative calculations.
 - Add a `NDLagrangeEvaluator` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a `extrapolation_rule` argument to `GMGPolarPoissonLikeSolver`. Default no extrapolation.
+- Add an `extrapolation_rule` argument to `GMGPolarPoissonLikeSolver`. Default no extrapolation.
 - Add a new constructor for `GaussLegendre` from an index range describing the cell edges.
 - Add a `GradientCreator` operator to group derivative calculations.
 - Add a `NDLagrangeEvaluator` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a `extrapolation_rule` argument to `GMGPolarPoissonLikeSolver`. Default no extrapolation. 
 - Add a new constructor for `GaussLegendre` from an index range describing the cell edges.
 - Add a `GradientCreator` operator to group derivative calculations.
 - Add a `NDLagrangeEvaluator` class.

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -206,7 +206,7 @@ public:
             ToPhysicalMapping to_physical,
             SplineBuilder const& builder,
             SplineEvaluator const& evaluator,
-            ExtrapolationType const& extrapolation_rule = ExtrapolationType::NONE,
+            ExtrapolationType const extrapolation_rule = ExtrapolationType::NONE,
             std::optional<int> max_iterations = std::nullopt,
             std::optional<double> absTol = std::nullopt,
             std::optional<double> relTol = std::nullopt)
@@ -222,7 +222,7 @@ public:
                   get_const_field(m_coeff_beta))
         , m_max_iterations(max_iterations.value_or(100))
         , m_absTol(absTol.value_or(1e-10))
-        , m_relTol(relTol.value_or(1e-7))
+        , m_relTol(relTol.value_or(1e-6))
     {
     }
 

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -181,7 +181,7 @@ private:
     DomainGeometry const m_domain_geom;
     SplineBuilder const& m_builder;
     SplineEvaluator const& m_evaluator;
-    ExtrapolationType const& m_extrapolation_rule;
+    ExtrapolationType const m_extrapolation_rule;
     SplineRThetaMem m_coeff_alpha;
     SplineRThetaMem m_coeff_beta;
     DensityCoeffs const m_density_coeffs;

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -181,6 +181,7 @@ private:
     DomainGeometry const m_domain_geom;
     SplineBuilder const& m_builder;
     SplineEvaluator const& m_evaluator;
+    ExtrapolationType const& m_extrapolation_rule;
     SplineRThetaMem m_coeff_alpha;
     SplineRThetaMem m_coeff_beta;
     DensityCoeffs const m_density_coeffs;
@@ -204,12 +205,14 @@ public:
             ToPhysicalMapping to_physical,
             SplineBuilder const& builder,
             SplineEvaluator const& evaluator,
+            ExtrapolationType const& extrapolation_rule = ExtrapolationType::NONE,
             std::optional<int> max_iterations = std::nullopt,
             std::optional<double> absTol = std::nullopt,
             std::optional<double> relTol = std::nullopt)
         : m_domain_geom(to_physical)
         , m_builder(builder)
         , m_evaluator(evaluator)
+        , m_extrapolation_rule(extrapolation_rule)
         , m_coeff_alpha(get_spline_idx_range(m_builder))
         , m_coeff_beta(get_spline_idx_range(m_builder))
         , m_density_coeffs(
@@ -282,7 +285,7 @@ public:
         solver.cacheDomainGeometry(true);
 
         // --- Multigrid settings --- //
-        solver.extrapolation(ExtrapolationType::IMPLICIT_EXTRAPOLATION); // Select extrapolation
+        solver.extrapolation(m_extrapolation_rule); // Select extrapolation
         solver.maxLevels(-1); // Max multigrid levels (-1 = use deepest possible)
         solver.preSmoothingSteps(1); // Smoothing before coarse-grid correction
         solver.postSmoothingSteps(1); // Smoothing after coarse-grid correction

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -197,6 +197,7 @@ public:
      * @param[in] to_physical The mapping from the logical to the physical domain.
      * @param[in] builder A builder to construct the coefficients of the interpolation.
      * @param[in] evaluator The evaluator for the interpolation.
+     * @param[in] extrapolation_rule A parameter to pass extrapolation rule to GMGPolar, default ExtrapolationType::NONE.
      * @param[in] max_iterations The maximum number of iterations that the solver should carry out.
      * @param[in] absTol The absolute tolerance for the convergence of the solver.
      * @param[in] relTol The relative tolerance for the convergence of the solver.

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -222,7 +222,7 @@ public:
                   get_const_field(m_coeff_beta))
         , m_max_iterations(max_iterations.value_or(100))
         , m_absTol(absTol.value_or(1e-10))
-        , m_relTol(relTol.value_or(1e-6))
+        , m_relTol(relTol.value_or(1e-7))
     {
     }
 

--- a/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
@@ -139,7 +139,7 @@ void test_GMGPolarIntegration__PoissonEquation()
 
     std::cout << "Max L-inf error: " << max_err << std::endl;
 
-    EXPECT_LT(max_err, 1e-6);
+    EXPECT_LT(max_err, 1e-5);
 }
 TEST(GMGPolarIntegration, PoissonEquation)
 {

--- a/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
@@ -66,7 +66,7 @@ void test_GMGPolarIntegration__PoissonEquation()
 {
     CoordR const r_min(1e-5);
     CoordR const r_max(1.0);
-    IdxStepR const r_ncells(16 - BSDegreeR + 1); // To have a number of grid cells that is 2**N
+    IdxStepR const r_ncells(32 - BSDegreeR + 1); // To have a number of grid cells that is 2**N
 
     CoordTheta const theta_min(0.0);
     CoordTheta const theta_max(2.0 * M_PI);

--- a/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
+++ b/tests/geometryRTheta/polar_poisson/gmgpolarpoissonsolver.cpp
@@ -139,7 +139,7 @@ void test_GMGPolarIntegration__PoissonEquation()
 
     std::cout << "Max L-inf error: " << max_err << std::endl;
 
-    EXPECT_LT(max_err, 1e-5);
+    EXPECT_LT(max_err, 1e-6);
 }
 TEST(GMGPolarIntegration, PoissonEquation)
 {


### PR DESCRIPTION
Add extrapolation rule as a parameter of `GMGPolarPoissonLikeSolver` to set GMGPolar multigrid settings. By default the value is `Extrapolation::None`.
Add a private member m_extrapolation_rule to the `GMGPolarPoissonLikeSolver` class.

This fixes the extrapolation warning [seen in the poisson-mini-app](https://github.com/gyselax/gysela-mini-app_poisson/pull/7#issuecomment-4878593933).

---

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?