### PR TITLE
Extend `LagrangeInterpolation` to handle ND cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove the C compiler dependency.
 - Make the dependency on GoogleTest dependent on the CMake option `GYSELALIBXX_BUILD_TESTING`.
 - Group extrapolation rules by dimension in `SplineInterpolator` and `LagrangeInterpolator`.
+- Change the `LagrangeInterpolator` templates to allow ND cases to be handled.
 
 ### Deprecated
 

--- a/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
+++ b/simulations/geometryXYVxVy/lagrange_definitions_xyvxvy.hpp
@@ -56,29 +56,29 @@ ddc::SplineBuilderClosure constexpr LagrangeVyClosure
 // SplineBuilder and SplineEvaluator definition
 using LagrangeInterpolatorX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagrangeX,
-        GridX,
-        ExtrapolationRule::Periodic,
-        Real>;
+        Real,
+        IdxRange<LagrangeX>,
+        IdxRange<GridX>,
+        ExtrapolationRule::Periodic>;
 using LagrangeInterpolatorY = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagrangeY,
-        GridY,
-        ExtrapolationRule::Periodic,
-        Real>;
+        Real,
+        IdxRange<LagrangeY>,
+        IdxRange<GridY>,
+        ExtrapolationRule::Periodic>;
 
 using LagrangeInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagrangeVx,
-        GridVx,
-        ddc::detail::TypeSeq<ExtrapolationRule::Constant, ExtrapolationRule::Constant>,
-        Real>;
+        Real,
+        IdxRange<LagrangeVx>,
+        IdxRange<GridVx>,
+        ExtrapolationRule::Constant_Constant>;
 using LagrangeInterpolatorVy = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagrangeVy,
-        GridVy,
-        ddc::detail::TypeSeq<ExtrapolationRule::Constant, ExtrapolationRule::Constant>,
-        Real>;
+        Real,
+        IdxRange<LagrangeVy>,
+        IdxRange<GridVy>,
+        ExtrapolationRule::Constant_Constant>;
 
 using IdxRangeLY = IdxRange<LagrangeY>;
 using IdxRangeLXY = IdxRange<LagrangeX, LagrangeY>;

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -219,11 +219,31 @@ public:
 
 private:
     template <class Rule>
-    using Min = ddc::type_seq_element_t<0, Rule>;
+    using MinRule = ddc::type_seq_element_t<0, Rule>;
 
     template <class Rule>
     using MaxRule = ddc::type_seq_element_t<1, Rule>;
 
+public:
+    /// @brief The NDIdentityInterpolationBuilder type built from the template parameters.
+    using BuilderType = NDIdentityInterpolationBuilder<
+            ExecSpace,
+            memory_space,
+            DataType,
+            IdxRange<Grid1D...>,
+            IdxRange<Basis...>>;
+
+    /// @brief The NDLagrangeEvaluator type built from the template parameters.
+    using EvaluatorType = NDLagrangeEvaluator<LagrangeEvaluator<
+            ExecSpace,
+            memory_space,
+            DataType,
+            Basis,
+            Grid1D,
+            MinRule<ExtrapRules>,
+            MaxRule<ExtrapRules>>...>;
+
+private:
     template <class B>
     using CoeffGrid = ddc::type_seq_element_t<
             ddc::type_seq_rank_v<B, ddc::detail::TypeSeq<Basis...>>,
@@ -247,24 +267,6 @@ private:
             "periodic");
 
 public:
-    /// @brief The NDIdentityInterpolationBuilder type built from the template parameters.
-    using BuilderType = NDIdentityInterpolationBuilder<
-            ExecSpace,
-            memory_space,
-            DataType,
-            IdxRange<Grid1D...>,
-            IdxRange<Basis...>>;
-
-    /// @brief The NDLagrangeEvaluator type built from the template parameters.
-    using EvaluatorType = NDLagrangeEvaluator<LagrangeEvaluator<
-            ExecSpace,
-            memory_space,
-            DataType,
-            Basis,
-            Grid1D,
-            MinRule<ExtrapRules>,
-            MaxRule<ExtrapRules>>...>;
-
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
     {

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -8,6 +8,8 @@
 #include "lagrange_basis_non_uniform.hpp"
 #include "lagrange_basis_uniform.hpp"
 #include "lagrange_evaluator.hpp"
+#include "nd_identity_interpolation_builder.hpp"
+#include "nd_lagrange_evaluator.hpp"
 
 namespace detail {
 
@@ -167,6 +169,276 @@ public:
     }
 };
 
+/**
+ * @brief An owning interpolation object that bundles an ND Lagrange builder and evaluator.
+ *
+ * NDLagrangeInterpolator constructs and owns a matching NDIdentityInterpolationBuilder and
+ * NDLagrangeEvaluator for a tensor-product grid of dimensions. It satisfies the
+ * concepts::Interpolation concept and is the ND generalisation of LagrangeInterpolator.
+ *
+ * The builder is an identity operation: it passes function values on the interpolation
+ * mesh directly as coefficients to the evaluator, which then performs local polynomial
+ * reconstruction via a tensor product of 1D Lagrange bases.
+ *
+ * @tparam ExecSpace     The Kokkos execution space used for computations.
+ * @tparam IdxRangeBasis The ND index range for the Lagrange basis types, of the form
+ *                       IdxRange<Basis1, ..., BasisN>, one per interpolation dimension.
+ * @tparam IdxRangeInterpGrid The ND index range for the interpolation mesh, of the form
+ *                       IdxRange<Grid1, ..., GridN>, in the same order as IdxRangeBasis.
+ * @tparam ExtrapRulesSeq A ddc::detail::TypeSeq<ExtrapRules1, ..., ExtrapRulesN> pairing,
+ *                       for each dimension, the extrapolation rules applied below/above
+ *                       the boundary (each ExtrapRulesI is itself a
+ *                       ddc::detail::TypeSeq<MinExtrapolationRuleI, MaxExtrapolationRuleI>).
+ * @tparam DataType      The floating-point type of the function values (default: double).
+ */
+template <
+        class ExecSpace,
+        class IdxRangeBasis,
+        class IdxRangeInterpGrid,
+        class ExtrapRulesSeq,
+        class DataType = double>
+class NDLagrangeInterpolator;
+
+/// The implementation of NDLagrangeInterpolator. This is separate to allow variadic packs.
+template <class ExecSpace, class... Basis, class... Grid, class... ExtrapRules, class DataType>
+class NDLagrangeInterpolator<
+        ExecSpace,
+        IdxRange<Basis...>,
+        IdxRange<Grid...>,
+        ddc::detail::TypeSeq<ExtrapRules...>,
+        DataType>
+{
+    static_assert(sizeof...(Basis) == sizeof...(Grid));
+    static_assert(sizeof...(Basis) == sizeof...(ExtrapRules));
+    static_assert(sizeof...(Basis) > 0);
+    static_assert((is_lagrange_basis_v<Basis> && ...));
+
+public:
+    /// @brief The type of the Kokkos memory space used by this class.
+    using memory_space = typename ExecSpace::memory_space;
+
+private:
+    template <class Rule>
+    using MinOf = ddc::type_seq_element_t<0, Rule>;
+
+    template <class Rule>
+    using MaxOf = ddc::type_seq_element_t<1, Rule>;
+
+    template <class B>
+    using CoeffGridOf = typename B::template Impl<B, memory_space>::knot_grid;
+
+    static_assert(
+            ((Basis::is_periodic()
+              == std::is_same_v<
+                      MinOf<ExtrapRules>,
+                      ddc::PeriodicExtrapolationRule<
+                              typename Basis::continuous_dimension_type>>)&&...),
+            "PeriodicExtrapolationRule has to be used if and only if the dimension is "
+            "periodic");
+    static_assert(
+            ((Basis::is_periodic()
+              == std::is_same_v<
+                      MaxOf<ExtrapRules>,
+                      ddc::PeriodicExtrapolationRule<
+                              typename Basis::continuous_dimension_type>>)&&...),
+            "PeriodicExtrapolationRule has to be used if and only if the dimension is "
+            "periodic");
+
+public:
+    /// @brief The NDIdentityInterpolationBuilder type built from the template parameters.
+    using BuilderType = NDIdentityInterpolationBuilder<
+            ExecSpace,
+            memory_space,
+            DataType,
+            IdxRange<Grid...>,
+            IdxRange<Basis...>>;
+
+    /// @brief The NDLagrangeEvaluator type built from the template parameters.
+    using EvaluatorType = NDLagrangeEvaluator<LagrangeEvaluator<
+            ExecSpace,
+            memory_space,
+            DataType,
+            Basis,
+            Grid,
+            MinOf<ExtrapRules>,
+            MaxOf<ExtrapRules>>...>;
+
+    /// @brief The number of interpolation dimensions.
+    static constexpr std::size_t rank()
+    {
+        return sizeof...(Grid);
+    }
+
+private:
+    BuilderType m_builder;
+    EvaluatorType m_evaluator;
+
+public:
+    /**
+     * @brief Construct an NDLagrangeInterpolator.
+     *
+     * The extrapolation rules are initialised from the discrete spaces of the Lagrange
+     * bases, so the corresponding ddc discrete spaces must be initialised before
+     * construction. No index range is required because the identity builder needs none.
+     * This overload is only available when every dimension's extrapolation rules can be
+     * built automatically (see is_extrapolation_rule_auto_constructible_v) - otherwise use
+     * the overload that takes the extrapolation rules explicitly.
+     *
+     * @param idx_range The index range on which the interpolator will act. This is
+     *                  unused but is included to match the SplineInterpolator interface.
+     */
+    explicit NDLagrangeInterpolator(IdxRange<Grid...> idx_range = IdxRange<Grid...> {}) requires(
+            (is_extrapolation_rule_auto_constructible_v<
+                     MinOf<ExtrapRules>,
+                     CoeffGridOf<Basis>,
+                     DataType,
+                     Basis> && ...)
+            && (is_extrapolation_rule_auto_constructible_v<
+                        MaxOf<ExtrapRules>,
+                        CoeffGridOf<Basis>,
+                        DataType,
+                        Basis> && ...))
+        : m_evaluator(LagrangeEvaluator<
+                      ExecSpace,
+                      memory_space,
+                      DataType,
+                      Basis,
+                      Grid,
+                      MinOf<ExtrapRules>,
+                      MaxOf<ExtrapRules>>(
+                get_extrapolation<MinOf<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                        Extremity::FRONT),
+                get_extrapolation<MaxOf<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                        Extremity::BACK))...)
+    {
+    }
+
+    /**
+     * @brief Construct an NDLagrangeInterpolator, specifying the extrapolation rules
+     * explicitly.
+     *
+     * Use this overload when a chosen extrapolation rule cannot be built automatically,
+     * e.g. a custom extrapolation rule that is not default-constructible and is not
+     * ExtrapolationRule::Constant.
+     *
+     * @param idx_range The index range on which the interpolator will act. This is
+     *                  unused but is included to match the SplineInterpolator interface.
+     * @param extrapolation_rules One std::pair<MinExtrapolationRuleI, MaxExtrapolationRuleI>
+     *                  per dimension, in the same order as IdxRangeBasis/IdxRangeInterpGrid.
+     */
+    explicit NDLagrangeInterpolator(
+            IdxRange<Grid...> idx_range,
+            std::pair<MinOf<ExtrapRules>, MaxOf<ExtrapRules>> const&... extrapolation_rules)
+        : m_evaluator(LagrangeEvaluator<
+                      ExecSpace,
+                      memory_space,
+                      DataType,
+                      Basis,
+                      Grid,
+                      MinOf<ExtrapRules>,
+                      MaxOf<ExtrapRules>>(extrapolation_rules.first, extrapolation_rules.second)...)
+    {
+    }
+
+    /**
+     * @brief Return a const reference to the owned ND identity builder.
+     * @return The BuilderType instance.
+     */
+    BuilderType const& get_builder() const
+    {
+        return m_builder;
+    }
+
+    /**
+     * @brief Return a const reference to the owned ND Lagrange evaluator.
+     * @return The EvaluatorType instance.
+     */
+    EvaluatorType const& get_evaluator() const
+    {
+        return m_evaluator;
+    }
+};
+
+/**
+ * @brief A helper alias to define an instance of detail::NDLagrangeInterpolator.
+ *
+ * The helper allows ExtrapRulesSeq to be more general. It is a
+ * ddc::detail::TypeSeq<ExtrapRules1, ..., ExtrapRulesN> pairing, for each dimension, the
+ * extrapolation rules applied below/above the boundary. Each ExtrapRulesI is itself a
+ * ddc::detail::TypeSeq<MinExtrapolationRuleI, MaxExtrapolationRuleI> where each rule may
+ * be one of the tags in the ExtrapolationRule namespace (e.g. ExtrapolationRule::Periodic)
+ * or a custom, already-concrete extrapolation rule class.
+ */
+template <
+        class ExecSpace,
+        class DataType,
+        class IdxRangeBasis,
+        class IdxRangeInterpGrid,
+        class... ExtrapRulesSeq>
+struct LagrangeInterpolatorResolver;
+
+template <class ExecSpace, class DataType, class Basis, class Grid, class ExtrapRules>
+struct LagrangeInterpolatorResolver<
+        ExecSpace,
+        DataType,
+        IdxRange<Basis>,
+        IdxRange<Grid>,
+        ExtrapRules>
+{
+    using type = detail::LagrangeInterpolator<
+            ExecSpace,
+            IdxRange<Basis>,
+            IdxRange<Grid>,
+            extrapolation_rule_t<
+                    ExtrapRules,
+                    typename IdentityInterpolationBuilder<
+                            ExecSpace,
+                            typename ExecSpace::memory_space,
+                            DataType,
+                            Grid,
+                            Basis>::basis_domain_type,
+                    DataType,
+                    Basis>,
+            DataType>;
+};
+
+template <
+        class ExecSpace,
+        class DataType,
+        class BasisHead,
+        class... Basis,
+        class GridHead,
+        class... Grid,
+        class ExtrapRulesHead,
+        class... ExtrapRules>
+struct LagrangeInterpolatorResolver<
+        ExecSpace,
+        DataType,
+        IdxRange<BasisHead, Basis...>,
+        IdxRange<GridHead, Grid...>,
+        ExtrapRulesHead,
+        ExtrapRules...>
+{
+    using type = detail::NDLagrangeInterpolator<
+            ExecSpace,
+            IdxRange<BasisHead, Basis...>,
+            IdxRange<GridHead, Grid...>,
+            ddc::detail::TypeSeq<
+                    extrapolation_rule_t<
+                            ExtrapRulesHead,
+                            typename BasisHead::template Impl<
+                                    BasisHead,
+                                    typename ExecSpace::memory_space>::knot_grid,
+                            DataType,
+                            BasisHead>,
+                    extrapolation_rule_t<
+                            ExtrapRules,
+                            typename Basis::template Impl<Basis, typename ExecSpace::memory_space>::
+                                    knot_grid,
+                            DataType,
+                            Basis>...>,
+            DataType>;
+};
 } // namespace detail
 
 /**
@@ -181,22 +453,13 @@ public:
  */
 template <
         class ExecSpace,
-        class Basis,
-        class InterpGrid,
-        class ExtrapRules,
-        class DataType = double>
-using LagrangeInterpolator = detail::LagrangeInterpolator<
+        class DataType,
+        class IdxRangeBasis,
+        class IdxRangeInterpGrid,
+        class... ExtrapRules>
+using LagrangeInterpolator = typename detail::NDLagrangeInterpolatorResolver<
         ExecSpace,
-        Basis,
-        InterpGrid,
-        extrapolation_rule_t<
-                ExtrapRules,
-                typename IdentityInterpolationBuilder<
-                        ExecSpace,
-                        typename ExecSpace::memory_space,
-                        DataType,
-                        InterpGrid,
-                        Basis>::basis_domain_type,
-                DataType,
-                Basis>,
-        DataType>;
+        DataType,
+        IdxRangeBasis,
+        IdxRangeInterpGrid,
+        ExtrapRules...>::type;

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -219,10 +219,10 @@ public:
 
 private:
     template <class Rule>
-    using MinOf = ddc::type_seq_element_t<0, Rule>;
+    using Min = ddc::type_seq_element_t<0, Rule>;
 
     template <class Rule>
-    using MaxOf = ddc::type_seq_element_t<1, Rule>;
+    using MaxRule = ddc::type_seq_element_t<1, Rule>;
 
     template <class B>
     using CoeffGridOf = typename B::template Impl<B, memory_space>::knot_grid;
@@ -230,7 +230,7 @@ private:
     static_assert(
             ((Basis::is_periodic()
               == std::is_same_v<
-                      MinOf<ExtrapRules>,
+                      MinRule<ExtrapRules>,
                       ddc::PeriodicExtrapolationRule<
                               typename Basis::continuous_dimension_type>>)&&...),
             "PeriodicExtrapolationRule has to be used if and only if the dimension is "
@@ -238,7 +238,7 @@ private:
     static_assert(
             ((Basis::is_periodic()
               == std::is_same_v<
-                      MaxOf<ExtrapRules>,
+                      MaxRule<ExtrapRules>,
                       ddc::PeriodicExtrapolationRule<
                               typename Basis::continuous_dimension_type>>)&&...),
             "PeriodicExtrapolationRule has to be used if and only if the dimension is "
@@ -260,8 +260,8 @@ public:
             DataType,
             Basis,
             Grid1D,
-            MinOf<ExtrapRules>,
-            MaxOf<ExtrapRules>>...>;
+            MinRule<ExtrapRules>,
+            MaxRule<ExtrapRules>>...>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
@@ -289,12 +289,12 @@ public:
      */
     explicit NDLagrangeInterpolator(IdxRange<Grid1D...> idx_range = IdxRange<Grid1D...> {}) requires(
             (is_extrapolation_rule_auto_constructible_v<
-                     MinOf<ExtrapRules>,
+                     MinRule<ExtrapRules>,
                      CoeffGridOf<Basis>,
                      DataType,
                      Basis> && ...)
             && (is_extrapolation_rule_auto_constructible_v<
-                        MaxOf<ExtrapRules>,
+                        MaxRule<ExtrapRules>,
                         CoeffGridOf<Basis>,
                         DataType,
                         Basis> && ...))
@@ -304,11 +304,11 @@ public:
                       DataType,
                       Basis,
                       Grid1D,
-                      MinOf<ExtrapRules>,
-                      MaxOf<ExtrapRules>>(
-                get_extrapolation<MinOf<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                      MinRule<ExtrapRules>,
+                      MaxRule<ExtrapRules>>(
+                get_extrapolation<MinRule<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
                         Extremity::FRONT),
-                get_extrapolation<MaxOf<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                get_extrapolation<MaxRule<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
                         Extremity::BACK))...)
     {
     }
@@ -328,15 +328,17 @@ public:
      */
     explicit NDLagrangeInterpolator(
             IdxRange<Grid1D...> idx_range,
-            std::pair<MinOf<ExtrapRules>, MaxOf<ExtrapRules>> const&... extrapolation_rules)
+            std::pair<MinRule<ExtrapRules>, MaxRule<ExtrapRules>> const&... extrapolation_rules)
         : m_evaluator(LagrangeEvaluator<
                       ExecSpace,
                       memory_space,
                       DataType,
                       Basis,
                       Grid1D,
-                      MinOf<ExtrapRules>,
-                      MaxOf<ExtrapRules>>(extrapolation_rules.first, extrapolation_rules.second)...)
+                      MinRule<ExtrapRules>,
+                      MaxRule<ExtrapRules>>(
+                extrapolation_rules.first,
+                extrapolation_rules.second)...)
     {
     }
 

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -387,8 +387,8 @@ struct LagrangeInterpolatorResolver<
 {
     using type = detail::LagrangeInterpolator<
             ExecSpace,
-            IdxRange<Basis>,
-            IdxRange<Grid>,
+            Basis,
+            Grid,
             extrapolation_rule_t<
                     ExtrapRules,
                     typename IdentityInterpolationBuilder<
@@ -457,7 +457,7 @@ template <
         class IdxRangeBasis,
         class IdxRangeInterpGrid,
         class... ExtrapRules>
-using LagrangeInterpolator = typename detail::NDLagrangeInterpolatorResolver<
+using LagrangeInterpolator = typename detail::LagrangeInterpolatorResolver<
         ExecSpace,
         DataType,
         IdxRangeBasis,

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -225,7 +225,9 @@ private:
     using MaxRule = ddc::type_seq_element_t<1, Rule>;
 
     template <class B>
-    using CoeffGridOf = typename B::template Impl<B, memory_space>::knot_grid;
+    using CoeffGrid = ddc::type_seq_element_t<
+            ddc::type_seq_rank_v<B, ddc::detail::TypeSeq<Basis...>>,
+            ddc::to_type_seq_t<typename BuilderType::coeff_idx_range_type>>;
 
     static_assert(
             ((Basis::is_periodic()
@@ -290,12 +292,12 @@ public:
     explicit NDLagrangeInterpolator(IdxRange<Grid1D...> idx_range = IdxRange<Grid1D...> {}) requires(
             (is_extrapolation_rule_auto_constructible_v<
                      MinRule<ExtrapRules>,
-                     CoeffGridOf<Basis>,
+                     CoeffGrid<Basis>,
                      DataType,
                      Basis> && ...)
             && (is_extrapolation_rule_auto_constructible_v<
                         MaxRule<ExtrapRules>,
-                        CoeffGridOf<Basis>,
+                        CoeffGrid<Basis>,
                         DataType,
                         Basis> && ...))
         : m_evaluator(LagrangeEvaluator<
@@ -306,9 +308,9 @@ public:
                       Grid1D,
                       MinRule<ExtrapRules>,
                       MaxRule<ExtrapRules>>(
-                get_extrapolation<MinRule<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                get_extrapolation<MinRule<ExtrapRules>, CoeffGrid<Basis>, DataType, Basis>(
                         Extremity::FRONT),
-                get_extrapolation<MaxRule<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
+                get_extrapolation<MaxRule<ExtrapRules>, CoeffGrid<Basis>, DataType, Basis>(
                         Extremity::BACK))...)
     {
     }

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -200,15 +200,15 @@ template <
 class NDLagrangeInterpolator;
 
 /// The implementation of NDLagrangeInterpolator. This is separate to allow variadic packs.
-template <class ExecSpace, class... Basis, class... Grid, class... ExtrapRules, class DataType>
+template <class ExecSpace, class... Basis, class... Grid1D, class... ExtrapRules, class DataType>
 class NDLagrangeInterpolator<
         ExecSpace,
         IdxRange<Basis...>,
-        IdxRange<Grid...>,
+        IdxRange<Grid1D...>,
         ddc::detail::TypeSeq<ExtrapRules...>,
         DataType>
 {
-    static_assert(sizeof...(Basis) == sizeof...(Grid));
+    static_assert(sizeof...(Basis) == sizeof...(Grid1D));
     static_assert(sizeof...(Basis) == sizeof...(ExtrapRules));
     static_assert(sizeof...(Basis) > 0);
     static_assert((is_lagrange_basis_v<Basis> && ...));
@@ -250,7 +250,7 @@ public:
             ExecSpace,
             memory_space,
             DataType,
-            IdxRange<Grid...>,
+            IdxRange<Grid1D...>,
             IdxRange<Basis...>>;
 
     /// @brief The NDLagrangeEvaluator type built from the template parameters.
@@ -259,14 +259,14 @@ public:
             memory_space,
             DataType,
             Basis,
-            Grid,
+            Grid1D,
             MinOf<ExtrapRules>,
             MaxOf<ExtrapRules>>...>;
 
     /// @brief The number of interpolation dimensions.
     static constexpr std::size_t rank()
     {
-        return sizeof...(Grid);
+        return sizeof...(Grid1D);
     }
 
 private:
@@ -287,7 +287,7 @@ public:
      * @param idx_range The index range on which the interpolator will act. This is
      *                  unused but is included to match the SplineInterpolator interface.
      */
-    explicit NDLagrangeInterpolator(IdxRange<Grid...> idx_range = IdxRange<Grid...> {}) requires(
+    explicit NDLagrangeInterpolator(IdxRange<Grid1D...> idx_range = IdxRange<Grid1D...> {}) requires(
             (is_extrapolation_rule_auto_constructible_v<
                      MinOf<ExtrapRules>,
                      CoeffGridOf<Basis>,
@@ -303,7 +303,7 @@ public:
                       memory_space,
                       DataType,
                       Basis,
-                      Grid,
+                      Grid1D,
                       MinOf<ExtrapRules>,
                       MaxOf<ExtrapRules>>(
                 get_extrapolation<MinOf<ExtrapRules>, CoeffGridOf<Basis>, DataType, Basis>(
@@ -327,14 +327,14 @@ public:
      *                  per dimension, in the same order as IdxRangeBasis/IdxRangeInterpGrid.
      */
     explicit NDLagrangeInterpolator(
-            IdxRange<Grid...> idx_range,
+            IdxRange<Grid1D...> idx_range,
             std::pair<MinOf<ExtrapRules>, MaxOf<ExtrapRules>> const&... extrapolation_rules)
         : m_evaluator(LagrangeEvaluator<
                       ExecSpace,
                       memory_space,
                       DataType,
                       Basis,
-                      Grid,
+                      Grid1D,
                       MinOf<ExtrapRules>,
                       MaxOf<ExtrapRules>>(extrapolation_rules.first, extrapolation_rules.second)...)
     {
@@ -377,25 +377,25 @@ template <
         class... ExtrapRulesSeq>
 struct LagrangeInterpolatorResolver;
 
-template <class ExecSpace, class DataType, class Basis, class Grid, class ExtrapRules>
+template <class ExecSpace, class DataType, class Basis, class Grid1D, class ExtrapRules>
 struct LagrangeInterpolatorResolver<
         ExecSpace,
         DataType,
         IdxRange<Basis>,
-        IdxRange<Grid>,
+        IdxRange<Grid1D>,
         ExtrapRules>
 {
     using type = detail::LagrangeInterpolator<
             ExecSpace,
             Basis,
-            Grid,
+            Grid1D,
             extrapolation_rule_t<
                     ExtrapRules,
                     typename IdentityInterpolationBuilder<
                             ExecSpace,
                             typename ExecSpace::memory_space,
                             DataType,
-                            Grid,
+                            Grid1D,
                             Basis>::basis_domain_type,
                     DataType,
                     Basis>,
@@ -407,22 +407,22 @@ template <
         class DataType,
         class BasisHead,
         class... Basis,
-        class GridHead,
-        class... Grid,
+        class Grid1DHead,
+        class... Grid1D,
         class ExtrapRulesHead,
         class... ExtrapRules>
 struct LagrangeInterpolatorResolver<
         ExecSpace,
         DataType,
         IdxRange<BasisHead, Basis...>,
-        IdxRange<GridHead, Grid...>,
+        IdxRange<Grid1DHead, Grid1D...>,
         ExtrapRulesHead,
         ExtrapRules...>
 {
     using type = detail::NDLagrangeInterpolator<
             ExecSpace,
             IdxRange<BasisHead, Basis...>,
-            IdxRange<GridHead, Grid...>,
+            IdxRange<Grid1DHead, Grid1D...>,
             ddc::detail::TypeSeq<
                     extrapolation_rule_t<
                             ExtrapRulesHead,

--- a/src/interpolation/nd_lagrange_evaluator.hpp
+++ b/src/interpolation/nd_lagrange_evaluator.hpp
@@ -260,7 +260,7 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class IdxDerivDims, class Layout, class BatchedLagrangeIdxRange, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION data_type deriv(
             IdxDerivDims const& deriv_order,
             Coord<CoordsDims...> const& coord_eval,
             ConstField<data_type, BatchedLagrangeIdxRange, memory_space, Layout> const

--- a/src/interpolation/nd_lagrange_evaluator.hpp
+++ b/src/interpolation/nd_lagrange_evaluator.hpp
@@ -260,11 +260,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class IdxDerivDims, class Layout, class BatchedLagrangeIdxRange, class... CoordsDims>
-    KOKKOS_FUNCTION data_type deriv(
-            IdxDerivDims const& deriv_order,
-            Coord<CoordsDims...> const& coord_eval,
-            ConstField<data_type, BatchedLagrangeIdxRange, memory_space, Layout> const
-                    lagrange_coef) const
+    KOKKOS_FUNCTION data_type
+    deriv(IdxDerivDims const& deriv_order,
+          Coord<CoordsDims...> const& coord_eval,
+          ConstField<data_type, BatchedLagrangeIdxRange, memory_space, Layout> const lagrange_coef)
+            const
     {
         return eval_no_bc(deriv_order, coord_eval, lagrange_coef);
     }

--- a/tests/advection/1d_advection_x.cpp
+++ b/tests/advection/1d_advection_x.cpp
@@ -76,16 +76,17 @@ struct LagBasisFloatX : UniformLagrangeBasis<X, 3, float>
 
 using LagrangeInterpolatorX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagBasisX,
-        GridX,
+        double,
+        IdxRange<LagBasisX>,
+        IdxRange<GridX>,
         ExtrapolationRule::Periodic>;
 
 using LagrangeInterpolatorFloatX = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagBasisFloatX,
-        GridX,
-        ExtrapolationRule::Periodic,
-        float>;
+        float,
+        IdxRange<LagBasisFloatX>,
+        IdxRange<GridX>,
+        ExtrapolationRule::Periodic>;
 
 
 template <class DataType>

--- a/tests/advection/velocity_advection_1d.cpp
+++ b/tests/advection/velocity_advection_1d.cpp
@@ -118,8 +118,9 @@ struct LagBasisVx : UniformLagrangeBasis<Vx, 3, double>
 
 using LagrangeInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagBasisVx,
-        GridVx,
+        double,
+        IdxRange<LagBasisVx>,
+        IdxRange<GridVx>,
         ddc::detail::TypeSeq<ExtrapolationRule::Constant, ExtrapolationRule::Constant>>;
 
 

--- a/tests/geometryXVx/velocityadvection.cpp
+++ b/tests/geometryXVx/velocityadvection.cpp
@@ -25,8 +25,9 @@ struct LagBasisVx : UniformLagrangeBasis<Vx, 3, double>
 
 using LagInterpolatorVx = LagrangeInterpolator<
         Kokkos::DefaultExecutionSpace,
-        LagBasisVx,
-        GridVx,
+        double,
+        IdxRange<LagBasisVx>,
+        IdxRange<GridVx>,
         ExtrapolationRule::Null_Null>;
 
 std::pair<IdxRange<GridX>, IdxRange<GridVx>> Init_idx_range_velocity_adv()

--- a/tests/interpolation/nd_lagrange_interpolation.cpp
+++ b/tests/interpolation/nd_lagrange_interpolation.cpp
@@ -9,8 +9,10 @@
 
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_helper.hpp"
+#include "i_interpolation.hpp"
 #include "lagrange_basis_non_uniform.hpp"
 #include "lagrange_basis_uniform.hpp"
+#include "lagrange_interpolation.hpp"
 #include "mesh_builder.hpp"
 #include "nd_identity_interpolation_builder.hpp"
 #include "nd_lagrange_evaluator.hpp"
@@ -536,6 +538,220 @@ TYPED_TEST(NDLagrangePeriodicFixture, PeriodicWraparound)
     ddc::host_for_each(test_range, [&](Idx<TestGridX, TestGridY> idx) {
         double const x = ddc::coordinate(Idx<TestGridX>(idx));
         double const y = ddc::coordinate(Idx<TestGridY>(idx));
+        double const expected = std::cos(x) * (1.0 + y);
+        EXPECT_NEAR(result_host(idx), expected, tol);
+    });
+}
+
+/**
+ * @brief Test that the bundled NDLagrangeInterpolator reproduces a separable polynomial
+ * exactly, going through its get_builder()/get_evaluator() interface (auto-extrapolation
+ * constructor) rather than constructing NDIdentityInterpolationBuilder/LagrangeEvaluator/
+ * NDLagrangeEvaluator directly.
+ *
+ * As with LagrangeInterpolator, the same grid type is used both to provide the function
+ * values (via the builder) and as the evaluator's InterpolationGrid. Evaluation is
+ * nonetheless performed away from the grid nodes by using the explicit-coordinates
+ * overload with a field of independently-chosen interior coordinates, so the test still
+ * exercises the Lagrange reconstruction rather than a trivial identity round-trip.
+ */
+TYPED_TEST(NDLagrangeNonPeriodicFixture, InterpolatorExactPolynomialInterpolation)
+{
+    using DataType = typename TestFixture::DataType;
+    using GridX = typename TestFixture::GridX;
+    using GridY = typename TestFixture::GridY;
+    using LagBasisX = typename TestFixture::LagBasisX;
+    using LagBasisY = typename TestFixture::LagBasisY;
+
+    constexpr std::size_t degree = TestFixture::degree;
+    static constexpr double TOL = TestFixture::TOL;
+
+    using Interpolator = LagrangeInterpolator<
+            Kokkos::DefaultExecutionSpace,
+            DataType,
+            IdxRange<LagBasisX, LagBasisY>,
+            IdxRange<GridX, GridY>,
+            ddc::detail::TypeSeq<ExtrapolationRule::Null_Null, ExtrapolationRule::Null_Null>>;
+    static_assert(concepts::Interpolation<Interpolator>);
+
+    // Set up the domains
+    Coord<X> xmin(0.0), xmax(2.0);
+    Coord<Y> ymin(0.0), ymax(3.0);
+    std::size_t const ncells = 10;
+
+    if constexpr (TestFixture::UNIFORM) {
+        ddc::init_discrete_space<GridX>(GridX::init(xmin, xmax, IdxStep<GridX>(ncells + 1)));
+        ddc::init_discrete_space<GridY>(GridY::init(ymin, ymax, IdxStep<GridY>(ncells + 1)));
+    } else {
+        ddc::init_discrete_space<GridX>(
+                build_random_non_uniform_break_points(xmin, xmax, IdxStep<GridX>(ncells), 0.5));
+        ddc::init_discrete_space<GridY>(
+                build_random_non_uniform_break_points(ymin, ymax, IdxStep<GridY>(ncells), 0.5));
+    }
+
+    IdxRange<GridX> const x_range(Idx<GridX>(0), IdxStep<GridX>(ncells + 1));
+    IdxRange<GridY> const y_range(Idx<GridY>(0), IdxStep<GridY>(ncells + 1));
+    IdxRange<GridX, GridY> const idx_range(x_range, y_range);
+    ddc::init_discrete_space<LagBasisX>(x_range);
+    ddc::init_discrete_space<LagBasisY>(y_range);
+
+    std::array<DataType, degree + 1> coeffs_x, coeffs_y;
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<double> dis(0.5, 1.5);
+    for (std::size_t i(0); i <= degree; ++i) {
+        coeffs_x[i] = static_cast<DataType>(dis(gen));
+        coeffs_y[i] = static_cast<DataType>(dis(gen));
+    }
+
+    FieldMem<DataType, IdxRange<GridX, GridY>> vals_alloc("vals", idx_range);
+    fill_polynomial_2d(get_field(vals_alloc), coeffs_x, coeffs_y);
+
+    Interpolator const interpolator(idx_range);
+    auto const& builder = interpolator.get_builder();
+    auto const& evaluator = interpolator.get_evaluator();
+
+    using IdxRangeCoeff = InterpolationBuilderTraits<typename Interpolator::BuilderType>::
+            template batched_basis_idx_range_type<IdxRange<GridX, GridY>>;
+    FieldMem<DataType, IdxRangeCoeff>
+            poly_coeffs_alloc("coeffs", batched_basis_idx_range(builder, idx_range));
+    builder(get_field(poly_coeffs_alloc), get_const_field(vals_alloc));
+
+    // Evaluate at independently-chosen interior coordinates (not the grid nodes) using a
+    // sub-range of GridX/GridY purely as index storage for the explicit-coordinates overload.
+    std::size_t const ntest = 7;
+    IdxRange<GridX> const test_x_range = x_range.take_first(IdxStep<GridX>(ntest));
+    IdxRange<GridY> const test_y_range = y_range.take_first(IdxStep<GridY>(ntest));
+    IdxRange<GridX, GridY> const test_range(test_x_range, test_y_range);
+
+    FieldMem<Coord<X, Y>, IdxRange<GridX, GridY>> coords_alloc(test_range);
+    auto coords_host = ddc::create_mirror_view(get_field(coords_alloc));
+    std::uniform_real_distribution<double>
+            coord_dis_x(static_cast<double>(xmin), static_cast<double>(xmax));
+    std::uniform_real_distribution<double>
+            coord_dis_y(static_cast<double>(ymin), static_cast<double>(ymax));
+    ddc::host_for_each(test_range, [&](Idx<GridX, GridY> idx) {
+        coords_host(idx) = Coord<X, Y>(coord_dis_x(gen), coord_dis_y(gen));
+    });
+    ddc::parallel_deepcopy(get_field(coords_alloc), get_field(coords_host));
+
+    FieldMem<DataType, IdxRange<GridX, GridY>> result_alloc(test_range);
+    evaluator(
+            get_field(result_alloc),
+            get_const_field(coords_alloc),
+            get_const_field(poly_coeffs_alloc));
+
+    auto const result_host = ddc::create_mirror_view_and_copy(get_const_field(result_alloc));
+    ddc::host_for_each(test_range, [&](Idx<GridX, GridY> idx) {
+        Coord<X, Y> const coord = coords_host(idx);
+        DataType const expected
+                = polynomial(Coord<X>(coord), coeffs_x) * polynomial(Coord<Y>(coord), coeffs_y);
+        EXPECT_NEAR(
+                static_cast<double>(result_host(idx)),
+                static_cast<double>(expected),
+                TOL * expected);
+    });
+}
+
+/**
+ * @brief Test that the bundled NDLagrangeInterpolator, constructed with the explicit-rules
+ * constructor (one std::pair<Min, Max> per dimension), correctly handles a periodic
+ * dimension via a round-trip evaluation of cos(x)*(1+y) at interior points distinct from
+ * the grid nodes.
+ */
+TYPED_TEST(NDLagrangePeriodicFixture, InterpolatorPeriodicWraparound)
+{
+    using DataType = typename TestFixture::DataType;
+    using GridX = typename TestFixture::GridX;
+    using GridY = typename TestFixture::GridY;
+    using LagBasisX = typename TestFixture::LagBasisX;
+    using LagBasisY = typename TestFixture::LagBasisY;
+
+    constexpr std::size_t degree = TestFixture::degree;
+
+    using Interpolator = LagrangeInterpolator<
+            Kokkos::DefaultExecutionSpace,
+            DataType,
+            IdxRange<LagBasisX, LagBasisY>,
+            IdxRange<GridX, GridY>,
+            ddc::detail::TypeSeq<ExtrapolationRule::Periodic, ExtrapolationRule::Null_Null>>;
+    static_assert(concepts::Interpolation<Interpolator>);
+
+    Coord<XPeriodic> const xmin(0.0), xmax(2.0 * M_PI);
+    Coord<Y> const ymin(0.0), ymax(1.0);
+    std::size_t const ncells = 10;
+
+    if constexpr (TestFixture::UNIFORM) {
+        ddc::init_discrete_space<GridX>(GridX::init(xmin, xmax, IdxStep<GridX>(ncells + 1)));
+        ddc::init_discrete_space<GridY>(GridY::init(ymin, ymax, IdxStep<GridY>(ncells + 1)));
+    } else {
+        ddc::init_discrete_space<GridX>(
+                build_random_non_uniform_break_points(xmin, xmax, IdxStep<GridX>(ncells), 0.5));
+        ddc::init_discrete_space<GridY>(
+                build_random_non_uniform_break_points(ymin, ymax, IdxStep<GridY>(ncells), 0.5));
+    }
+
+    IdxRange<GridX> const knot_x_range(Idx<GridX>(0), IdxStep<GridX>(ncells + 1));
+    IdxRange<GridY> const knot_y_range(Idx<GridY>(0), IdxStep<GridY>(ncells + 1));
+    IdxRange<GridX, GridY> const
+            idx_range(knot_x_range.remove_last(IdxStep<GridX>(1)), knot_y_range);
+
+    ddc::init_discrete_space<LagBasisX>(knot_x_range);
+    ddc::init_discrete_space<LagBasisY>(knot_y_range);
+
+    FieldMem<DataType, IdxRange<GridX, GridY>> vals_alloc("vals", idx_range);
+    Field<DataType, IdxRange<GridX, GridY>> vals(vals_alloc);
+    fill_cos_2d(vals);
+
+    ddc::PeriodicExtrapolationRule<XPeriodic> const periodic_extrap;
+    ddc::NullExtrapolationRule const null_extrap;
+    Interpolator const interpolator(
+            idx_range,
+            std::make_pair(periodic_extrap, periodic_extrap),
+            std::make_pair(null_extrap, null_extrap));
+    auto const& builder = interpolator.get_builder();
+    auto const& evaluator = interpolator.get_evaluator();
+
+    using IdxRangeCoeff = InterpolationBuilderTraits<typename Interpolator::BuilderType>::
+            template batched_basis_idx_range_type<IdxRange<GridX, GridY>>;
+    FieldMem<DataType, IdxRangeCoeff>
+            coeffs_alloc("coeffs", batched_basis_idx_range(builder, idx_range));
+    builder(get_field(coeffs_alloc), get_const_field(vals_alloc));
+
+    double h = static_cast<double>(xmax) / static_cast<double>(ncells);
+    double const tol = ipow(h, degree + 1);
+
+    // Round-trip evaluation at independently-chosen interior coordinates, using a
+    // sub-range of GridX/GridY purely as index storage for the explicit-coordinates overload.
+    std::size_t const ntest = 7;
+    IdxRange<GridX> const idx_range_x(idx_range);
+    IdxRange<GridY> const idx_range_y(idx_range);
+    IdxRange<GridX> const test_x_range = idx_range_x.take_first(IdxStep<GridX>(ntest));
+    IdxRange<GridY> const test_y_range = idx_range_y.take_first(IdxStep<GridY>(ntest));
+    IdxRange<GridX, GridY> const test_range(test_x_range, test_y_range);
+
+    FieldMem<Coord<XPeriodic, Y>, IdxRange<GridX, GridY>> coords_alloc(test_range);
+    auto coords_host = ddc::create_mirror_view(get_field(coords_alloc));
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<double>
+            coord_dis_x(static_cast<double>(xmin), static_cast<double>(xmax));
+    std::uniform_real_distribution<double>
+            coord_dis_y(static_cast<double>(ymin), static_cast<double>(ymax));
+    ddc::host_for_each(test_range, [&](Idx<GridX, GridY> idx) {
+        coords_host(idx) = Coord<XPeriodic, Y>(coord_dis_x(gen), coord_dis_y(gen));
+    });
+    ddc::parallel_deepcopy(get_field(coords_alloc), get_field(coords_host));
+
+    FieldMem<DataType, IdxRange<GridX, GridY>> result_alloc(test_range);
+    evaluator(
+            get_field(result_alloc),
+            get_const_field(coords_alloc),
+            get_const_field(coeffs_alloc));
+
+    auto const result_host = ddc::create_mirror_view_and_copy(get_const_field(result_alloc));
+    ddc::host_for_each(test_range, [&](Idx<GridX, GridY> idx) {
+        Coord<XPeriodic, Y> const coord = coords_host(idx);
+        double const x = Coord<XPeriodic>(coord);
+        double const y = Coord<Y>(coord);
         double const expected = std::cos(x) * (1.0 + y);
         EXPECT_NEAR(result_host(idx), expected, tol);
     });

--- a/tests/interpolation/nd_lagrange_interpolation.cpp
+++ b/tests/interpolation/nd_lagrange_interpolation.cpp
@@ -571,7 +571,8 @@ TYPED_TEST(NDLagrangeNonPeriodicFixture, InterpolatorExactPolynomialInterpolatio
             DataType,
             IdxRange<LagBasisX, LagBasisY>,
             IdxRange<GridX, GridY>,
-            ddc::detail::TypeSeq<ExtrapolationRule::Null_Null, ExtrapolationRule::Null_Null>>;
+            ExtrapolationRule::Null_Null,
+            ExtrapolationRule::Null_Null>;
     static_assert(concepts::Interpolation<Interpolator>);
 
     // Set up the domains
@@ -673,7 +674,8 @@ TYPED_TEST(NDLagrangePeriodicFixture, InterpolatorPeriodicWraparound)
             DataType,
             IdxRange<LagBasisX, LagBasisY>,
             IdxRange<GridX, GridY>,
-            ddc::detail::TypeSeq<ExtrapolationRule::Periodic, ExtrapolationRule::Null_Null>>;
+            ExtrapolationRule::Periodic,
+            ExtrapolationRule::Null_Null>;
     static_assert(concepts::Interpolation<Interpolator>);
 
     Coord<XPeriodic> const xmin(0.0), xmax(2.0 * M_PI);

--- a/tests/interpolation/nd_lagrange_interpolation.cpp
+++ b/tests/interpolation/nd_lagrange_interpolation.cpp
@@ -548,12 +548,6 @@ TYPED_TEST(NDLagrangePeriodicFixture, PeriodicWraparound)
  * exactly, going through its get_builder()/get_evaluator() interface (auto-extrapolation
  * constructor) rather than constructing NDIdentityInterpolationBuilder/LagrangeEvaluator/
  * NDLagrangeEvaluator directly.
- *
- * As with LagrangeInterpolator, the same grid type is used both to provide the function
- * values (via the builder) and as the evaluator's InterpolationGrid. Evaluation is
- * nonetheless performed away from the grid nodes by using the explicit-coordinates
- * overload with a field of independently-chosen interior coordinates, so the test still
- * exercises the Lagrange reconstruction rather than a trivial identity round-trip.
  */
 TYPED_TEST(NDLagrangeNonPeriodicFixture, InterpolatorExactPolynomialInterpolation)
 {


### PR DESCRIPTION
Extend `LagrangeInterpolation` to handle ND cases. The ND case is handled by a new class `NDLagrangeInterpolation`.

Template arguments are re-ordered to allow `ExtrapRules` to be variadic. 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
