### PR TITLE
Extend ExtrapolationRule::Constant to ND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix use of `BslAdvectionSpatial` and `BslAdvectionVelocity` with non-double precision.
 - Fix H100 toolchain on Jean-Zay.
 - Fix Lagrange basis non-uniform initialisation for a sub-domain.
+- Fix use of `ExtrapolationRule::Constant` for 2D splines.
 
 ### Changed
 

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -34,6 +34,15 @@ template <class... CDim>
 static constexpr bool
         is_ddc_constant_extrapolation_rule_v<ddc::ConstantExtrapolationRule<CDim...>> = true;
 
+template <class ExtrapRule>
+struct ConstantExtrapRuleRank;
+
+template <class... CDim>
+struct ConstantExtrapRuleRank<ddc::ConstantExtrapolationRule<CDim...>>
+{
+    static constexpr std::size_t rank = sizeof...(CDim);
+};
+
 } // namespace details
 
 /// @brief True if get_extrapolation<Rule, CoeffGrid, DataType, ...> can build the rule
@@ -69,21 +78,44 @@ using extrapolation_rule_t = ddc::detail::TypeSeq<
  * Initialise the extrapolation rule using the default constructor if available. For a
  * constant extrapolation, initialise the extrapolation from the selected extremity.
  */
-template <class Rule, class CoeffGrid, class DataType, class Basis>
+template <class Rule, class DataType, class CDim, class IdxRangeCoeff, class IdxRangeBasis>
 Rule get_extrapolation(Extremity extremity)
 {
     if constexpr (std::is_default_constructible_v<Rule>) {
         return Rule();
-    } else if constexpr (details::is_ddc_constant_extrapolation_rule_v<Rule>) {
-        if (extremity == Extremity::FRONT) {
-            return Rule(ddc::discrete_space<Basis>().rmin());
+    }
+
+    using Basis = find_grid_t<CDim, ddc::to_type_seq_t<IdxRangeBasis>>;
+    if constexpr (details::is_ddc_constant_extrapolation_rule_v<Rule>) {
+        static constexpr std::size_t rank = details::ConstantExtrapRuleRank<Rule>::rank;
+        if constexpr (rank == 1) {
+            if (extremity == Extremity::FRONT) {
+                return Rule(ddc::discrete_space<Basis>().rmin());
+            } else {
+                return Rule(ddc::discrete_space<Basis>().rmax());
+            }
         } else {
-            return Rule(ddc::discrete_space<Basis>().rmax());
+            static_assert(rank == 2);
+            using NIBasis = ddc::type_seq_element_t<
+                    0,
+                    ddc::to_type_seq_t<ddc::remove_dims_of_t<Basis, IdxRangeBasis>>>;
+            if (extremity == Extremity::FRONT) {
+                return Rule(
+                        ddc::discrete_space<Basis>().rmin(),
+                        ddc::discrete_space<NIBasis>().rmin(),
+                        ddc::discrete_space<NIBasis>().rmax());
+            } else {
+                return Rule(
+                        ddc::discrete_space<Basis>().rmax(),
+                        ddc::discrete_space<NIBasis>().rmin(),
+                        ddc::discrete_space<NIBasis>().rmax());
+            }
         }
-    } else if constexpr (
-            std::is_same_v<
-                    Rule,
-                    ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>) {
+    }
+    using CoeffGrid = find_grid_t<CDim, ddc::to_type_seq_t<IdxRangeCoeff>>;
+    if constexpr (std::is_same_v<
+                          Rule,
+                          ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>) {
         if (extremity == Extremity::FRONT) {
             return Rule(ddc::discrete_space<Basis>().full_domain().front());
         } else {

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -27,6 +27,13 @@ struct ExtrapolationRuleResolver<
     using type = typename Rule::template type<DataType, Basis, CoeffIdxRange>;
 };
 
+template <class Rule>
+static constexpr bool is_ddc_constant_extrapolation_rule_v = false;
+
+template <class... CDim>
+static constexpr bool
+        is_ddc_constant_extrapolation_rule_v<ddc::ConstantExtrapolationRule<CDim...>> = true;
+
 } // namespace details
 
 /// @brief True if get_extrapolation<Rule, CoeffGrid, DataType, ...> can build the rule
@@ -36,9 +43,7 @@ struct ExtrapolationRuleResolver<
 template <class Rule, class CoeffGrid, class DataType, class Basis>
 constexpr bool is_extrapolation_rule_auto_constructible_v
         = (std::is_default_constructible_v<Rule>)
-          || (std::is_same_v<
-                  Rule,
-                  ddc::ConstantExtrapolationRule<typename CoeffGrid::continuous_dimension_type>>)
+          || (details::is_ddc_constant_extrapolation_rule_v<Rule>)
           || (std::is_same_v<
                   Rule,
                   ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>);
@@ -69,10 +74,7 @@ Rule get_extrapolation(Extremity extremity)
 {
     if constexpr (std::is_default_constructible_v<Rule>) {
         return Rule();
-    } else if constexpr (std::is_same_v<
-                                 Rule,
-                                 ddc::ConstantExtrapolationRule<
-                                         typename Basis::continuous_dimension_type>>) {
+    } else if constexpr (details::is_ddc_constant_extrapolation_rule_v<Rule>) {
         if (extremity == Extremity::FRONT) {
             return Rule(ddc::discrete_space<Basis>().rmin());
         } else {

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -7,7 +7,7 @@ namespace details {
 
 /// Primary template: Rule has no nested `type` alias template, so it is assumed to
 /// already be a concrete, usable extrapolation rule class - use it as-is.
-template <class Rule, class DataType, class Basis, class CoeffIdxRange, class = void>
+template <class Rule, class DataType, class Basis, class IdxRangeCoeff, class = void>
 struct ExtrapolationRuleResolver
 {
     using type = Rule;
@@ -16,15 +16,15 @@ struct ExtrapolationRuleResolver
 /// Specialisation selected via SFINAE when Rule exposes `Rule::type<Basis, DataType>`
 /// (i.e. Rule is a self-describing tag such as ExtrapolationRule::Periodic) - resolve
 /// through it to obtain the concrete extrapolation rule class.
-template <class Rule, class DataType, class Basis, class CoeffIdxRange>
+template <class Rule, class DataType, class Basis, class IdxRangeCoeff>
 struct ExtrapolationRuleResolver<
         Rule,
         DataType,
         Basis,
-        CoeffIdxRange,
-        std::void_t<typename Rule::template type<DataType, Basis, CoeffIdxRange>>>
+        IdxRangeCoeff,
+        std::void_t<typename Rule::template type<DataType, Basis, IdxRangeCoeff>>>
 {
-    using type = typename Rule::template type<DataType, Basis, CoeffIdxRange>;
+    using type = typename Rule::template type<DataType, Basis, IdxRangeCoeff>;
 };
 
 template <class Rule>
@@ -50,18 +50,18 @@ constexpr bool is_extrapolation_rule_auto_constructible_v
 
 /// @brief Resolve Rule (either a self-describing tag or a concrete extrapolation rule
 /// class) to the concrete extrapolation rule class to use for a given Basis/DataType.
-template <class Rule, class DataType, class Basis, class CoeffIdxRange>
+template <class Rule, class DataType, class Basis, class IdxRangeCoeff>
 using extrapolation_rule_t = ddc::detail::TypeSeq<
         typename details::ExtrapolationRuleResolver<
                 ddc::type_seq_element_t<0, Rule>,
                 DataType,
                 Basis,
-                CoeffIdxRange>::type,
+                IdxRangeCoeff>::type,
         typename details::ExtrapolationRuleResolver<
                 ddc::type_seq_element_t<1, Rule>,
                 DataType,
                 Basis,
-                CoeffIdxRange>::type>;
+                IdxRangeCoeff>::type>;
 
 /**
  * @brief Initialise the extrapolation rule.

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -7,7 +7,7 @@ namespace details {
 
 /// Primary template: Rule has no nested `type` alias template, so it is assumed to
 /// already be a concrete, usable extrapolation rule class - use it as-is.
-template <class Rule, class CoeffGrid, class DataType, class Basis, class = void>
+template <class Rule, class DataType, class Basis, class CoeffIdxRange, class = void>
 struct ExtrapolationRuleResolver
 {
     using type = Rule;
@@ -16,15 +16,15 @@ struct ExtrapolationRuleResolver
 /// Specialisation selected via SFINAE when Rule exposes `Rule::type<Basis, DataType>`
 /// (i.e. Rule is a self-describing tag such as ExtrapolationRule::Periodic) - resolve
 /// through it to obtain the concrete extrapolation rule class.
-template <class Rule, class CoeffGrid, class DataType, class Basis>
+template <class Rule, class DataType, class Basis, class CoeffIdxRange>
 struct ExtrapolationRuleResolver<
         Rule,
-        CoeffGrid,
         DataType,
         Basis,
-        std::void_t<typename Rule::template type<CoeffGrid, DataType, Basis>>>
+        CoeffIdxRange,
+        std::void_t<typename Rule::template type<DataType, Basis, CoeffIdxRange>>>
 {
-    using type = typename Rule::template type<CoeffGrid, DataType, Basis>;
+    using type = typename Rule::template type<DataType, Basis, CoeffIdxRange>;
 };
 
 } // namespace details
@@ -45,18 +45,18 @@ constexpr bool is_extrapolation_rule_auto_constructible_v
 
 /// @brief Resolve Rule (either a self-describing tag or a concrete extrapolation rule
 /// class) to the concrete extrapolation rule class to use for a given Basis/DataType.
-template <class Rule, class CoeffGrid, class DataType, class Basis>
+template <class Rule, class DataType, class Basis, class CoeffIdxRange>
 using extrapolation_rule_t = ddc::detail::TypeSeq<
         typename details::ExtrapolationRuleResolver<
                 ddc::type_seq_element_t<0, Rule>,
-                CoeffGrid,
                 DataType,
-                Basis>::type,
+                Basis,
+                CoeffIdxRange>::type,
         typename details::ExtrapolationRuleResolver<
                 ddc::type_seq_element_t<1, Rule>,
-                CoeffGrid,
                 DataType,
-                Basis>::type>;
+                Basis,
+                CoeffIdxRange>::type>;
 
 /**
  * @brief Initialise the extrapolation rule.

--- a/src/interpolation/extrapolation_rule_choice.hpp
+++ b/src/interpolation/extrapolation_rule_choice.hpp
@@ -98,7 +98,7 @@ Rule get_extrapolation(Extremity extremity)
             static_assert(rank == 2);
             using NIBasis = ddc::type_seq_element_t<
                     0,
-                    ddc::to_type_seq_t<ddc::remove_dims_of_t<Basis, IdxRangeBasis>>>;
+                    ddc::to_type_seq_t<ddc::remove_dims_of_t<IdxRangeBasis, Basis>>>;
             if (extremity == Extremity::FRONT) {
                 return Rule(
                         ddc::discrete_space<Basis>().rmin(),

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -102,8 +102,8 @@ namespace ExtrapolationRule {
 struct OneSidedPeriodic
 {
     /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
-    template <class CoeffGrid, class DataType, class Basis>
-    using type = ddc::PeriodicExtrapolationRule<typename CoeffGrid::continuous_dimension_type>;
+    template <class DataType, class Basis, class CoeffGrid>
+    using type = ddc::PeriodicExtrapolationRule<typename Basis::continuous_dimension_type>;
 };
 
 /// @brief Convenience pairing of ExtrapolationRule::OneSidedPeriodic for both boundaries.
@@ -113,12 +113,33 @@ using Periodic = ddc::detail::TypeSeq<OneSidedPeriodic, OneSidedPeriodic>;
 struct NullValue
 {
     /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
-    template <class CoeffGrid, class DataType, class Basis>
+    template <class DataType, class Basis, class CoeffGrid>
     using type = ddc::NullExtrapolationRule;
 };
 
 /// @brief Convenience pairing of ExtrapolationRule::NullValue for both boundaries.
 using Null_Null = ddc::detail::TypeSeq<NullValue, NullValue>;
+
+namespace detail {
+template <class IdxRangeNDims, class CDim>
+struct DDCConstantExtrapolationRuleBuilder;
+
+template <class CDim, class... NDimGrids>
+struct DDCConstantExtrapolationRuleBuilder<IdxRange<NDimGrids...>, CDim>
+{
+    using type = ddc::
+            ConstantExtrapolationRule<CDim, typename NDimGrids::continuous_dimension_type...>;
+};
+} // namespace detail
+
+template <class Basis, class CoeffIdxRange>
+using DDCRule = detail::DDCConstantExtrapolationRuleBuilder<
+        ddc::remove_dims_of_t<
+                CoeffIdxRange,
+                find_grid_t<
+                        typename Basis::continuous_dimension_type,
+                        ddc::to_type_seq_t<CoeffIdxRange>>>,
+        typename Basis::continuous_dimension_type>::type;
 
 /**
  * @brief Tag selecting constant extrapolation.
@@ -128,11 +149,15 @@ using Null_Null = ddc::detail::TypeSeq<NullValue, NullValue>;
 struct Constant
 {
     /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
-    template <class CoeffGrid, class DataType, class Basis>
+    template <class DataType, class Basis, class CoeffIdxRange>
     using type = std::conditional_t<
             is_spline_basis_v<Basis>,
-            ddc::ConstantExtrapolationRule<typename CoeffGrid::continuous_dimension_type>,
-            ConstantIdentityInterpolationExtrapolationRule<CoeffGrid, DataType>>;
+            DDCRule<Basis, CoeffIdxRange>,
+            ConstantIdentityInterpolationExtrapolationRule<
+                    find_grid_t<
+                            typename Basis::continuous_dimension_type,
+                            ddc::to_type_seq_t<CoeffIdxRange>>,
+                    DataType>>;
 };
 
 /// @brief Convenience pairing of ExtrapolationRule::Constant for both boundaries.

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -132,15 +132,6 @@ struct DDCConstantExtrapolationRuleBuilder<IdxRange<NDimGrids...>, CDim>
 };
 } // namespace detail
 
-template <class Basis, class IdxRangeCoeff>
-using DDCRule = detail::DDCConstantExtrapolationRuleBuilder<
-        ddc::remove_dims_of_t<
-                IdxRangeCoeff,
-                find_grid_t<
-                        typename Basis::continuous_dimension_type,
-                        ddc::to_type_seq_t<IdxRangeCoeff>>>,
-        typename Basis::continuous_dimension_type>::type;
-
 /**
  * @brief Tag selecting constant extrapolation.
  *
@@ -152,7 +143,13 @@ struct Constant
     template <class DataType, class Basis, class IdxRangeCoeff>
     using type = std::conditional_t<
             is_spline_basis_v<Basis>,
-            DDCRule<Basis, IdxRangeCoeff>,
+            typename detail::DDCConstantExtrapolationRuleBuilder<
+                    ddc::remove_dims_of_t<
+                            IdxRangeCoeff,
+                            find_grid_t<
+                                    typename Basis::continuous_dimension_type,
+                                    ddc::to_type_seq_t<IdxRangeCoeff>>>,
+                    typename Basis::continuous_dimension_type>::type,
             ConstantIdentityInterpolationExtrapolationRule<
                     find_grid_t<
                             typename Basis::continuous_dimension_type,

--- a/src/interpolation/i_interpolation.hpp
+++ b/src/interpolation/i_interpolation.hpp
@@ -132,13 +132,13 @@ struct DDCConstantExtrapolationRuleBuilder<IdxRange<NDimGrids...>, CDim>
 };
 } // namespace detail
 
-template <class Basis, class CoeffIdxRange>
+template <class Basis, class IdxRangeCoeff>
 using DDCRule = detail::DDCConstantExtrapolationRuleBuilder<
         ddc::remove_dims_of_t<
-                CoeffIdxRange,
+                IdxRangeCoeff,
                 find_grid_t<
                         typename Basis::continuous_dimension_type,
-                        ddc::to_type_seq_t<CoeffIdxRange>>>,
+                        ddc::to_type_seq_t<IdxRangeCoeff>>>,
         typename Basis::continuous_dimension_type>::type;
 
 /**
@@ -149,14 +149,14 @@ using DDCRule = detail::DDCConstantExtrapolationRuleBuilder<
 struct Constant
 {
     /// @brief The concrete extrapolation rule class for a given CoeffGrid/DataType.
-    template <class DataType, class Basis, class CoeffIdxRange>
+    template <class DataType, class Basis, class IdxRangeCoeff>
     using type = std::conditional_t<
             is_spline_basis_v<Basis>,
-            DDCRule<Basis, CoeffIdxRange>,
+            DDCRule<Basis, IdxRangeCoeff>,
             ConstantIdentityInterpolationExtrapolationRule<
                     find_grid_t<
                             typename Basis::continuous_dimension_type,
-                            ddc::to_type_seq_t<CoeffIdxRange>>,
+                            ddc::to_type_seq_t<IdxRangeCoeff>>,
                     DataType>>;
 };
 

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -120,13 +120,13 @@ public:
                             Basis>))
         : m_min_extrapolation(get_extrapolation<
                               MinExtrapolationRule,
-                              double,
+                              DataType,
                               typename Basis::continuous_dimension_type,
                               IdxRange<CoeffGridType>,
                               IdxRange<Basis>>(Extremity::FRONT))
         , m_max_extrapolation(get_extrapolation<
                               MaxExtrapolationRule,
-                              double,
+                              DataType,
                               typename Basis::continuous_dimension_type,
                               IdxRange<CoeffGridType>,
                               IdxRange<Basis>>(Extremity::BACK))
@@ -318,13 +318,13 @@ public:
                       MaxRule<ExtrapRules>>(
                 get_extrapolation<
                         MinRule<ExtrapRules>,
-                        double,
+                        DataType,
                         typename Basis::continuous_dimension_type,
                         IdxRange<CoeffGrid<Basis>>,
                         IdxRange<Basis>>(Extremity::FRONT),
                 get_extrapolation<
                         MaxRule<ExtrapRules>,
-                        double,
+                        DataType,
                         typename Basis::continuous_dimension_type,
                         IdxRange<CoeffGrid<Basis>>,
                         IdxRange<Basis>>(Extremity::BACK))...)

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -118,12 +118,18 @@ public:
                             CoeffGridType,
                             DataType,
                             Basis>))
-        : m_min_extrapolation(
-                get_extrapolation<MinExtrapolationRule, CoeffGridType, DataType, Basis>(
-                        Extremity::FRONT))
-        , m_max_extrapolation(
-                  get_extrapolation<MaxExtrapolationRule, CoeffGridType, DataType, Basis>(
-                          Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<
+                              MinExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<CoeffGridType>,
+                              IdxRange<Basis>>(Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<
+                              MaxExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<CoeffGridType>,
+                              IdxRange<Basis>>(Extremity::BACK))
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
     }
@@ -310,10 +316,18 @@ public:
                       Grid1D,
                       MinRule<ExtrapRules>,
                       MaxRule<ExtrapRules>>(
-                get_extrapolation<MinRule<ExtrapRules>, CoeffGrid<Basis>, DataType, Basis>(
-                        Extremity::FRONT),
-                get_extrapolation<MaxRule<ExtrapRules>, CoeffGrid<Basis>, DataType, Basis>(
-                        Extremity::BACK))...)
+                get_extrapolation<
+                        MinRule<ExtrapRules>,
+                        double,
+                        typename Basis::continuous_dimension_type,
+                        IdxRange<CoeffGrid<Basis>>,
+                        IdxRange<Basis>>(Extremity::FRONT),
+                get_extrapolation<
+                        MaxRule<ExtrapRules>,
+                        double,
+                        typename Basis::continuous_dimension_type,
+                        IdxRange<CoeffGrid<Basis>>,
+                        IdxRange<Basis>>(Extremity::BACK))...)
     {
     }
 

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -397,14 +397,14 @@ struct LagrangeInterpolatorResolver<
             Grid1D,
             extrapolation_rule_t<
                     ExtrapRules,
+                    DataType,
+                    Basis,
                     typename IdentityInterpolationBuilder<
                             ExecSpace,
                             typename ExecSpace::memory_space,
                             DataType,
                             Grid1D,
-                            Basis>::basis_domain_type,
-                    DataType,
-                    Basis>,
+                            Basis>::coeff_idx_range_type>,
             DataType>;
 };
 
@@ -436,13 +436,25 @@ struct LagrangeInterpolatorResolver<
                                     BasisHead,
                                     typename ExecSpace::memory_space>::knot_grid,
                             DataType,
-                            BasisHead>,
+                            BasisHead,
+                            typename NDIdentityInterpolationBuilder<
+                                    ExecSpace,
+                                    typename ExecSpace::memory_space,
+                                    DataType,
+                                    IdxRange<Grid1DHead, Grid1D...>,
+                                    IdxRange<BasisHead, Basis...>>::coeff_idx_range_type>,
                     extrapolation_rule_t<
                             ExtrapRules,
                             typename Basis::template Impl<Basis, typename ExecSpace::memory_space>::
                                     knot_grid,
                             DataType,
-                            Basis>...>,
+                            Basis,
+                            typename NDIdentityInterpolationBuilder<
+                                    ExecSpace,
+                                    typename ExecSpace::memory_space,
+                                    DataType,
+                                    IdxRange<Grid1DHead, Grid1D...>,
+                                    IdxRange<BasisHead, Basis...>>::coeff_idx_range_type>...>,
             DataType>;
 };
 } // namespace detail

--- a/src/interpolation/lagrange_interpolation.hpp
+++ b/src/interpolation/lagrange_interpolation.hpp
@@ -432,9 +432,6 @@ struct LagrangeInterpolatorResolver<
             ddc::detail::TypeSeq<
                     extrapolation_rule_t<
                             ExtrapRulesHead,
-                            typename BasisHead::template Impl<
-                                    BasisHead,
-                                    typename ExecSpace::memory_space>::knot_grid,
                             DataType,
                             BasisHead,
                             typename NDIdentityInterpolationBuilder<
@@ -445,8 +442,6 @@ struct LagrangeInterpolatorResolver<
                                     IdxRange<BasisHead, Basis...>>::coeff_idx_range_type>,
                     extrapolation_rule_t<
                             ExtrapRules,
-                            typename Basis::template Impl<Basis, typename ExecSpace::memory_space>::
-                                    knot_grid,
                             DataType,
                             Basis,
                             typename NDIdentityInterpolationBuilder<

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -162,10 +162,18 @@ public:
                             InterpGrid,
                             double,
                             Basis>)
-        : m_min_extrapolation(get_extrapolation<MinExtrapolationRule, InterpGrid, double, Basis>(
-                Extremity::FRONT))
-        , m_max_extrapolation(get_extrapolation<MaxExtrapolationRule, InterpGrid, double, Basis>(
-                  Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<
+                              MinExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<InterpGrid>,
+                              IdxRange<Basis>>(Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<
+                              MaxExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<InterpGrid>,
+                              IdxRange<Basis>>(Extremity::BACK))
         , m_builder(label, idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
@@ -192,10 +200,18 @@ public:
                             InterpGrid,
                             double,
                             Basis>)
-        : m_min_extrapolation(get_extrapolation<MinExtrapolationRule, InterpGrid, double, Basis>(
-                Extremity::FRONT))
-        , m_max_extrapolation(get_extrapolation<MaxExtrapolationRule, InterpGrid, double, Basis>(
-                  Extremity::BACK))
+        : m_min_extrapolation(get_extrapolation<
+                              MinExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<InterpGrid>,
+                              IdxRange<Basis>>(Extremity::FRONT))
+        , m_max_extrapolation(get_extrapolation<
+                              MaxExtrapolationRule,
+                              double,
+                              typename Basis::continuous_dimension_type,
+                              IdxRange<InterpGrid>,
+                              IdxRange<Basis>>(Extremity::BACK))
         , m_builder(idx_range)
         , m_evaluator(m_min_extrapolation, m_max_extrapolation)
     {
@@ -442,18 +458,30 @@ public:
                             InterpGrid2,
                             double,
                             Basis2>)&&(is_extrapolation_rule_auto_constructible_v<MaxExtrapolationRule2, InterpGrid2, double, Basis2>))
-        : m_min_extrapolation1(
-                get_extrapolation<MinExtrapolationRule1, InterpGrid1, double, Basis1>(
-                        Extremity::FRONT))
-        , m_max_extrapolation1(
-                  get_extrapolation<MaxExtrapolationRule1, InterpGrid1, double, Basis1>(
-                          Extremity::BACK))
-        , m_min_extrapolation2(
-                  get_extrapolation<MinExtrapolationRule2, InterpGrid2, double, Basis2>(
-                          Extremity::FRONT))
-        , m_max_extrapolation2(
-                  get_extrapolation<MaxExtrapolationRule2, InterpGrid2, double, Basis2>(
-                          Extremity::BACK))
+        : m_min_extrapolation1(get_extrapolation<
+                               MinExtrapolationRule1,
+                               double,
+                               typename Basis1::continuous_dimension_type,
+                               IdxRange<InterpGrid1, InterpGrid2>,
+                               IdxRange<Basis1, Basis2>>(Extremity::FRONT))
+        , m_max_extrapolation1(get_extrapolation<
+                               MaxExtrapolationRule1,
+                               double,
+                               typename Basis1::continuous_dimension_type,
+                               IdxRange<InterpGrid1, InterpGrid2>,
+                               IdxRange<Basis1, Basis2>>(Extremity::BACK))
+        , m_min_extrapolation2(get_extrapolation<
+                               MinExtrapolationRule2,
+                               double,
+                               typename Basis2::continuous_dimension_type,
+                               IdxRange<InterpGrid1, InterpGrid2>,
+                               IdxRange<Basis1, Basis2>>(Extremity::FRONT))
+        , m_max_extrapolation2(get_extrapolation<
+                               MaxExtrapolationRule2,
+                               double,
+                               typename Basis2::continuous_dimension_type,
+                               IdxRange<InterpGrid1, InterpGrid2>,
+                               IdxRange<Basis1, Basis2>>(Extremity::BACK))
         , m_builder(idx_range)
         , m_evaluator(
                   m_min_extrapolation1,

--- a/src/interpolation/spline_interpolation.hpp
+++ b/src/interpolation/spline_interpolation.hpp
@@ -550,7 +550,7 @@ struct SplineInterpolatorResolver<
             ExecSpace,
             Basis,
             InterpGrid,
-            extrapolation_rule_t<ExtrapRules, InterpGrid, double, Basis>,
+            extrapolation_rule_t<ExtrapRules, double, Basis, IdxRange<InterpGrid>>,
             BoundaryClosures,
             Solver>;
 };
@@ -584,8 +584,16 @@ struct SplineInterpolatorResolver<
             InterpGrid1,
             InterpGrid2,
             ddc::detail::TypeSeq<
-                    extrapolation_rule_t<ExtrapRules1, InterpGrid1, double, Basis1>,
-                    extrapolation_rule_t<ExtrapRules2, InterpGrid2, double, Basis2>>,
+                    extrapolation_rule_t<
+                            ExtrapRules1,
+                            double,
+                            Basis1,
+                            IdxRange<InterpGrid1, InterpGrid2>>,
+                    extrapolation_rule_t<
+                            ExtrapRules2,
+                            double,
+                            Basis2,
+                            IdxRange<InterpGrid1, InterpGrid2>>>,
             ddc::detail::TypeSeq<BoundaryClosures1, BoundaryClosures2>,
             Solver>;
 };

--- a/tests/math_tools/test_partial_derivatives.cpp
+++ b/tests/math_tools/test_partial_derivatives.cpp
@@ -356,60 +356,48 @@ public:
     using typename base_type::IdxRangeXY;
     using typename base_type::IdxRangeY;
 
-    static constexpr ddc::SplineBuilderClosure SplineClosure
-            = X::PERIODIC ? ddc::SplineBuilderClosure::PERIODIC
-                          : ddc::SplineBuilderClosure::GREVILLE;
+    using SplineClosureX = std::conditional_t<
+            X::PERIODIC,
+            SplineBoundaryClosure::Periodic,
+            SplineBoundaryClosure::Greville_Greville>;
+    using SplineClosureY = std::conditional_t<
+            Y::PERIODIC,
+            SplineBoundaryClosure::Periodic,
+            SplineBoundaryClosure::Greville_Greville>;
 
     struct BSplinesX : ddc::NonUniformBSplines<X, spline_degree>
     {
     };
-    using SplineInterpPointsX
-            = ddc::GrevilleInterpolationPoints<BSplinesX, SplineClosure, SplineClosure>;
+    using SplineInterpPointsX = ddc::GrevilleInterpolationPoints<
+            BSplinesX,
+            SplineClosureX::min::value,
+            SplineClosureX::max::value>;
 
     struct BSplinesY : ddc::NonUniformBSplines<Y, spline_degree>
     {
     };
-    using SplineInterpPointsY
-            = ddc::GrevilleInterpolationPoints<BSplinesY, SplineClosure, SplineClosure>;
-
-    using SplineBuilder2D = ddc::SplineBuilder2D<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            BSplinesX,
+    using SplineInterpPointsY = ddc::GrevilleInterpolationPoints<
             BSplinesY,
-            GridX,
-            GridY,
-            SplineClosure,
-            SplineClosure,
-            SplineClosure,
-            SplineClosure,
-            ddc::SplineSolver::LAPACK>;
+            SplineClosureY::min::value,
+            SplineClosureY::max::value>;
 
-    using XExtrapolationRule = std::conditional_t<
+    using XExtrapolationRules = std::conditional_t<
             X::PERIODIC,
-            ddc::PeriodicExtrapolationRule<X>,
-            ddc::ConstantExtrapolationRule<X, Y>>;
+            ExtrapolationRule::Periodic,
+            ExtrapolationRule::Constant_Constant>;
     using YExtrapolationRule = std::conditional_t<
             Y::PERIODIC,
-            ddc::PeriodicExtrapolationRule<Y>,
-            ddc::ConstantExtrapolationRule<Y, X>>;
+            ExtrapolationRule::Periodic,
+            ExtrapolationRule::Constant_Constant>;
 
-    using SplineEvaluator2D = ddc::SplineEvaluator2D<
+    using SplineInterpolator2D = SplineInterpolator<
             Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            BSplinesX,
-            BSplinesY,
-            GridX,
-            GridY,
-            XExtrapolationRule,
-            XExtrapolationRule,
+            IdxRange<BSplinesX, BSplinesY>,
+            IdxRangeXY,
+            XExtrapolationRules,
             YExtrapolationRule,
-            YExtrapolationRule>;
-
-    XExtrapolationRule const m_bv_xmin;
-    XExtrapolationRule const m_bv_xmax;
-    YExtrapolationRule const m_bv_ymin;
-    YExtrapolationRule const m_bv_ymax;
+            SplineClosureX,
+            SplineClosureY>;
 
 public:
     PartialDerivativeTestSpline2D(
@@ -418,10 +406,6 @@ public:
             double const ymin,
             double const ymax)
         : base_type(xmin, xmax, ymin, ymax)
-        , m_bv_xmin(get_x_bv(Coord<X>(xmin), Coord<Y>(ymin), Coord<Y>(ymax)))
-        , m_bv_xmax(get_x_bv(Coord<X>(xmax), Coord<Y>(ymin), Coord<Y>(ymax)))
-        , m_bv_ymin(get_y_bv(Coord<Y>(ymin), Coord<X>(xmin), Coord<X>(xmax)))
-        , m_bv_ymax(get_y_bv(Coord<Y>(ymax), Coord<X>(xmin), Coord<X>(xmax)))
     {
         std::vector<Coord<X>> point_sampling_x = build_random_non_uniform_break_points(
                 base_type::m_xmin,
@@ -448,12 +432,15 @@ public:
         IdxRangeY const idxrange_y = SplineInterpPointsY::template get_domain<GridY>();
         IdxRangeXY const idxrange = IdxRangeXY(idxrange_x, idxrange_y);
 
-        SplineBuilder2D builder(idxrange);
-        SplineBuilder2DCache<SplineBuilder2D, IdxRangeXY> builder_cache(builder, idxrange);
-        SplineEvaluator2D evaluator(m_bv_xmin, m_bv_xmax, m_bv_ymin, m_bv_ymax);
+        SplineInterpolator2D interpolator(idxrange);
+        SplineBuilder2DCache<typename SplineInterpolator2D::BuilderType, IdxRangeXY>
+                builder_cache(interpolator.get_builder(), idxrange);
 
-        Spline2DPartialDerivativeCreator<SplineBuilder2D, SplineEvaluator2D, DDim, IdxRangeXY> const
-                derivative_creator(builder_cache, evaluator);
+        Spline2DPartialDerivativeCreator<
+                typename SplineInterpolator2D::BuilderType,
+                typename SplineInterpolator2D::EvaluatorType,
+                DDim,
+                IdxRangeXY> const derivative_creator(builder_cache, interpolator.get_evaluator());
 
         FunctionToDifferentiateCosine<X, Y> function_to_differentiate;
         double const max_error = base_type::template compute_max_error<
@@ -463,24 +450,6 @@ public:
                         Y>>(idxrange, function_to_differentiate, derivative_creator, max_distance);
 
         return max_error;
-    }
-
-private:
-    static XExtrapolationRule get_x_bv(Coord<X> xmin, Coord<Y> ymin, Coord<Y> ymax)
-    {
-        if constexpr (X::PERIODIC) {
-            return XExtrapolationRule();
-        } else {
-            return XExtrapolationRule(xmin, ymin, ymax);
-        }
-    }
-    static YExtrapolationRule get_y_bv(Coord<Y> ymin, Coord<X> xmin, Coord<X> xmax)
-    {
-        if constexpr (Y::PERIODIC) {
-            return YExtrapolationRule();
-        } else {
-            return YExtrapolationRule(ymin, xmin, xmax);
-        }
     }
 };
 


### PR DESCRIPTION
Modify template argument order in `ExtrapolationRuleResolver` to pass `CoeffIdxRange` instead of `CoeffGrid`. This allows ND `ddc::ConstantExtrapolationRule` objects to be initialised (although DDC currently only provides a 1D and a 2D version).

Fixes #745 

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
