### PR TITLE
Missing template parameter in `SplineInterpolator` constructor initialization on `get_extrapolation`

### DIFF
--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -123,7 +123,7 @@ public:
         : m_min_extrapolation(get_extrapolation<MinExtrapolationRule, InterpGrid, double, Basis>(
                 Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<MaxExtrapolationRule, InterpGrid, double, Basis>(
-                Extremity::BACK))
+                  Extremity::BACK))
         , m_builder(label, idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -120,10 +120,10 @@ public:
                             InterpGrid,
                             double,
                             Basis>)
-        : m_min_extrapolation(
-                get_extrapolation<MinExtrapolationRule, Basis, double>(Extremity::FRONT))
-        , m_max_extrapolation(
-                  get_extrapolation<MaxExtrapolationRule, Basis, double>(Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<MinExtrapolationRule, InterpGrid, double, Basis>(
+                Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<MaxExtrapolationRule, InterpGrid, double, Basis>(
+                Extremity::BACK))
         , m_builder(label, idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {


### PR DESCRIPTION
Closes https://github.com/gyselax/gyselalibxx/issues/731

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
