### PR TITLE
Makes type IdxRangeRTheta public in the class DiscretePoloidalCSSplineMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add class `GMGPolarPoissonLikeSolver` to allow the use of [GMGPolar](https://github.com/SciCompMod/GMGPolar) as a polar Poisson solver.
 - Add GMGPolar in the toolchains.
 - Allow `SplineInterpolator` and `LagrangeInterpolator` to specify custom extrapolation rules.
+- Made the type `IdxRangeRTheta` in class `DiscretePoloidalCSSplineMapping` public.
 
 ### Fixed
 

--- a/src/coord_transformations/discrete_poloidal_cs_spline_mapping.hpp
+++ b/src/coord_transformations/discrete_poloidal_cs_spline_mapping.hpp
@@ -68,7 +68,7 @@ public:
     using R_cov = typename R::Dual;
     /// @brief The covariant form of the second logical coordinate.
     using Theta_cov = typename Theta::Dual;
-
+    /// @brief The index range where the spline evaluator can be called.
     using IdxRangeRTheta = typename SplineEvaluator::evaluation_domain_type;
 
 private:

--- a/src/coord_transformations/discrete_poloidal_cs_spline_mapping.hpp
+++ b/src/coord_transformations/discrete_poloidal_cs_spline_mapping.hpp
@@ -69,12 +69,12 @@ public:
     /// @brief The covariant form of the second logical coordinate.
     using Theta_cov = typename Theta::Dual;
 
+    using IdxRangeRTheta = typename SplineEvaluator::evaluation_domain_type;
+
 private:
     using spline_idx_range = IdxRange<BSplineR, BSplineTheta>;
 
     using SplineType = DConstField<spline_idx_range, MemorySpace>;
-
-    using IdxRangeRTheta = typename SplineEvaluator::evaluation_domain_type;
     using IdxRangeTheta = typename SplineEvaluator::evaluation_domain_type2;
     using IdxTheta = typename IdxRangeTheta::discrete_element_type;
 


### PR DESCRIPTION
The use of splines restricts the mapping of type `DiscretePoloidalCSSplineMapping` to a specific IdxRange, which corresponds to `IdxRangeRTheta`. This PR makes it public, as required for MR !327 in Gysela-X++. 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [X] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [X] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [X] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [X] Have you checked that the AUTHORS file is up to date ?
- [X] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [x] Have you checked that existing tests cover all code after the changes ?
- [x] Have you checked that existing tests are still passing ?
- [x] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
