### PR TITLE
Ensure 2D polar advection operators work with generic interpolators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix H100 toolchain on Jean-Zay.
 - Fix Lagrange basis non-uniform initialisation for a sub-domain.
 - Fix use of `ExtrapolationRule::Constant` for 2D splines.
+- Fix use of a generic interpolator in `FEM1DPoissonSolver` and `PolarFootFinder`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix H100 toolchain on Jean-Zay.
 - Fix Lagrange basis non-uniform initialisation for a sub-domain.
 - Fix use of `ExtrapolationRule::Constant` for 2D splines.
-- Fix use of a generic interpolator in `FEM1DPoissonSolver` and `PolarFootFinder`.
+- Fix use of a generic interpolator in `FEM1DPoissonSolver`, `PolarFootFinder` and `BslAdvectionPolar`.
 
 ### Changed
 

--- a/src/advection/bsl_advection_polar.hpp
+++ b/src/advection/bsl_advection_polar.hpp
@@ -4,6 +4,7 @@
 #include "ddc_alias_inline_functions.hpp"
 #include "ddc_aliases.hpp"
 #include "i_interpolation.hpp"
+#include "i_interpolation_builder.hpp"
 #include "indexed_tensor.hpp"
 #include "l_norm_tools.hpp"
 #include "metric_tensor_evaluator.hpp"

--- a/src/advection/bsl_advection_polar.hpp
+++ b/src/advection/bsl_advection_polar.hpp
@@ -43,7 +43,7 @@
  * which are determined in the PolarFootFinder operator.
  *
  * The interpolation of the function is always done in the logical domain,
- * where the B-splines are defined. 
+ * where the interpolation is defined.
  *
  *
  * @see IPolarFootFinder
@@ -86,8 +86,8 @@ class BslAdvectionPolar
     using Builder2D = typename Interpolator2D::BuilderType;
     using Evaluator2D = typename Interpolator2D::EvaluatorType;
 
-    using IdxRangeBSRTheta =
-            typename Builder2D::template batched_spline_domain_type<IdxRangeBatched>;
+    using IdxRangeCoeffBatchedRTheta = typename InterpolationBuilderTraits<
+            Builder2D>::template batched_basis_idx_range_type<IdxRangeBatched>;
 
     using DFieldFDistribu = DField<IdxRangeBatched, MemorySpace>;
 
@@ -177,9 +177,9 @@ public:
             DVectorConstFieldAdvection advection_field,
             double dt) const
     {
-        // Pre-allocate spline coefficient storage
-        DFieldMem<IdxRangeBSRTheta, MemorySpace> coefs_alloc(
-                m_builder_2d.batched_spline_domain(get_idx_range(allfdistribu)));
+        // Pre-allocate coefficient storage
+        DFieldMem<IdxRangeCoeffBatchedRTheta, MemorySpace> coefs_alloc(
+                batched_basis_idx_range(m_builder_2d, get_idx_range(allfdistribu)));
 
         // Compute the feet of the characteristics at tn -----------------------------------------
         typename FootFinder::ElementwiseOperator find_foot_alloc
@@ -192,7 +192,7 @@ public:
 
         Evaluator2D const& evaluator_2d_proxy = m_evaluator_2d;
 
-        DConstField<IdxRangeBSRTheta, MemorySpace> coefs = get_const_field(coefs_alloc);
+        DConstField<IdxRangeCoeffBatchedRTheta, MemorySpace> coefs = get_const_field(coefs_alloc);
 
         IdxRangeBatched idx_range_advected_points;
         if (m_idx_range_advected_points) {

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -20,7 +20,7 @@
 /**
  * @brief Operator for finding the feet of the characteristics on a polar slice.
  *
- * Calculates the spline representation of the advection field and uses it together
+ * Calculates the interplation representation of the advection field and uses it together
  * with a time-stepping method to solve the characteristic equation. The space in
  * which the advection field is expressed and the space in which foot-finding is
  * performed are selected at compile time via @p FFSpace and @p AFSpace.
@@ -169,7 +169,7 @@ public:
     /**
      * @brief Get an elementwise operator capable of calculating the feet of the characteristics.
      *
-     * Computes the spline coefficients of the advection field, then packages them together
+     * Computes the interpolation coefficients of the advection field, then packages them together
      * with the mappings and time stepper into an @ref ElementwiseOperator. Calling
      * @c operator()(dt) on the returned object yields a GPU-copyable functor.
      *
@@ -182,7 +182,7 @@ public:
                     advection_field) const
     {
         AdvecCoefField advection_field_coefs(
-                m_builder_advection_field.batched_spline_domain(get_idx_range(advection_field)));
+                batched_basis_idx_range(m_builder_advection_field, get_idx_range(advection_field)));
         m_builder_advection_field(
                 ddcHelper::get<AdvDim1>(advection_field_coefs),
                 ddcHelper::get<AdvDim1>(get_const_field(advection_field)));
@@ -196,7 +196,7 @@ public:
     /**
      * @brief Advect the feet over @f$ dt @f$.
      *
-     * Computes the spline coefficients of the advection field, solves the characteristic
+     * Computes the coefficients of the advection field, solves the characteristic
      * equation over @f$ dt @f$ at every grid point, and writes the resulting feet in-place.
      *
      * @param[in, out] feet
@@ -213,7 +213,7 @@ public:
             double dt) const
     {
         AdvecCoefField advection_field_coefs(
-                m_builder_advection_field.batched_spline_domain(get_idx_range(advection_field)));
+                batched_basis_idx_range(m_builder_advection_field, get_idx_range(advection_field)));
         m_builder_advection_field(
                 ddcHelper::get<AdvDim1>(advection_field_coefs),
                 ddcHelper::get<AdvDim1>(get_const_field(advection_field)));

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -81,8 +81,8 @@ public:
     using AdvDim2 = std::conditional_t<AFSpace == AdvectionFieldSpace::PHYSICAL, Y, Theta>;
 
 private:
-    using PolarGrid
-            = ddc::to_type_seq_t<typename RThetaAdvectionBuilder::interpolation_domain_type>;
+    using PolarGrid = ddc::to_type_seq_t<typename InterpolationBuilderTraits<
+            RThetaAdvectionBuilder>::interpolation_idx_range_type>;
     using GridR = find_grid_t<R, PolarGrid>;
     using GridTheta = find_grid_t<Theta, PolarGrid>;
 

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -86,14 +86,8 @@ private:
     using GridR = find_grid_t<R, PolarGrid>;
     using GridTheta = find_grid_t<Theta, PolarGrid>;
 
-    using BSplinesR = typename RThetaAdvectionBuilder::bsplines_type1;
-    using BSplinesTheta = typename RThetaAdvectionBuilder::bsplines_type2;
-
-    using IdxRangeSplineBatched
-            = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
-                    ddc::to_type_seq_t<IdxRangeBatched>,
-                    ddc::detail::TypeSeq<GridR, GridTheta>,
-                    ddc::detail::TypeSeq<BSplinesR, BSplinesTheta>>>;
+    using IdxRangeCoeffBatched = typename InterpolationBuilderTraits<
+            RThetaAdvectionBuilder>::batched_basis_idx_range_type<IdxRangeBatched>;
 
     using IdxRangeBatch = ddc::remove_dims_of_t<IdxRangeBatched, GridR, GridTheta>;
     using IdxRangeRTheta = IdxRange<GridR, GridTheta>;
@@ -106,10 +100,8 @@ private:
 
     using CoordRTheta = Coord<R, Theta>;
 
-    using AdvecCoefField = DVectorFieldMem<
-            IdxRangeSplineBatched,
-            VectorIndexSet<AdvDim1, AdvDim2>,
-            memory_space>;
+    using AdvecCoefField
+            = DVectorFieldMem<IdxRangeCoeffBatched, VectorIndexSet<AdvDim1, AdvDim2>, memory_space>;
 
 public:
     /// The operator returned by operator() which calculates the feet elementwise.

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -20,7 +20,7 @@
 /**
  * @brief Operator for finding the feet of the characteristics on a polar slice.
  *
- * Calculates the interplation representation of the advection field and uses it together
+ * Calculates the interpolation representation of the advection field and uses it together
  * with a time-stepping method to solve the characteristic equation. The space in
  * which the advection field is expressed and the space in which foot-finding is
  * performed are selected at compile time via @p FFSpace and @p AFSpace.

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -14,6 +14,7 @@
 #include "ddc_aliases.hpp"
 #include "geometry_pseudo_cartesian.hpp"
 #include "i_interpolation.hpp"
+#include "i_interpolation_builder.hpp"
 #include "l_norm_tools.hpp"
 #include "vector_index_tools.hpp"
 

--- a/src/advection/polar_foot_finder.hpp
+++ b/src/advection/polar_foot_finder.hpp
@@ -88,7 +88,7 @@ private:
     using GridTheta = find_grid_t<Theta, PolarGrid>;
 
     using IdxRangeCoeffBatched = typename InterpolationBuilderTraits<
-            RThetaAdvectionBuilder>::batched_basis_idx_range_type<IdxRangeBatched>;
+            RThetaAdvectionBuilder>::template batched_basis_idx_range_type<IdxRangeBatched>;
 
     using IdxRangeBatch = ddc::remove_dims_of_t<IdxRangeBatched, GridR, GridTheta>;
     using IdxRangeRTheta = IdxRange<GridR, GridTheta>;

--- a/src/interpolation/i_interpolation_builder.hpp
+++ b/src/interpolation/i_interpolation_builder.hpp
@@ -68,7 +68,6 @@ struct InterpolationBuilderTraits
  * Mapping:
  *   interpolation_discrete_dimension_type -> interpolation_grid_type
  *   interpolation_domain_type             -> interpolation_idx_range_type
- *   bsplines_type                         -> basis_domain_type
  *   batched_spline_domain_type<D>         -> batched_basis_idx_range_type<D>
  *   batched_derivs_domain_type<D>         -> batched_derivs_idx_range_type<D>
  */
@@ -139,7 +138,6 @@ public:
  * Mapping:
  *   interpolation_discrete_dimension_type -> interpolation_grid_type
  *   interpolation_domain_type             -> interpolation_idx_range_type
- *   bsplines_type                         -> basis_domain_type
  *   batched_spline_domain_type<D>         -> batched_basis_idx_range_type<D>
  *   batched_derivs_domain_type<D>         -> batched_derivs_idx_range_type<D>
  */
@@ -280,8 +278,7 @@ concept InterpolationBuilder = requires
  *
  * Refines InterpolationBuilder with the additional requirements that:
  *   - The builder operates over exactly one interpolation dimension (rank() == 1).
- *   - InterpolationBuilderTraits<Builder>::basis_domain_type is defined, i.e. the
- *     builder exposes a discrete dimension for its basis coefficients.
+ *   - The builder has an appropriate operator()
  */
 template <class Builder>
 concept InterpolationBuilder1D

--- a/src/pde_solvers/fem_1d_poisson_solver.hpp
+++ b/src/pde_solvers/fem_1d_poisson_solver.hpp
@@ -491,7 +491,6 @@ public:
             IdxFEMBSplines first_repeat_bspline(ddc::discrete_space<FEMBSplines>().nbasis());
             // Copy the first d coefficients into the last d coefficients
             // These coefficients refer to the same InputBSplines which cross the boundaries
-            const std::source_location location = std::source_location::current();
             ddc::parallel_for_each(
                     location.function_name(),
                     exec_space(),

--- a/src/pde_solvers/fem_1d_poisson_solver.hpp
+++ b/src/pde_solvers/fem_1d_poisson_solver.hpp
@@ -23,11 +23,12 @@
  */
 template <
         class SplineInterpolatorType,
-        class IdxRangeBatched =
-                typename SplineInterpolatorType::BuilderType::interpolation_domain_type>
+        class IdxRangeBatched = typename InterpolationBuilderTraits<
+                typename SplineInterpolatorType::BuilderType>::interpolation_idx_range_type>
 class FEM1DPoissonSolver
     : public IPoissonSolver<
-              typename SplineInterpolatorType::EvaluatorType::evaluation_domain_type,
+              typename InterpolationEvaluatorTraits<
+                      typename SplineInterpolatorType::EvaluatorType>::evaluation_idx_range_type,
               IdxRangeBatched,
               double,
               typename SplineInterpolatorType::EvaluatorType::memory_space,
@@ -46,9 +47,9 @@ private:
 
 private:
     /// The interpolation mesh type
-    using GridPDEDim = typename SplineBuilder::interpolation_discrete_dimension_type;
+    using GridPDEDim = typename InterpolationBuilderTraits<SplineBuilder>::interpolation_grid_type;
 
-    using InputBSplines = typename SplineBuilder::bsplines_type;
+    using InputBSplines = typename InterpolationBuilderTraits<SplineBuilder>::basis_domain_type;
 
     using PDEDim = typename GridPDEDim::continuous_dimension_type;
 

--- a/src/pde_solvers/fem_1d_poisson_solver.hpp
+++ b/src/pde_solvers/fem_1d_poisson_solver.hpp
@@ -7,6 +7,7 @@
 #include "ddc_aliases.hpp"
 #include "ddc_helper.hpp"
 #include "gauss_legendre_integration.hpp"
+#include "i_interpolation_builder.hpp"
 #include "ipoisson_solver.hpp"
 #include "matrix.hpp"
 

--- a/src/pde_solvers/fem_1d_poisson_solver.hpp
+++ b/src/pde_solvers/fem_1d_poisson_solver.hpp
@@ -8,6 +8,7 @@
 #include "ddc_helper.hpp"
 #include "gauss_legendre_integration.hpp"
 #include "i_interpolation_builder.hpp"
+#include "i_interpolation_evaluator.hpp"
 #include "ipoisson_solver.hpp"
 #include "matrix.hpp"
 
@@ -40,7 +41,8 @@ private:
     using SplineEvaluator = typename SplineInterpolatorType::EvaluatorType;
 
     using base_type = IPoissonSolver<
-            typename SplineEvaluator::evaluation_domain_type,
+            typename InterpolationEvaluatorTraits<
+                    typename SplineInterpolatorType::EvaluatorType>::evaluation_idx_range_type,
             IdxRangeBatched,
             double,
             typename SplineEvaluator::memory_space,
@@ -50,7 +52,10 @@ private:
     /// The interpolation mesh type
     using GridPDEDim = typename InterpolationBuilderTraits<SplineBuilder>::interpolation_grid_type;
 
-    using InputBSplines = typename InterpolationBuilderTraits<SplineBuilder>::basis_domain_type;
+    using InputBSplines = ddc::type_seq_element_t<
+            0,
+            ddc::to_type_seq_t<
+                    typename InterpolationBuilderTraits<SplineBuilder>::coeff_idx_range_type>>;
 
     using PDEDim = typename GridPDEDim::continuous_dimension_type;
 


### PR DESCRIPTION
Ensure 2D polar advection operators work with generic interpolators (i.e. with spline or Lagrange interpolation)

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [x] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [x] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [x] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [x] Have you checked that the AUTHORS file is up to date ?
- [x] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [x] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
