### PR TITLE
Set warnings as errors with Wextra

### DIFF
--- a/.github/actions/build_code/action.yml
+++ b/.github/actions/build_code/action.yml
@@ -15,7 +15,6 @@ runs:
     - name: Compile code
       run: |
         ${{ inputs.environment_command }}
-        cmake -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }} -B build -S .
+        cmake -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }} -B build -S .
         cmake --build build --parallel 4
       shell: bash
-

--- a/docker/gyselalibxx_env/Dockerfile
+++ b/docker/gyselalibxx_env/Dockerfile
@@ -54,7 +54,7 @@ RUN chmod +x /bin/bash_run \
  && cd .. \
  && rm -rf ginkgo \
  && git clone --branch 5.1.1 --depth 1 https://github.com/kokkos/kokkos.git \
- && git clone --branch v1.1.0 --depth 1 https://github.com/kokkos/kokkos-fft.git \
+ && git clone --branch v1.0.0 --depth 1 https://github.com/kokkos/kokkos-fft.git \
  && git clone --branch 5.1.1 --depth 1 https://github.com/kokkos/kokkos-kernels.git \
  && git clone --branch develop --depth 1 https://github.com/kokkos/kokkos-tools.git \
  && git clone --branch v0.2.0 --depth 1 https://gitlab.com/cines/code.gysela/libkoliop \

--- a/tests/coord_transformations/coord_transformations_execution_space_access.cpp
+++ b/tests/coord_transformations/coord_transformations_execution_space_access.cpp
@@ -306,10 +306,14 @@ TEST_F(MappingMemoryAccess, HostDiscreteLagrangeCoordConverter)
 
 // Coord converter: logical -> physical.
 // Workaround false positive
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     CoordXY diff_coord_xy = to_physical_mapping(coord_rtheta) - coord_xy;
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
     EXPECT_LE(ddc::get<X>(diff_coord_xy), 1e-6);
     EXPECT_LE(ddc::get<Y>(diff_coord_xy), 1e-6);
 }

--- a/toolchains/common_toolchains/debug_toolchain.cmake
+++ b/toolchains/common_toolchains/debug_toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Debug)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Werror=parentheses -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-O1 -Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS ON)

--- a/toolchains/common_toolchains/release_toolchain.cmake
+++ b/toolchains/common_toolchains/release_toolchain.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/importable_defaults.cmake)
 set(CMAKE_BUILD_TYPE Release)
 
 # Compiler options
-set(CMAKE_CXX_FLAGS_INIT "-Wall -Werror=unused-local-typedefs -Werror=unused-variable -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra -Wno-sign-compare -Wno-unused-but-set-parameter -Wno-unused-parameter")
 
 # Activate/deactivate parts of the code
 set(GYSELALIBXX_ACTIVATE_RESTART_TESTS OFF)


### PR DESCRIPTION
Second attempt after #724, this time warnings are turned into errors only on the github side. It should not impact Gysela-X++. Local warning "maybe-uninitialized" is also protected for GCC-only compiler.

---

Please complete the checklist to ensure that all tasks are completed before marking your pull request as ready for review.

### All Submissions

- [ ] Have you ensured that all lines changed in this PR are justified by a comment found in the description ?
- [ ] Have you updated the [CHANGELOG.md](https://github.com/gyselax/gyselalibxx/blob/devel/CHANGELOG.md) ?
- [ ] Have you linked any issues that should be closed when this PR is merged (using closing keywords) ?
- [ ] Have you checked that the AUTHORS file is up to date ?
- [ ] Have you checked that the copyright information in the LICENCE file is up to date (including dates) ?
- [ ] Do you follow the conventions specified in our [coding standards](https://gyselax.github.io/gyselalibxx/docs/standards/CODING_STANDARD.html) ?

### New Feature Submissions

- [ ] Have you added tests for the new functionalities ?
- [ ] Have you documented the new functionalities:
  - [ ] API documentation describing the available methods, when each should be used and how to use them ?
  - [ ] User-friendly documentation in README files (which may link to the API documentation).
  - [ ] If the new functionality is non-trivial to use, provide a tutorial or example ? (optional)

### Changes to Existing Features

- [ ] Have you checked that existing tests cover all code after the changes ?
- [ ] Have you checked that existing tests are still passing ?
- [ ] Have you checked that the existing documentation is still accurate (API and README files) ?

### Changes to the CI

- [ ] Have you made the same changes to both the GitHub CI and the GitLab CI (for the private fork) ?
