### PR TITLE
Use fast math flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the dependency on GoogleTest dependent on the CMake option `GYSELALIBXX_BUILD_TESTING`.
 - Group extrapolation rules by dimension in `SplineInterpolator` and `LagrangeInterpolator`.
 - Group spline boundary closure rules by dimension in `SplineInterpolator`.
+- Add `-ffast-math` flag to toolchains.
 
 ### Deprecated
 

--- a/tests/quadrature/batched_quadrature.cpp
+++ b/tests/quadrature/batched_quadrature.cpp
@@ -228,7 +228,7 @@ void batched_operator_1d_2d()
                      + y_min * y_min * (-x_max * x_max - 6 * x_max + x_min * x_min + 6 * x_min)
                      - 4 * y_min * (x_max * x_max - x_min * x_min))
                   / 4;
-        EXPECT_DOUBLE_EQ(results_host(ib), exact);
+        EXPECT_NEAR(results_host(ib), exact, 1e-11);
     });
 }
 

--- a/toolchains/a100.raven.spack/toolchain.cmake
+++ b/toolchains/a100.raven.spack/toolchain.cmake
@@ -8,4 +8,4 @@ set(CMAKE_CXX_COMPILER nvcc_wrapper)
 set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -ffast-math")

--- a/toolchains/common_toolchains/release_toolchain.cmake
+++ b/toolchains/common_toolchains/release_toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare -ffast-math")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS OFF)

--- a/toolchains/genoa.gcc.adastra.spack/toolchain.cmake
+++ b/toolchains/genoa.gcc.adastra.spack/toolchain.cmake
@@ -8,4 +8,4 @@ set(CMAKE_C_COMPILER gcc)
 set(CMAKE_Fortran_COMPILER gfortran)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable -ffast-math")

--- a/toolchains/h100.jean-zay.spack/toolchain.cmake
+++ b/toolchains/h100.jean-zay.spack/toolchain.cmake
@@ -8,4 +8,4 @@ set(CMAKE_CXX_COMPILER nvcc_wrapper)
 set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -ffast-math")

--- a/toolchains/h200.hpcc.spack/toolchain.cmake
+++ b/toolchains/h200.hpcc.spack/toolchain.cmake
@@ -8,4 +8,4 @@ set(CMAKE_CXX_COMPILER nvcc_wrapper)
 set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF anyway when compiling with nvcc
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -ffast-math")

--- a/toolchains/mi250.hipcc.adastra.spack/toolchain.cmake
+++ b/toolchains/mi250.hipcc.adastra.spack/toolchain.cmake
@@ -8,5 +8,5 @@ set(CMAKE_C_COMPILER amdclang)
 set(CMAKE_Fortran_COMPILER amdflang)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable -ffast-math")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-L/opt/cray/pe/mpich/8.1.30/gtl/lib -lmpi_gtl_hsa")

--- a/toolchains/mi250.hipcc.lumi.spack/toolchain.cmake
+++ b/toolchains/mi250.hipcc.lumi.spack/toolchain.cmake
@@ -8,5 +8,5 @@ set(CMAKE_C_COMPILER amdclang)
 set(CMAKE_Fortran_COMPILER amdflang)
 set(CMAKE_CXX_EXTENSIONS OFF)
 # We should add that too, but there is too much warnings ! -Wsuggest-override -Wctor-dtor-privacy -Wdouble-promotion -Wcast-qual -Wredundant-decls -Wswitch-default -Wold-style-cast -Wswitch-enum -Wundef
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wpedantic -Wcast-align -Wformat=2 -Winit-self -Woverloaded-virtual -Wsign-promo -Wstrict-aliasing -Wdisabled-optimization -Wtautological-compare -Wpacked -Wunreachable-code -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable -ffast-math")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-L/opt/cray/pe/mpich/9.0.1/gtl/lib -lmpi_gtl_hsa")

--- a/toolchains/persee/v100/toolchain.cmake
+++ b/toolchains/persee/v100/toolchain.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_EXTENSIONS OFF) # Avoid a Kokkos warning that will force if to OFF
 # The compile option ipa-sra triggers a segfault with nvcc. @tpadioleau reported it to Nvidia. We then disable it.
 # Using CUDA 12.9 triggers a spurious warning when compiling for Nvidia Volta architectures. We then disable it.
 set(CMAKE_CXX_FLAGS_INIT "-fno-ipa-sra -Wno-deprecated-gpu-targets")
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wall -Wno-sign-compare --Werror cross-execution-space-call -Xcudafe --diag_suppress=unsigned_compare_with_zero -Xcudafe --diag_suppress=integer_sign_change -ffast-math")
 
 # Activate/deactivate parts of the code
 if (DEFINED ENV{DDC_BUILD_TESTING})

--- a/toolchains/persee/xeon/toolchain.cmake
+++ b/toolchains/persee/xeon/toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../common_toolchains/importable_defaults.cm
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Wno-sign-compare -Wno-unused-but-set-variable")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wno-sign-compare -Wno-unused-but-set-variable -ffast-math")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS OFF)


### PR DESCRIPTION
Several optimisations in Gyselalib++ are made by returning a `constexpr` value (e.g. 1 or 0). When calculations contain a `constexpr` 0 this term should ideally be dropped to avoid extensive unnecessary calculations. This is only done if `-ffast-math` is used. This is particularly important for anything using the types in `static_tensors.hpp` (e.g. the Lie-Poisson bracket).

This PR therefore adds the `-ffast-math` to the flags used in release toolchains.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
