### PR TITLE
Group spline boundary closure rules by dimension in `SplineInterpolator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove the C compiler dependency.
 - Make the dependency on GoogleTest dependent on the CMake option `GYSELALIBXX_BUILD_TESTING`.
 - Group extrapolation rules by dimension in `SplineInterpolator` and `LagrangeInterpolator`.
+- Group spline boundary closure rules by dimension in `SplineInterpolator`.
 
 ### Deprecated
 

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -50,16 +50,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         XExtrapRule,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
         ExtrapolationRule::Constant_Constant,
-        SplineVxClosure,
-        SplineVxClosure>;
+        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/simulations/geometryXVx/spline_definitions_xvx.hpp
+++ b/simulations/geometryXVx/spline_definitions_xvx.hpp
@@ -50,14 +50,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         XExtrapRule,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
         ExtrapolationRule::Constant_Constant,
-        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
+        SplineBoundaryClosures<SplineVxClosure, SplineVxClosure>>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/simulations/geometryXY/spline_definitions_xy.hpp
+++ b/simulations/geometryXY/spline_definitions_xy.hpp
@@ -46,16 +46,14 @@ using SplineXInterpolator = SplineInterpolator<
         BSplinesX,
         GridX,
         SplineXExtrapolation,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 using SplineYInterpolator = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
         SplineYExtrapolation,
-        SplineYClosure,
-        SplineYClosure>;
+        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
 
 // Spline index range
 using IdxRangeBSX = IdxRange<BSplinesX>;

--- a/simulations/geometryXY/spline_definitions_xy.hpp
+++ b/simulations/geometryXY/spline_definitions_xy.hpp
@@ -46,14 +46,14 @@ using SplineXInterpolator = SplineInterpolator<
         BSplinesX,
         GridX,
         SplineXExtrapolation,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 using SplineYInterpolator = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
         SplineYExtrapolation,
-        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
+        SplineBoundaryClosures<SplineYClosure, SplineYClosure>>;
 
 // Spline index range
 using IdxRangeBSX = IdxRange<BSplinesX>;

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -48,14 +48,14 @@ using SplineInterpolatorY = SplineInterpolator<
         BSplinesY,
         GridY,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
+        SplineBoundaryClosures<SplineYClosure, SplineYClosure>>;
 
 using SplineInterpolatorVy = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVy,
         GridVy,
         ExtrapolationRule::Constant_Constant,
-        SplineBoundaryClosures {SplineVyClosure, SplineVyClosure}>;
+        SplineBoundaryClosures<SplineVyClosure, SplineVyClosure>>;
 
 using IdxRangeBSY = IdxRange<BSplinesY>;
 using IdxRangeBSXY = IdxRange<BSplinesX, BSplinesY>;

--- a/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/spline_definitions_xyvxvy.hpp
@@ -48,16 +48,14 @@ using SplineInterpolatorY = SplineInterpolator<
         BSplinesY,
         GridY,
         ExtrapolationRule::Periodic,
-        SplineYClosure,
-        SplineYClosure>;
+        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
 
 using SplineInterpolatorVy = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVy,
         GridVy,
         ExtrapolationRule::Constant_Constant,
-        SplineVyClosure,
-        SplineVyClosure>;
+        SplineBoundaryClosures {SplineVyClosure, SplineVyClosure}>;
 
 using IdxRangeBSY = IdxRange<BSplinesY>;
 using IdxRangeBSXY = IdxRange<BSplinesX, BSplinesY>;

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -7,6 +7,33 @@
 #include "ddc_aliases.hpp"
 #include "extrapolation_rule_choice.hpp"
 
+/**
+ * @brief Groups the lower (min) and upper (max) ddc::SplineBuilderClosure of a
+ * spline builder into a single non-type template argument.
+ */
+struct SplineBoundaryClosures
+{
+    ddc::SplineBuilderClosure min;
+    ddc::SplineBuilderClosure max;
+};
+
+/// @brief Predefined SplineBoundaryClosures for the common case where the same
+/// closure applies at both boundaries.
+namespace SplineBoundaryClosure {
+inline constexpr SplineBoundaryClosures Periodic {
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC};
+inline constexpr SplineBoundaryClosures Greville {
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE};
+inline constexpr SplineBoundaryClosures Hermite {
+        ddc::SplineBuilderClosure::HERMITE,
+        ddc::SplineBuilderClosure::HERMITE};
+inline constexpr SplineBoundaryClosures HomogeneousHermite {
+        ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
+        ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE};
+} // namespace SplineBoundaryClosure
+
 namespace detail {
 
 /**
@@ -17,7 +44,7 @@ namespace detail {
  * concepts::Interpolation concept and is the recommended way to create a
  * spline interpolation for use with advection operators and similar algorithms.
  *
- * The boundary condition (MinBound / MaxBound) and extrapolation rule
+ * The boundary condition (BoundaryClosures) and extrapolation rule
  * (the Min/Max pair in ExtrapRules) must be consistent: both must be PERIODIC for
  * periodic dimensions and both must be non-PERIODIC for non-periodic dimensions.
  *
@@ -27,8 +54,8 @@ namespace detail {
  * @tparam ExtrapRules   A ddc::detail::TypeSeq<MinExtrapolationRule, MaxExtrapolationRule> pairing the
  *                       extrapolation rules applied below/above the boundary. Where
  *                       MinExtrapolationRule and MaxExtrapolationRule are extrapolation rule classes.
- * @tparam MinBound      The ddc::SplineBuilderClosure at the lower boundary of the spline builder.
- * @tparam MaxBound      The ddc::SplineBuilderClosure at the upper boundary of the spline builder.
+ * @tparam BoundaryClosures A SplineBoundaryClosures pairing the ddc::SplineBuilderClosure
+ *                       applied at the lower/upper boundary of the spline builder.
  * @tparam Solver        The spline solver backend (default: LAPACK).
  */
 template <
@@ -36,8 +63,7 @@ template <
         class Basis,
         class InterpGrid,
         class ExtrapRules,
-        ddc::SplineBuilderClosure MinBound,
-        ddc::SplineBuilderClosure MaxBound,
+        SplineBoundaryClosures BoundaryClosures,
         ddc::SplineSolver Solver>
 class SplineInterpolator
 {
@@ -46,6 +72,9 @@ private:
 
     using MinExtrapolationRule = ddc::type_seq_element_t<0, ExtrapRules>;
     using MaxExtrapolationRule = ddc::type_seq_element_t<1, ExtrapRules>;
+
+    static constexpr ddc::SplineBuilderClosure MinBound = BoundaryClosures.min;
+    static constexpr ddc::SplineBuilderClosure MaxBound = BoundaryClosures.max;
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
@@ -243,14 +272,12 @@ template <
         class Basis,
         class InterpGrid,
         class ExtrapRules,
-        ddc::SplineBuilderClosure MinBound,
-        ddc::SplineBuilderClosure MaxBound,
+        SplineBoundaryClosures BoundaryClosures,
         ddc::SplineSolver Solver = ddc::SplineSolver::LAPACK>
 using SplineInterpolator = detail::SplineInterpolator<
         ExecSpace,
         Basis,
         InterpGrid,
         extrapolation_rule_t<ExtrapRules, InterpGrid, double, Basis>,
-        MinBound,
-        MaxBound,
+        BoundaryClosures,
         Solver>;

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -13,22 +13,34 @@
  */
 struct SplineBoundaryClosures
 {
+    /// @brief The ddc::SplineBuilderClosure at the lower boundary of the spline builder.
     ddc::SplineBuilderClosure min;
+    /// @brief The ddc::SplineBuilderClosure at the upper boundary of the spline builder.
     ddc::SplineBuilderClosure max;
 };
 
 /// @brief Predefined SplineBoundaryClosures for the common case where the same
 /// closure applies at both boundaries.
 namespace SplineBoundaryClosure {
+
+/// @brief Convenience pairing of ddc::SplineBuilderClosure::PERIODIC for both boundaries.
 inline constexpr SplineBoundaryClosures
         Periodic {ddc::SplineBuilderClosure::PERIODIC, ddc::SplineBuilderClosure::PERIODIC};
+
+/// @brief Convenience pairing of ddc::SplineBuilderClosure::GREVILLE for both boundaries.
 inline constexpr SplineBoundaryClosures
         Greville {ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE};
+
+/// @brief Convenience pairing of ddc::SplineBuilderClosure::HERMITE for both boundaries.
 inline constexpr SplineBoundaryClosures
         Hermite {ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::HERMITE};
+
+/// @brief Convenience pairing of ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE for both
+/// boundaries.
 inline constexpr SplineBoundaryClosures HomogeneousHermite {
         ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
         ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE};
+
 } // namespace SplineBoundaryClosure
 
 namespace detail {

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -20,15 +20,12 @@ struct SplineBoundaryClosures
 /// @brief Predefined SplineBoundaryClosures for the common case where the same
 /// closure applies at both boundaries.
 namespace SplineBoundaryClosure {
-inline constexpr SplineBoundaryClosures Periodic {
-        ddc::SplineBuilderClosure::PERIODIC,
-        ddc::SplineBuilderClosure::PERIODIC};
-inline constexpr SplineBoundaryClosures Greville {
-        ddc::SplineBuilderClosure::GREVILLE,
-        ddc::SplineBuilderClosure::GREVILLE};
-inline constexpr SplineBoundaryClosures Hermite {
-        ddc::SplineBuilderClosure::HERMITE,
-        ddc::SplineBuilderClosure::HERMITE};
+inline constexpr SplineBoundaryClosures
+        Periodic {ddc::SplineBuilderClosure::PERIODIC, ddc::SplineBuilderClosure::PERIODIC};
+inline constexpr SplineBoundaryClosures
+        Greville {ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE};
+inline constexpr SplineBoundaryClosures
+        Hermite {ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::HERMITE};
 inline constexpr SplineBoundaryClosures HomogeneousHermite {
         ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
         ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE};

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -11,12 +11,13 @@
  * @brief Groups the lower (min) and upper (max) ddc::SplineBuilderClosure of a
  * spline builder into a single non-type template argument.
  */
+template <ddc::SplineBuilderClosure MinClosure, ddc::SplineBuilderClosure MaxClosure>
 struct SplineBoundaryClosures
 {
     /// @brief The ddc::SplineBuilderClosure at the lower boundary of the spline builder.
-    ddc::SplineBuilderClosure min;
+    using min = std::integral_constant<ddc::SplineBuilderClosure, MinClosure>;
     /// @brief The ddc::SplineBuilderClosure at the upper boundary of the spline builder.
-    ddc::SplineBuilderClosure max;
+    using max = std::integral_constant<ddc::SplineBuilderClosure, MaxClosure>;
 };
 
 /// @brief Predefined SplineBoundaryClosures for the common case where the same
@@ -24,22 +25,25 @@ struct SplineBoundaryClosures
 namespace SplineBoundaryClosure {
 
 /// @brief Convenience pairing of ddc::SplineBuilderClosure::PERIODIC for both boundaries.
-inline constexpr SplineBoundaryClosures
-        Periodic {ddc::SplineBuilderClosure::PERIODIC, ddc::SplineBuilderClosure::PERIODIC};
+using Periodic = SplineBoundaryClosures<
+        ddc::SplineBuilderClosure::PERIODIC,
+        ddc::SplineBuilderClosure::PERIODIC>;
 
 /// @brief Convenience pairing of ddc::SplineBuilderClosure::GREVILLE for both boundaries.
-inline constexpr SplineBoundaryClosures
-        Greville {ddc::SplineBuilderClosure::GREVILLE, ddc::SplineBuilderClosure::GREVILLE};
+using Greville_Greville = SplineBoundaryClosures<
+        ddc::SplineBuilderClosure::GREVILLE,
+        ddc::SplineBuilderClosure::GREVILLE>;
 
 /// @brief Convenience pairing of ddc::SplineBuilderClosure::HERMITE for both boundaries.
-inline constexpr SplineBoundaryClosures
-        Hermite {ddc::SplineBuilderClosure::HERMITE, ddc::SplineBuilderClosure::HERMITE};
+using Hermite_Hermite = SplineBoundaryClosures<
+        ddc::SplineBuilderClosure::HERMITE,
+        ddc::SplineBuilderClosure::HERMITE>;
 
 /// @brief Convenience pairing of ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE for both
 /// boundaries.
-inline constexpr SplineBoundaryClosures HomogeneousHermite {
+using HomogeneousHermite_HomogeneousHermite = SplineBoundaryClosures<
         ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE,
-        ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE};
+        ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE>;
 
 } // namespace SplineBoundaryClosure
 

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -76,7 +76,7 @@ template <
         class Basis,
         class InterpGrid,
         class ExtrapRules,
-        SplineBoundaryClosures BoundaryClosures,
+        class BoundaryClosures,
         ddc::SplineSolver Solver>
 class SplineInterpolator
 {
@@ -86,8 +86,8 @@ private:
     using MinExtrapolationRule = ddc::type_seq_element_t<0, ExtrapRules>;
     using MaxExtrapolationRule = ddc::type_seq_element_t<1, ExtrapRules>;
 
-    static constexpr ddc::SplineBuilderClosure MinBound = BoundaryClosures.min;
-    static constexpr ddc::SplineBuilderClosure MaxBound = BoundaryClosures.max;
+    static constexpr ddc::SplineBuilderClosure MinBound = BoundaryClosures::min::value;
+    static constexpr ddc::SplineBuilderClosure MaxBound = BoundaryClosures::max::value;
 
     static constexpr bool is_periodic = continuous_dimension_type::PERIODIC;
 
@@ -285,7 +285,7 @@ template <
         class Basis,
         class InterpGrid,
         class ExtrapRules,
-        SplineBoundaryClosures BoundaryClosures,
+        class BoundaryClosures,
         ddc::SplineSolver Solver = ddc::SplineSolver::LAPACK>
 using SplineInterpolator = detail::SplineInterpolator<
         ExecSpace,

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -62,8 +62,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 // Lagrange basis for the advection field interpolation
 struct LagBasisX : UniformLagrangeBasis<X, 3, double>

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -62,7 +62,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 // Lagrange basis for the advection field interpolation
 struct LagBasisX : UniformLagrangeBasis<X, 3, double>

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -105,7 +105,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 
 class XVxAdvection1DTest : public ::testing::Test

--- a/tests/advection/1d_advection_xvx.cpp
+++ b/tests/advection/1d_advection_xvx.cpp
@@ -105,8 +105,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 
 class XVxAdvection1DTest : public ::testing::Test

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -126,14 +126,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 using SplineInterpolatorY = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
+        SplineBoundaryClosures<SplineYClosure, SplineYClosure>>;
 
 
 

--- a/tests/advection/1d_advection_xyvxvy.cpp
+++ b/tests/advection/1d_advection_xyvxvy.cpp
@@ -126,16 +126,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 using SplineInterpolatorY = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesY,
         GridY,
         ExtrapolationRule::Periodic,
-        SplineYClosure,
-        SplineYClosure>;
+        SplineBoundaryClosures {SplineYClosure, SplineYClosure}>;
 
 
 

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -106,8 +106,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 
 class Spatial1DAdvectionTest : public ::testing::Test

--- a/tests/advection/spatial_advection_1d.cpp
+++ b/tests/advection/spatial_advection_1d.cpp
@@ -106,7 +106,7 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 
 class Spatial1DAdvectionTest : public ::testing::Test

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -129,8 +129,7 @@ using SplineInterpolatorVx = SplineInterpolator<
         BSplinesVx,
         GridVx,
         ddc::detail::TypeSeq<ExtrapolationRule::Constant, ExtrapolationRule::Constant>,
-        SplineVxClosure,
-        SplineVxClosure>;
+        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
 
 
 class Velocity1DAdvectionTest : public ::testing::Test

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -129,7 +129,7 @@ using SplineInterpolatorVx = SplineInterpolator<
         BSplinesVx,
         GridVx,
         ddc::detail::TypeSeq<ExtrapolationRule::Constant, ExtrapolationRule::Constant>,
-        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
+        SplineBoundaryClosures<SplineVxClosure, SplineVxClosure>>;
 
 
 class Velocity1DAdvectionTest : public ::testing::Test

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -87,16 +87,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         XExtrapRule,
-        SplineXClosure,
-        SplineXClosure>;
+        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
         ExtrapolationRule::Constant_Constant,
-        SplineVxClosure,
-        SplineVxClosure>;
+        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/tests/geometryXVx/spline_definitions_xvx.hpp
+++ b/tests/geometryXVx/spline_definitions_xvx.hpp
@@ -87,14 +87,14 @@ using SplineInterpolatorX = SplineInterpolator<
         BSplinesX,
         GridX,
         XExtrapRule,
-        SplineBoundaryClosures {SplineXClosure, SplineXClosure}>;
+        SplineBoundaryClosures<SplineXClosure, SplineXClosure>>;
 
 using SplineInterpolatorVx = SplineInterpolator<
         Kokkos::DefaultExecutionSpace,
         BSplinesVx,
         GridVx,
         ExtrapolationRule::Constant_Constant,
-        SplineBoundaryClosures {SplineVxClosure, SplineVxClosure}>;
+        SplineBoundaryClosures<SplineVxClosure, SplineVxClosure>>;
 
 using IdxRangeBSX = IdxRange<BSplinesX>;
 

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -277,7 +277,7 @@ public:
             BSplinesDDim,
             GridDDim,
             SplineExtrapolation,
-            SplineBoundaryClosures {SplineClosure, SplineClosure}>;
+            SplineBoundaryClosures<SplineClosure, SplineClosure>>;
 
 public:
     PartialDerivativeTestSpline1D(

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -277,8 +277,7 @@ public:
             BSplinesDDim,
             GridDDim,
             SplineExtrapolation,
-            SplineClosure,
-            SplineClosure>;
+            SplineBoundaryClosures {SplineClosure, SplineClosure}>;
 
 public:
     PartialDerivativeTestSpline1D(

--- a/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
@@ -44,7 +44,7 @@ using SplineXInterpolator = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Null_Null,
-        SplineBoundaryClosure::Greville>;
+        SplineBoundaryClosure::Greville_Greville>;
 
 using DFieldMemX = DFieldMem<IdxRangeX>;
 

--- a/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femnonperiodicpoissonsolver.cpp
@@ -44,8 +44,7 @@ using SplineXInterpolator = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Null_Null,
-        ddc::SplineBuilderClosure::GREVILLE,
-        ddc::SplineBuilderClosure::GREVILLE>;
+        SplineBoundaryClosure::Greville>;
 
 using DFieldMemX = DFieldMem<IdxRangeX>;
 

--- a/tests/pde_solvers/femperiodicpoissonsolver.cpp
+++ b/tests/pde_solvers/femperiodicpoissonsolver.cpp
@@ -60,8 +60,7 @@ using SplineXInterpolator = SplineInterpolator<
         BSplinesX,
         GridX,
         ExtrapolationRule::Periodic,
-        ddc::SplineBuilderClosure::PERIODIC,
-        ddc::SplineBuilderClosure::PERIODIC>;
+        SplineBoundaryClosure::Periodic>;
 
 using DFieldMemX = DFieldMem<IdxRangeX>;
 using DFieldMemBatchX = DFieldMem<IdxRangeBatchX>;


### PR DESCRIPTION
Group spline boundary closure rules by dimension in `SplineInterpolator`. This matches the implementation for the extrapolation rules and will make it easier to identify how spline boundary closure rules are grouped for ND interpolators.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
