### PR TITLE
Move `GMGPolar` setup

### DIFF
--- a/.github/actions/test_filter/action.yml
+++ b/.github/actions/test_filter/action.yml
@@ -11,7 +11,7 @@ runs:
       echo "CHANGED_FILES=${changed_files}" >> $GITHUB_ENV
       FOUND_POLAR_SPLINES=$(grep "src/interpolation/polar_splines/.*" -x changed_files.txt || true)
       if [ -n "$FOUND_POLAR_SPLINES" ]; then echo "GYSELALIBXX_POLAR_SPLINES_TEST_DEGREE_MIN=1" >> $GITHUB_ENV; echo "GYSELALIBXX_POLAR_SPLINES_TEST_DEGREE_MIN=6" >> $GITHUB_ENV; fi
-      FOUND_POISSON_2D=$(grep -P "(src/pde_solvers/polarpoissonlikesolver.hpp)|(src/pde_solvers/polarpoissonlikeassembler.hpp)|(tests/geometryRTheta/polar_poisson/.*)" -x changed_files.txt || true)
+      FOUND_POISSON_2D=$(grep -P "(src/pde_solvers/polarpoissonlikesolver.hpp)|(src/pde_solvers/polarpoissonlikeassembler.hpp)|(src/pde_solvers/gmg_polar_poisson_like_solver.hpp)|(tests/geometryRTheta/polar_poisson/.*)" -x changed_files.txt || true)
       if [ -z "$FOUND_POISSON_2D" ]; then echo "GYSELALIBXX_POISSON_2D_BUILD_TESTING=OFF" >> $GITHUB_ENV; else echo "GYSELALIBXX_POISSON_2D_BUILD_TESTING=ON" >> $GITHUB_ENV; fi
     shell: bash
   - name: "Check filters"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Group spline boundary closure rules by dimension in `SplineInterpolator`.
 - Change the `LagrangeInterpolator` templates to allow ND cases to be handled.
 - Change the `SplineInterpolator` templates to allow 2D cases to be handled.
+- Setup `GMGPolar` in `GMGPolarPoissonLikeSolver::update_coefficients` instead of `GMGPolarPoissonLikeSolver::operator()`.
 
 ### Deprecated
 

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -188,7 +188,7 @@ private:
     int m_max_iterations;
     double m_absTol;
     double m_relTol;
-    gmgpolar::PolarGrid m_grid;
+    gmgpolar::PolarGrid m_polar_grid;
     std::unique_ptr<gmgpolar::GMGPolar<DomainGeometry, DensityCoeffs>> m_solver;
 
 
@@ -322,9 +322,10 @@ public:
         Kokkos::View<double*> solution = m_solver->solution();
 
         gmgpolar::PolarGrid const& polar_grid = m_grid;
+        IdxRangeRTheta idx_range(get_idx_range(phi));
 
         ddc::parallel_for_each(
-                get_idx_range(phi),
+                idx_range,
                 KOKKOS_LAMBDA(IdxRTheta idx) {
                     IdxStepRTheta offset(idx - idx_range.front());
                     int i_r = ddc::select<GridR>(offset);

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -188,6 +188,9 @@ private:
     int m_max_iterations;
     double m_absTol;
     double m_relTol;
+
+    DFieldMem<IdxRangeR> m_r_coords;
+    DFieldMem<IdxRangeTheta> m_theta_coords;
     gmgpolar::PolarGrid m_polar_grid;
     std::unique_ptr<gmgpolar::GMGPolar<DomainGeometry, DensityCoeffs>> m_solver;
 
@@ -232,14 +235,15 @@ public:
         IdxRangeTheta idx_range_theta_with_poloidal_point(
                 idx_range_theta.front(),
                 idx_range_theta.extents() + 1);
-        DFieldMem<IdxRangeR> r_coords(idx_range_r);
-        DFieldMem<IdxRangeTheta> theta_coords(idx_range_theta_with_poloidal_point);
-        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(r_coords));
-        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(theta_coords));
+        m_r_coords = DFieldMem<IdxRangeR>(idx_range_r);
+        m_theta_coords = DFieldMem<IdxRangeTheta>(idx_range_theta_with_poloidal_point);
+        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(m_r_coords));
+        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(m_theta_coords));
 
         // --- Create a cartesian grid representation of the polar grid for GMGPolar --- //
-        m_polar_grid = gmgpolar::
-                PolarGrid(r_coords.allocation_kokkos_view(), theta_coords.allocation_kokkos_view());
+        m_polar_grid = gmgpolar::PolarGrid(
+                m_r_coords.allocation_kokkos_view(),
+                m_theta_coords.allocation_kokkos_view());
     }
 
     /**

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -256,7 +256,7 @@ public:
         // --- Create GMGPolar solver for the selected geometry and coefficients --- //
         m_solver = std::make_unique<gmgpolar::GMGPolar<
                 DomainGeometry,
-                DensityCoeffs>>(m_grid, m_domain_geom, m_density_coeffs);
+                DensityCoeffs>>(m_polar_grid, m_domain_geom, m_density_coeffs);
 
         // ------------------//
         // Solver parameters //
@@ -321,7 +321,7 @@ public:
         // Copy solution back to phi
         Kokkos::View<double*> solution = m_solver->solution();
 
-        gmgpolar::PolarGrid const& polar_grid = m_grid;
+        gmgpolar::PolarGrid const& polar_grid = m_polar_grid;
         IdxRangeRTheta idx_range(get_idx_range(phi));
 
         ddc::parallel_for_each(

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -188,6 +188,8 @@ private:
     int m_max_iterations;
     double m_absTol;
     double m_relTol;
+    gmgpolar::PolarGrid m_grid;
+    std::unique_ptr<gmgpolar::GMGPolar<DomainGeometry, DensityCoeffs>> m_solver;
 
 
 public:
@@ -224,6 +226,20 @@ public:
         , m_absTol(absTol.value_or(1e-10))
         , m_relTol(relTol.value_or(1e-6))
     {
+        IdxRangeRTheta idx_range(builder.interpolation_domain());
+        IdxRangeR idx_range_r(idx_range);
+        IdxRangeTheta idx_range_theta(idx_range);
+        IdxRangeTheta idx_range_theta_with_poloidal_point(
+                idx_range_theta.front(),
+                idx_range_theta.extents() + 1);
+        DFieldMem<IdxRangeR> r_coords(idx_range_r);
+        DFieldMem<IdxRangeTheta> theta_coords(idx_range_theta_with_poloidal_point);
+        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(r_coords));
+        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(theta_coords));
+
+        // --- Create a cartesian grid representation of the polar grid for GMGPolar --- //
+        m_polar_grid = gmgpolar::
+                PolarGrid(r_coords.allocation_kokkos_view(), theta_coords.allocation_kokkos_view());
     }
 
     /**
@@ -236,6 +252,58 @@ public:
     {
         m_builder(get_field(m_coeff_alpha), get_const_field(alpha));
         m_builder(get_field(m_coeff_beta), get_const_field(beta));
+
+        // --- Create GMGPolar solver for the selected geometry and coefficients --- //
+        m_solver = std::make_unique<gmgpolar::GMGPolar<
+                DomainGeometry,
+                DensityCoeffs>>(m_grid, m_domain_geom, m_density_coeffs);
+
+        // ------------------//
+        // Solver parameters //
+        // ------------------//
+
+        // --- General solver output and visualisation settings --- //
+        m_solver->verbose(0); // Enable/disable verbose output
+        m_solver->paraview(false); // Enable/disable ParaView output
+
+        // --- Numerical method setup --- //
+        // Are boundary conditions provided on the interior. False = Use Across-the-origin discretisation
+        m_solver->DirBC_Interior(false);
+        // Stencil distribution strategy: Take, Give
+        m_solver->stencilDistributionMethod(StencilDistributionMethod::TAKE);
+        // Cache density profile coefficients: alpha, beta
+        m_solver->cacheDensityProfileCoefficients(true);
+        // Cache domain geometry data: arr, att, art, detDF
+        m_solver->cacheDomainGeometry(true);
+
+        // --- Multigrid settings --- //
+        m_solver->extrapolation(m_extrapolation_rule); // Select extrapolation
+        m_solver->maxLevels(-1); // Max multigrid levels (-1 = use deepest possible)
+        m_solver->preSmoothingSteps(1); // Smoothing before coarse-grid correction
+        m_solver->postSmoothingSteps(1); // Smoothing after coarse-grid correction
+        m_solver->multigridCycle(MultigridCycleType::V_CYCLE); // Multigrid cycle type
+        m_solver->FMG(true); // Full Multigrid mode on/off
+        m_solver->FMG_iterations(2); // FMG iteration count
+        m_solver->FMG_cycle(MultigridCycleType::F_CYCLE); // FMG cycle type
+
+        // --- Preconditioned Conjugate Gradient settings --- //
+        m_solver->PCG(false); // Preconditioned Conjugate Gradient mode on/off
+        m_solver->PCG_FMG(true); // Use FMG as preconditioner for PCG
+        m_solver->PCG_FMG_iterations(1); // FMG iterations for PCG preconditioner
+        m_solver->PCG_FMG_cycle(
+                MultigridCycleType::V_CYCLE); // FMG cycle type for PCG preconditioner
+        m_solver->PCG_MG_iterations(1); // Multigrid iterations for PCG preconditioner
+        m_solver->PCG_MG_cycle(
+                MultigridCycleType::V_CYCLE); // Multigrid cycle type for PCG iterations
+
+        // --- Iterative solver controls --- //
+        m_solver->maxIterations(m_max_iterations); // Max number of iterations
+        m_solver->residualNormType(ResidualNormType::WEIGHTED_EUCLIDEAN); // Residual norm type
+        m_solver->absoluteTolerance(m_absTol); // Absolute residual tolerance
+        m_solver->relativeTolerance(m_relTol); // Relative residual tolerance
+
+        // --- Finalise solver setup --- //
+        m_solver->setup();
     }
 
     /**
@@ -246,82 +314,17 @@ public:
      */
     void operator()(DField<IdxRangeRTheta> phi, DConstField<IdxRangeRTheta> rho) const override
     {
-        IdxRangeRTheta idx_range = get_idx_range(phi);
-        IdxRangeR idx_range_r(idx_range);
-        IdxRangeTheta idx_range_theta(idx_range);
-        IdxRangeTheta idx_range_theta_with_poloidal_point(
-                idx_range_theta.front(),
-                idx_range_theta.extents() + 1);
-
-        DFieldMem<IdxRangeR> r_coords(idx_range_r);
-        DFieldMem<IdxRangeTheta> theta_coords(idx_range_theta_with_poloidal_point);
-        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(r_coords));
-        ddcHelper::dump_coordinates(Kokkos::DefaultExecutionSpace(), get_field(theta_coords));
-
-        // --- Create a cartesian grid representation of the polar grid for GMGPolar --- //
-        gmgpolar::PolarGrid const polar_grid(
-                r_coords.allocation_kokkos_view(),
-                theta_coords.allocation_kokkos_view());
-
-        // --- Create GMGPolar solver for the selected geometry and coefficients --- //
-        gmgpolar::GMGPolar<DomainGeometry, DensityCoeffs>
-                solver(polar_grid, m_domain_geom, m_density_coeffs);
-
-        // ------------------//
-        // Solver parameters //
-        // ------------------//
-
-        // --- General solver output and visualisation settings --- //
-        solver.verbose(0); // Enable/disable verbose output
-        solver.paraview(false); // Enable/disable ParaView output
-
-        // --- Numerical method setup --- //
-        // Are boundary conditions provided on the interior. False = Use Across-the-origin discretisation
-        solver.DirBC_Interior(false);
-        // Stencil distribution strategy: Take, Give
-        solver.stencilDistributionMethod(StencilDistributionMethod::TAKE);
-        // Cache density profile coefficients: alpha, beta
-        solver.cacheDensityProfileCoefficients(true);
-        // Cache domain geometry data: arr, att, art, detDF
-        solver.cacheDomainGeometry(true);
-
-        // --- Multigrid settings --- //
-        solver.extrapolation(m_extrapolation_rule); // Select extrapolation
-        solver.maxLevels(-1); // Max multigrid levels (-1 = use deepest possible)
-        solver.preSmoothingSteps(1); // Smoothing before coarse-grid correction
-        solver.postSmoothingSteps(1); // Smoothing after coarse-grid correction
-        solver.multigridCycle(MultigridCycleType::V_CYCLE); // Multigrid cycle type
-        solver.FMG(true); // Full Multigrid mode on/off
-        solver.FMG_iterations(2); // FMG iteration count
-        solver.FMG_cycle(MultigridCycleType::F_CYCLE); // FMG cycle type
-
-        // --- Preconditioned Conjugate Gradient settings --- //
-        solver.PCG(false); // Preconditioned Conjugate Gradient mode on/off
-        solver.PCG_FMG(true); // Use FMG as preconditioner for PCG
-        solver.PCG_FMG_iterations(1); // FMG iterations for PCG preconditioner
-        solver.PCG_FMG_cycle(MultigridCycleType::V_CYCLE); // FMG cycle type for PCG preconditioner
-        solver.PCG_MG_iterations(1); // Multigrid iterations for PCG preconditioner
-        solver.PCG_MG_cycle(MultigridCycleType::V_CYCLE); // Multigrid cycle type for PCG iterations
-
-        // --- Iterative solver controls --- //
-        solver.maxIterations(m_max_iterations); // Max number of iterations
-        solver.residualNormType(ResidualNormType::WEIGHTED_EUCLIDEAN); // Residual norm type
-        solver.absoluteTolerance(m_absTol); // Absolute residual tolerance
-        solver.relativeTolerance(m_relTol); // Relative residual tolerance
-
-        // --- Finalise solver setup --- //
-        solver.setup();
-
         // Source term: maps GMGPolar (i_r, i_theta) indices to rho grid values
         GMGPolarTools::HomogeneousDirichletBoundaryConditions const bcs;
-        solver.solve(bcs, rho.allocation_kokkos_view());
+        m_solver->solve(bcs, rho.allocation_kokkos_view());
 
         // Copy solution back to phi
-        //Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace> solution = solver.solution();
-        Kokkos::View<double*> solution = solver.solution();
+        Kokkos::View<double*> solution = m_solver->solution();
+
+        gmgpolar::PolarGrid const& polar_grid = m_grid;
 
         ddc::parallel_for_each(
-                idx_range,
+                get_idx_range(phi),
                 KOKKOS_LAMBDA(IdxRTheta idx) {
                     IdxStepRTheta offset(idx - idx_range.front());
                     int i_r = ddc::select<GridR>(offset);

--- a/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
+++ b/src/pde_solvers/gmg_polar_poisson_like_solver.hpp
@@ -292,7 +292,7 @@ public:
         m_solver->PCG_FMG_iterations(1); // FMG iterations for PCG preconditioner
         m_solver->PCG_FMG_cycle(
                 MultigridCycleType::V_CYCLE); // FMG cycle type for PCG preconditioner
-        m_solver->PCG_MG_iterations(1); // Multigrid iterations for PCG preconditioner
+        m_solver->PCG_MG_iterations(2); // Multigrid iterations for PCG preconditioner
         m_solver->PCG_MG_cycle(
                 MultigridCycleType::V_CYCLE); // Multigrid cycle type for PCG iterations
 


### PR DESCRIPTION
Setup `GMGPolar` in `GMGPolarPoissonLikeSolver::update_coefficients` instead of `GMGPolarPoissonLikeSolver::operator()`. This should improve the speed, especially if `update_coefficients` is not called at every time step.

Also fix the trigger so GMGPolar is also tested on CPU.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
