### PR TITLE
Warning message when the Clang-format used is not v14

### DIFF
--- a/bin/indent
+++ b/bin/indent
@@ -73,12 +73,14 @@ if [ "$(hostname)" == "persee.partenaires.cea.fr" ]
 then
     CLANG_FORMAT=/data/gyselarunner/clang-format
 else
-    CLANG_FORMAT=clang-format-14
+    CLANG_FORMAT=clang-format
     set +e
-    if ! command -v ${CLANG_FORMAT} 2>&1 >/dev/null
+    VERSION=$(clang-format --version | grep -oP "version +\K[0-9]+")
+    if [ ! "${VERSION}" -eq "14" ]
     then
         CLANG_FORMAT=clang-format
-        echo "Could not find clang-format v14. Clang-formatting may not behave as expected"
+        echo "The version of clang-format is v${VERSION}."
+        echo "Formatting may not match exactly what is expected by the CI (v14)."
     fi
     set -e
 fi

--- a/bin/indent
+++ b/bin/indent
@@ -73,14 +73,26 @@ if [ "$(hostname)" == "persee.partenaires.cea.fr" ]
 then
     CLANG_FORMAT=/data/gyselarunner/clang-format
 else
-    CLANG_FORMAT=clang-format
     set +e
-    VERSION=$(clang-format --version | grep -oP "version +\K[0-9]+")
-    if [ ! "${VERSION}" -eq "14" ]
+    CLANG_FORMAT=
+    if command -v clang-format-14 2>&1 >/dev/null
+    then
+        CLANG_FORMAT=clang-format-14
+    elif command -v clang-format 2>&1 >/dev/null
     then
         CLANG_FORMAT=clang-format
-        echo "The version of clang-format is v${VERSION}."
-        echo "Formatting may not match exactly what is expected by the CI (v14)."
+        VERSION=$(clang-format --version | grep -oP "version +\K[0-9]+")
+        if [ "${VERSION}" -ne "14" ]
+        then
+            echo "The version of clang-format is v${VERSION}."
+            echo "Formatting may not match exactly what is expected by the CI (v14)."
+        fi
+    fi
+    if [ -z "${CLANG_FORMAT}" ]
+    then
+        echo "Couldn't find clang-format."
+        set -e
+        exit 1
     fi
     set -e
 fi


### PR DESCRIPTION
Slightly modified the check for the version of clang-format and the warning message when the version differs.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [X] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [X] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
